### PR TITLE
Unify bus APIs

### DIFF
--- a/src/system/bus/CMakeLists.txt
+++ b/src/system/bus/CMakeLists.txt
@@ -1,2 +1,12 @@
+target_sources(pslab-mini-firmware
+    PRIVATE
+        bus_common.c
+)
+
+target_include_directories(pslab-mini-firmware
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
 add_subdirectory(uart)
 add_subdirectory(usb)

--- a/src/system/bus/bus_common.c
+++ b/src/system/bus/bus_common.c
@@ -1,0 +1,156 @@
+/**
+ * @file bus_common.c
+ * @brief Common utilities for bus interfaces (UART, USB, etc.)
+ *
+ * This module provides shared functionality for various bus interfaces,
+ * including circular buffer implementations and utility functions.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "bus_common.h"
+
+/**
+ * @brief Initialize a circular buffer
+ *
+ * @param cb Pointer to circular buffer structure
+ * @param buffer Memory area to use for the buffer
+ * @param size Size of the buffer (should be a power of 2)
+ */
+void circular_buffer_init(circular_buffer_t *cb, uint8_t *buffer, uint32_t size)
+{
+    cb->buffer = buffer;
+    cb->head = 0;
+    cb->tail = 0;
+    cb->size = size;
+}
+
+/**
+ * @brief Check if circular buffer is empty
+ *
+ * @param cb Pointer to circular buffer structure
+ * @return true if buffer is empty, false otherwise
+ */
+bool circular_buffer_is_empty(circular_buffer_t *cb)
+{
+    return cb->head == cb->tail;
+}
+
+/**
+ * @brief Check if circular buffer is full
+ *
+ * @param cb Pointer to circular buffer structure
+ * @return true if buffer is full, false otherwise
+ */
+bool circular_buffer_is_full(circular_buffer_t *cb)
+{
+    return ((cb->head + 1) % cb->size) == cb->tail;
+}
+
+/**
+ * @brief Get number of bytes available in circular buffer
+ *
+ * @param cb Pointer to circular buffer structure
+ * @return Number of bytes available
+ */
+uint32_t circular_buffer_available(circular_buffer_t *cb)
+{
+    if (cb->head >= cb->tail) {
+        return cb->head - cb->tail;
+    } else {
+        return cb->size - cb->tail + cb->head;
+    }
+}
+
+/**
+ * @brief Put a byte into circular buffer
+ *
+ * @param cb Pointer to circular buffer structure
+ * @param data Byte to put into buffer
+ * @return true if successful, false if buffer is full
+ */
+bool circular_buffer_put(circular_buffer_t *cb, uint8_t data)
+{
+    if (circular_buffer_is_full(cb)) {
+        return false;
+    }
+
+    cb->buffer[cb->head] = data;
+    cb->head = (cb->head + 1) % cb->size;
+    return true;
+}
+
+/**
+ * @brief Get a byte from circular buffer
+ *
+ * @param cb Pointer to circular buffer structure
+ * @param data Pointer to store the read byte
+ * @return true if successful, false if buffer is empty
+ */
+bool circular_buffer_get(circular_buffer_t *cb, uint8_t *data)
+{
+    if (circular_buffer_is_empty(cb)) {
+        return false;
+    }
+
+    *data = cb->buffer[cb->tail];
+    cb->tail = (cb->tail + 1) % cb->size;
+    return true;
+}
+
+/**
+ * @brief Reset (empty) a circular buffer
+ *
+ * @param cb Pointer to circular buffer structure
+ */
+void circular_buffer_reset(circular_buffer_t *cb)
+{
+    cb->head = cb->tail = 0;
+}
+
+/**
+ * @brief Write multiple bytes to circular buffer
+ *
+ * @param cb Pointer to circular buffer structure
+ * @param data Pointer to data to write
+ * @param len Number of bytes to write
+ * @return Number of bytes actually written
+ */
+uint32_t circular_buffer_write(circular_buffer_t *cb, const uint8_t *data, uint32_t len)
+{
+    uint32_t bytes_written = 0;
+
+    while (bytes_written < len && !circular_buffer_is_full(cb)) {
+        if (circular_buffer_put(cb, data[bytes_written])) {
+            bytes_written++;
+        } else {
+            break;
+        }
+    }
+
+    return bytes_written;
+}
+
+/**
+ * @brief Read multiple bytes from circular buffer
+ *
+ * @param cb Pointer to circular buffer structure
+ * @param data Pointer to buffer for read data
+ * @param len Maximum number of bytes to read
+ * @return Number of bytes actually read
+ */
+uint32_t circular_buffer_read(circular_buffer_t *cb, uint8_t *data, uint32_t len)
+{
+    uint32_t bytes_read = 0;
+
+    while (bytes_read < len && !circular_buffer_is_empty(cb)) {
+        if (circular_buffer_get(cb, &data[bytes_read])) {
+            bytes_read++;
+        } else {
+            break;
+        }
+    }
+
+    return bytes_read;
+}

--- a/src/system/bus/bus_common.h
+++ b/src/system/bus/bus_common.h
@@ -1,0 +1,113 @@
+/**
+ * @file bus_common.h
+ * @brief Common utilities for bus interfaces (UART, USB, etc.)
+ *
+ * This module provides shared functionality for various bus interfaces,
+ * including circular buffer implementations and utility functions.
+ */
+
+#ifndef BUS_COMMON_H
+#define BUS_COMMON_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Circular buffer structure
+ *
+ * This structure manages a circular buffer with head and tail pointers.
+ */
+typedef struct {
+    uint8_t *buffer;
+    uint32_t volatile head;
+    uint32_t volatile tail;
+    uint32_t size;
+} circular_buffer_t;
+
+/**
+ * @brief Initialize a circular buffer
+ *
+ * @param cb Pointer to circular buffer structure
+ * @param buffer Memory area to use for the buffer
+ * @param size Size of the buffer (should be a power of 2)
+ */
+void circular_buffer_init(circular_buffer_t *cb, uint8_t *buffer, uint32_t size);
+
+/**
+ * @brief Check if circular buffer is empty
+ *
+ * @param cb Pointer to circular buffer structure
+ * @return true if buffer is empty, false otherwise
+ */
+bool circular_buffer_is_empty(circular_buffer_t *cb);
+
+/**
+ * @brief Check if circular buffer is full
+ *
+ * @param cb Pointer to circular buffer structure
+ * @return true if buffer is full, false otherwise
+ */
+bool circular_buffer_is_full(circular_buffer_t *cb);
+
+/**
+ * @brief Get number of bytes available in circular buffer
+ *
+ * @param cb Pointer to circular buffer structure
+ * @return Number of bytes available
+ */
+uint32_t circular_buffer_available(circular_buffer_t *cb);
+
+/**
+ * @brief Put a byte into circular buffer
+ *
+ * @param cb Pointer to circular buffer structure
+ * @param data Byte to put into buffer
+ * @return true if successful, false if buffer is full
+ */
+bool circular_buffer_put(circular_buffer_t *cb, uint8_t data);
+
+/**
+ * @brief Get a byte from circular buffer
+ *
+ * @param cb Pointer to circular buffer structure
+ * @param data Pointer to store the read byte
+ * @return true if successful, false if buffer is empty
+ */
+bool circular_buffer_get(circular_buffer_t *cb, uint8_t *data);
+
+/**
+ * @brief Reset (empty) a circular buffer
+ *
+ * @param cb Pointer to circular buffer structure
+ */
+void circular_buffer_reset(circular_buffer_t *cb);
+
+/**
+ * @brief Write multiple bytes to circular buffer
+ *
+ * @param cb Pointer to circular buffer structure
+ * @param data Pointer to data to write
+ * @param len Number of bytes to write
+ * @return Number of bytes actually written
+ */
+uint32_t circular_buffer_write(circular_buffer_t *cb, const uint8_t *data, uint32_t len);
+
+/**
+ * @brief Read multiple bytes from circular buffer
+ *
+ * @param cb Pointer to circular buffer structure
+ * @param data Pointer to buffer for read data
+ * @param len Maximum number of bytes to read
+ * @return Number of bytes actually read
+ */
+uint32_t circular_buffer_read(circular_buffer_t *cb, uint8_t *data, uint32_t len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BUS_COMMON_H */

--- a/src/system/bus/uart/uart.h
+++ b/src/system/bus/uart/uart.h
@@ -41,8 +41,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#include "stm32h5xx_hal.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -54,7 +52,7 @@ extern "C" {
  *
  * @return HAL status (HAL_OK on success).
  */
-HAL_StatusTypeDef UART_init(void);
+void UART_init(void);
 
 /**
  * @brief Transmit data over UART.
@@ -63,7 +61,7 @@ HAL_StatusTypeDef UART_init(void);
  * @param sz    Number of bytes to send.
  * @return HAL status (HAL_OK on success).
  */
-HAL_StatusTypeDef UART_write(uint8_t const *txbuf, uint32_t sz);
+uint32_t UART_write(uint8_t const *txbuf, uint32_t sz);
 
 /**
  * @brief Receive data from UART.

--- a/src/system/bus/uart/uart_internal.h
+++ b/src/system/bus/uart/uart_internal.h
@@ -1,0 +1,28 @@
+#ifndef PSLAB_UART_INTERNAL_H
+#define PSLAB_UART_INTERNAL_H
+
+/**
+ * @brief Initialize the internal UART buffers.
+ * Called from UART_init() in h563xx/uart.c
+ */
+void UART_buffer_init(void);
+
+/**
+ * @brief Callback for completed transmissions
+ * @param bytes_transferred Number of bytes successfully transmitted
+ */
+void UART_tx_complete_callback(uint32_t bytes_transferred);
+
+/**
+ * @brief Callback for completed reception
+ * @param buffer_size Size of the buffer used for reception
+ */
+void UART_rx_complete_callback(uint32_t buffer_size);
+
+/**
+ * @brief Callback for UART idle detection
+ * @param dma_pos Current DMA position in reception buffer
+ */
+void UART_idle_callback(uint32_t dma_pos);
+
+#endif /* PSLAB_UART_INTERNAL_H */

--- a/src/system/bus/usb/CMakeLists.txt
+++ b/src/system/bus/usb/CMakeLists.txt
@@ -1,6 +1,7 @@
 target_sources(pslab-mini-firmware
     PRIVATE
         usb_descriptors.c
+        usb.c
 )
 
 target_include_directories(pslab-mini-firmware

--- a/src/system/bus/usb/usb.c
+++ b/src/system/bus/usb/usb.c
@@ -1,0 +1,155 @@
+/**
+ * @file usb.c
+ * @brief USB interface implementation for TinyUSB
+ *
+ * This module provides a CDC-based USB API on top of the TinyUSB stack,
+ * mirroring the UART API functionality to provide a consistent interface
+ * for different communication methods.
+ *
+ * Features:
+ * - Non-blocking read/write operations
+ * - Configurable RX callback for protocol implementations
+ * - Buffer status inquiry functions
+ * - Circular buffer for reliable USB data reception
+ */
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "tusb.h"
+
+#include "bus_common.h"
+#include "usb.h"
+#include "usb_internal.h"
+
+/* Circular buffer size - must be a power of 2 */
+#define USB_RX_BUFFER_SIZE 256
+
+/* Buffers and their management structures */
+static uint8_t rx_buffer_data[USB_RX_BUFFER_SIZE];
+static circular_buffer_t rx_buffer;
+
+/* Callback state */
+static usb_rx_callback_t rx_callback = NULL;
+static uint32_t rx_threshold = 0;
+
+/**
+ * @brief Move data from TinyUSB CDC RX buffer to our circular buffer
+ */
+static uint32_t transfer_from_usb_to_buffer(void)
+{
+    uint32_t available = tud_cdc_available();
+    uint32_t transferred = 0;
+    uint8_t temp;
+
+    while (available > 0 && !circular_buffer_is_full(&rx_buffer)) {
+        if (tud_cdc_read(&temp, 1) == 1) {
+            circular_buffer_put(&rx_buffer, temp);
+            transferred++;
+            available--;
+        } else {
+            break;
+        }
+    }
+
+    return transferred;
+}
+
+/* Periodic check for callbacks */
+static bool check_rx_callback(void)
+{
+    if (rx_callback && circular_buffer_available(&rx_buffer) >= rx_threshold) {
+        rx_callback(circular_buffer_available(&rx_buffer));
+        return true;
+    }
+    return false;
+}
+
+/**
+ * @brief Initialize the internal USB buffers.
+ * Called from USB_init() in h563xx/usb.c
+ */
+void USB_buffer_init(void)
+{
+    circular_buffer_init(&rx_buffer, rx_buffer_data, USB_RX_BUFFER_SIZE);
+}
+
+void USB_task(void)
+{
+    tud_task();
+
+    // Transfer any available data from the USB FIFO to our circular buffer
+    if (tud_cdc_available() > 0) {
+        transfer_from_usb_to_buffer();
+    }
+
+    // Check for RX callbacks after processing USB tasks
+    check_rx_callback();
+
+    // Flush TX buffer if needed
+    if (tud_cdc_write_available() < CFG_TUD_CDC_TX_BUFSIZE) {
+        tud_cdc_write_flush();
+    }
+}
+
+bool USB_rx_ready(void)
+{
+    return !circular_buffer_is_empty(&rx_buffer) || tud_cdc_available() > 0;
+}
+
+uint32_t USB_rx_available(void)
+{
+    // Make sure we've transferred any available data to our buffer
+    if (tud_cdc_available() > 0) {
+        transfer_from_usb_to_buffer();
+    }
+
+    return circular_buffer_available(&rx_buffer);
+}
+
+uint32_t USB_read(uint8_t *buf, uint32_t sz)
+{
+    if (buf == NULL || sz == 0) {
+        return 0;
+    }
+
+    // Make sure we've transferred any available data to our buffer
+    if (tud_cdc_available() > 0) {
+        transfer_from_usb_to_buffer();
+    }
+
+    // Read from our circular buffer using the common function
+    return circular_buffer_read(&rx_buffer, buf, sz);
+}
+
+uint32_t USB_write(uint8_t const *buf, uint32_t sz)
+{
+    if (buf == NULL || sz == 0) {
+        return 0;
+    }
+
+    return tud_cdc_write(buf, sz);
+}
+
+void USB_set_rx_callback(usb_rx_callback_t callback, uint32_t threshold)
+{
+    rx_callback = callback;
+    rx_threshold = threshold;
+
+    // Check if callback should be triggered immediately
+    check_rx_callback();
+}
+
+uint32_t USB_tx_free_space(void)
+{
+    return tud_cdc_write_available();
+}
+
+bool USB_tx_busy(void)
+{
+    // TinyUSB doesn't have a direct way to check if TX is busy,
+    // but we can check if the buffer is non-empty
+    return tud_cdc_write_available() < CFG_TUD_CDC_TX_BUFSIZE;
+}

--- a/src/system/bus/usb/usb.h
+++ b/src/system/bus/usb/usb.h
@@ -23,6 +23,13 @@
 #endif // STM32H563xx
 
 /**
+ * @brief Callback function type for USB RX data availability.
+ *
+ * @param bytes_available Number of bytes currently available in RX buffer.
+ */
+typedef void (*usb_rx_callback_t)(uint32_t bytes_available);
+
+/**
  * @brief Initialize USB hardware and TinyUSB driver
  */
 void USB_init(void);
@@ -32,20 +39,21 @@ void USB_init(void);
  *
  * Must be called periodically (at least once per 1 ms) to handle USB events.
  */
-static inline void USB_task(void)
-{
-    tud_task();
-}
+void USB_task(void);
 
 /**
  * @brief Check if USB RX data is available
  *
  * @return true if data is ready to be read, false otherwise
  */
-static inline bool USB_rx_ready(void)
-{
-    return tud_cdc_available();
-}
+bool USB_rx_ready(void);
+
+/**
+ * @brief Get number of bytes available in receive buffer.
+ *
+ * @return Number of bytes available to read.
+ */
+uint32_t USB_rx_available(void);
 
 /**
  * @brief Read data from USB interface
@@ -54,10 +62,7 @@ static inline bool USB_rx_ready(void)
  * @param sz  Maximum number of bytes to read
  * @return Number of bytes actually read
  */
-static inline uint32_t USB_read(uint8_t *buf, uint32_t sz)
-{
-    return tud_cdc_read(buf, sz);
-}
+uint32_t USB_read(uint8_t *buf, uint32_t sz);
 
 /**
  * @brief Write data to USB interface
@@ -66,30 +71,29 @@ static inline uint32_t USB_read(uint8_t *buf, uint32_t sz)
  * @param sz  Number of bytes to write
  * @return Number of bytes actually written
  */
-static inline uint32_t USB_write(uint8_t *buf, uint32_t sz)
-{
-    return tud_cdc_write(buf, sz);
-}
+uint32_t USB_write(uint8_t const *buf, uint32_t sz);
 
 /**
- * @brief Flush the USB RX buffer
+ * @brief Set RX callback to be triggered when threshold bytes are available.
  *
- * This function clears any pending data in the USB RX buffer.
+ * @param callback Function to call when threshold is reached (NULL to disable)
+ * @param threshold Number of bytes that must be available to trigger callback
  */
-static inline void USB_rx_flush(void)
-{
-    tud_cdc_read_flush();
-}
+void USB_set_rx_callback(usb_rx_callback_t callback, uint32_t threshold);
 
 /**
- * @brief Flush any pending USB TX data
+ * @brief Get TX buffer free space.
  *
- * @return Number of bytes that were flushed
+ * @return Number of bytes that can still be written to TX buffer.
  */
-static inline uint32_t USB_tx_flush(void)
-{
-    return tud_cdc_write_flush();
-}
+uint32_t USB_tx_free_space(void);
+
+/**
+ * @brief Check if TX transmission is in progress.
+ *
+ * @return true if transmission is ongoing, false otherwise.
+ */
+bool USB_tx_busy(void);
 
 /**
  * @brief Retrieve the unique device serial as a USB string descriptor

--- a/src/system/bus/usb/usb_internal.h
+++ b/src/system/bus/usb/usb_internal.h
@@ -1,0 +1,10 @@
+#ifndef PSLAB_USB_INTERNAL_H
+#define PSLAB_USB_INTERNAL_H
+
+/**
+ * @brief Initialize the internal USB buffers.
+ * Called from USB_init() in h563xx/usb.c
+ */
+void USB_buffer_init(void);
+
+#endif /* PSLAB_USB_INTERNAL_H */

--- a/src/system/h563xx/CMakeLists.txt
+++ b/src/system/h563xx/CMakeLists.txt
@@ -3,6 +3,7 @@ target_sources(pslab-mini-firmware
         startup_stm32h563xx.s
         system_stm32h5xx.c
         usb.c
+        uart.c
 )
 
 target_include_directories(pslab-mini-firmware

--- a/src/system/h563xx/uart.c
+++ b/src/system/h563xx/uart.c
@@ -1,0 +1,273 @@
+/**
+ * @file uart.c
+ * @brief UART hardware implementation for STM32H563xx
+ *
+ * This module handles initialization and operation of the UART peripheral of
+ * the STM32H5 microcontroller. It configures the hardware and dispatches UART
+ * interrupts to the hardware-independent UART implementation.
+ *
+ * Implementation Details:
+ * - Uses USART3 on STM32H5 (PD8=TX, PD9=RX)
+ * - Configured for 115200 baud, 8N1 format
+ * - DMA-based reception with idle line detection
+ * - DMA-based transmission for optimal performance
+ * - NVIC priority set to 3 for UART interrupts
+ *
+ * @author Alexander Bessman
+ * @date 2025-06-28
+ */
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "stm32h5xx_hal.h"
+
+#include "uart.h"
+#include "../bus/uart/uart_internal.h"
+
+/* HAL UART handle */
+static UART_HandleTypeDef huart = { 0 };
+static DMA_HandleTypeDef hdma_usart3_tx = { 0 };
+static DMA_HandleTypeDef hdma_usart3_rx = { 0 };
+
+/* Buffer for DMA reception */
+static uint8_t *rx_buffer_data;
+static uint32_t rx_buffer_size;
+
+/* Interrupt state */
+static volatile bool tx_in_progress = false;
+static volatile uint32_t tx_dma_size = 0;
+
+/**
+ * @brief MSP initialization for UART
+ *
+ * This function is called by HAL_UART_Init() to configure GPIO pins,
+ * DMA channels, and interrupts for the UART interface.
+ *
+ * @param huart UART handle
+ */
+void HAL_UART_MspInit(UART_HandleTypeDef* uartHandle)
+{
+    if (uartHandle->Instance == USART3) {
+        /* USART3 clock enable */
+        __HAL_RCC_USART3_CLK_ENABLE();
+        __HAL_RCC_GPIOD_CLK_ENABLE();
+        __HAL_RCC_GPIOB_CLK_ENABLE();
+        __HAL_RCC_GPDMA1_CLK_ENABLE();
+
+        /* UART GPIO Configuration */
+        GPIO_InitTypeDef GPIO_InitStruct = {0};
+        GPIO_InitStruct.Pin = GPIO_PIN_8|GPIO_PIN_9;
+        GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+        GPIO_InitStruct.Pull = GPIO_NOPULL;
+        GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_HIGH;
+        GPIO_InitStruct.Alternate = GPIO_AF7_USART3;
+        HAL_GPIO_Init(GPIOD, &GPIO_InitStruct);
+
+        /* UART DMA Init */
+        /* Configure DMA for TX */
+        hdma_usart3_tx.Instance = GPDMA1_Channel0;
+        hdma_usart3_tx.Init.Request = GPDMA1_REQUEST_USART3_TX;
+        hdma_usart3_tx.Init.BlkHWRequest = DMA_BREQ_SINGLE_BURST;
+        hdma_usart3_tx.Init.Direction = DMA_MEMORY_TO_PERIPH;
+        hdma_usart3_tx.Init.SrcInc = DMA_SINC_INCREMENTED;
+        hdma_usart3_tx.Init.DestInc = DMA_DINC_FIXED;
+        hdma_usart3_tx.Init.SrcDataWidth = DMA_SRC_DATAWIDTH_BYTE;
+        hdma_usart3_tx.Init.DestDataWidth = DMA_DEST_DATAWIDTH_BYTE;
+        hdma_usart3_tx.Init.Priority = DMA_LOW_PRIORITY_LOW_WEIGHT;
+        hdma_usart3_tx.Init.SrcBurstLength = 1;
+        hdma_usart3_tx.Init.DestBurstLength = 1;
+        hdma_usart3_tx.Init.TransferAllocatedPort = (
+            DMA_SRC_ALLOCATED_PORT0 | DMA_DEST_ALLOCATED_PORT0
+        );
+        hdma_usart3_tx.Init.TransferEventMode = DMA_TCEM_BLOCK_TRANSFER;
+        hdma_usart3_tx.Init.Mode = DMA_NORMAL;
+
+        HAL_DMA_Init(&hdma_usart3_tx);
+        __HAL_LINKDMA(uartHandle, hdmatx, hdma_usart3_tx);
+
+        /* Configure DMA for RX */
+        hdma_usart3_rx.Instance = GPDMA1_Channel1;
+        hdma_usart3_rx.Init.Request = GPDMA1_REQUEST_USART3_RX;
+        hdma_usart3_rx.Init.BlkHWRequest = DMA_BREQ_SINGLE_BURST;
+        hdma_usart3_rx.Init.Direction = DMA_PERIPH_TO_MEMORY;
+        hdma_usart3_rx.Init.SrcInc = DMA_SINC_FIXED;
+        hdma_usart3_rx.Init.DestInc = DMA_DINC_INCREMENTED;
+        hdma_usart3_rx.Init.SrcDataWidth = DMA_SRC_DATAWIDTH_BYTE;
+        hdma_usart3_rx.Init.DestDataWidth = DMA_DEST_DATAWIDTH_BYTE;
+        hdma_usart3_rx.Init.Priority = DMA_LOW_PRIORITY_LOW_WEIGHT;
+        hdma_usart3_rx.Init.SrcBurstLength = 1;
+        hdma_usart3_rx.Init.DestBurstLength = 1;
+        hdma_usart3_rx.Init.TransferAllocatedPort = (
+            DMA_SRC_ALLOCATED_PORT0 | DMA_DEST_ALLOCATED_PORT0
+        );
+        hdma_usart3_rx.Init.TransferEventMode = DMA_TCEM_BLOCK_TRANSFER;
+        /* Use normal mode, manage circular manually */
+        hdma_usart3_rx.Init.Mode = DMA_NORMAL;
+
+        HAL_DMA_Init(&hdma_usart3_rx);
+        __HAL_LINKDMA(uartHandle, hdmarx, hdma_usart3_rx);
+
+        /* UART interrupt Init */
+        HAL_NVIC_SetPriority(USART3_IRQn, 3, 0);
+        HAL_NVIC_EnableIRQ(USART3_IRQn);
+
+        /* DMA interrupt init */
+        HAL_NVIC_SetPriority(GPDMA1_Channel0_IRQn, 3, 1);
+        HAL_NVIC_EnableIRQ(GPDMA1_Channel0_IRQn);
+
+        HAL_NVIC_SetPriority(GPDMA1_Channel1_IRQn, 3, 1);
+        HAL_NVIC_EnableIRQ(GPDMA1_Channel1_IRQn);
+    }
+}
+
+/**
+ * @brief Initialize the UART peripheral.
+ *
+ * This function configures the UART hardware, including baud rate, data bits,
+ * stop bits, and parity, to prepare it for serial communication.
+ */
+void UART_init(void)
+{
+    /* Initialize the hardware-independent part first */
+    UART_buffer_init();
+
+    huart.Instance = USART3;
+    huart.Init.BaudRate = 115200;
+    huart.Init.WordLength = UART_WORDLENGTH_8B;
+    huart.Init.StopBits = UART_STOPBITS_1;
+    huart.Init.Parity = UART_PARITY_NONE;
+    huart.Init.Mode = UART_MODE_TX_RX;
+    huart.Init.HwFlowCtl = UART_HWCONTROL_NONE;
+    huart.Init.OverSampling = UART_OVERSAMPLING_16;
+    huart.Init.OneBitSampling = UART_ONE_BIT_SAMPLE_DISABLE;
+    huart.Init.ClockPrescaler = UART_PRESCALER_DIV1;
+    HAL_UART_Init(&huart);
+
+    /* Start DMA reception */
+    HAL_UART_Receive_DMA(&huart, rx_buffer_data, rx_buffer_size);
+
+    /* Enable UART idle line interrupt for packet detection */
+    __HAL_UART_ENABLE_IT(&huart, UART_IT_IDLE);
+
+    /* Clear any pending flags */
+    __HAL_UART_CLEAR_FLAG(&huart, UART_FLAG_IDLE);
+    __HAL_UART_CLEAR_FLAG(&huart, UART_FLAG_ORE);
+}
+
+/**
+ * @brief Start UART DMA transmission
+ *
+ * @param buffer Pointer to data to transmit
+ * @param size Number of bytes to transmit
+ */
+void UART_start_dma_tx(uint8_t *buffer, uint32_t size)
+{
+    tx_in_progress = true;
+    tx_dma_size = size;
+    HAL_UART_Transmit_DMA(&huart, buffer, size);
+}
+
+/**
+ * @brief Get current DMA position for RX buffer
+ *
+ * @return Current DMA position
+ */
+uint32_t UART_get_dma_position(void)
+{
+    return rx_buffer_size - __HAL_DMA_GET_COUNTER(&hdma_usart3_rx);
+}
+
+/**
+ * @brief Check if UART TX is busy
+ *
+ * @return true if TX is in progress, false otherwise
+ */
+bool UART_hw_tx_busy(void)
+{
+    return tx_in_progress;
+}
+
+/**
+ * @brief UART TX complete callback
+ *
+ * Called by HAL when TX DMA transfer is complete.
+ */
+void HAL_UART_TxCpltCallback(UART_HandleTypeDef *huart)
+{
+    if (huart->Instance == USART3) {
+        tx_in_progress = false;
+        /* Notify the hardware-independent layer */
+        UART_tx_complete_callback(tx_dma_size);
+    }
+}
+
+/**
+ * @brief UART RX complete callback
+ *
+ * Called by HAL when RX DMA buffer is full.
+ */
+void HAL_UART_RxCpltCallback(UART_HandleTypeDef *huart)
+{
+    if (huart->Instance == USART3) {
+        /* In circular DMA mode, this indicates buffer is full */
+        /* Notify the hardware-independent layer */
+        UART_rx_complete_callback(rx_buffer_size);
+    }
+}
+
+/**
+ * @brief USART3 interrupt handler
+ *
+ * This function handles USART3 interrupts including idle line detection
+ * and error handling.
+ */
+void USART3_IRQHandler(void)
+{
+    /* Check for idle line detection */
+    if(__HAL_UART_GET_FLAG(&huart, UART_FLAG_IDLE) != RESET) {
+        __HAL_UART_CLEAR_IDLEFLAG(&huart);
+
+        /* Calculate the number of bytes received */
+        uint32_t dma_pos = UART_get_dma_position();
+
+        /* Notify the hardware-independent layer */
+        UART_idle_callback(dma_pos);
+    }
+
+    /* Handle other UART interrupts */
+    HAL_UART_IRQHandler(&huart);
+}
+
+/**
+ * @brief GPDMA1 Channel0 interrupt handler (TX channel)
+ */
+void GPDMA1_Channel0_IRQHandler(void)
+{
+    HAL_DMA_IRQHandler(&hdma_usart3_tx);
+}
+
+/**
+ * @brief GPDMA1 Channel1 interrupt handler (RX channel)
+ */
+void GPDMA1_Channel1_IRQHandler(void)
+{
+    HAL_DMA_IRQHandler(&hdma_usart3_rx);
+}
+
+/**
+ * @brief Set up the RX buffer for DMA
+ *
+ * This function is called from the hardware-independent UART module to
+ * provide the buffer for DMA operations.
+ *
+ * @param buffer Pointer to the RX buffer
+ * @param size Size of the RX buffer
+ */
+void UART_set_dma_buffer(uint8_t *buffer, uint32_t size)
+{
+    rx_buffer_data = buffer;
+    rx_buffer_size = size;
+}

--- a/src/system/h563xx/usb.c
+++ b/src/system/h563xx/usb.c
@@ -18,6 +18,7 @@
 #include "uart.h"
 
 #include "usb.h"
+#include "../bus/usb/usb_internal.h"
 
 // USB clock, 48 MHz
 #define USB_CRS_FRQ_TARGET (48000000)
@@ -56,6 +57,9 @@ static void crs_enable(void)
 
 void USB_init(void)
 {
+    /* Initialize the buffer first */
+    USB_buffer_init();
+
     HAL_PWREx_EnableVddUSB();
 
     // Initialize USB clock.


### PR DESCRIPTION
This PR refactors the USB API to match the UART API. Types and functions common to both drivers now live in bus_common. The UART driver is refactored into hardware specific and hardware independent parts.

## Summary by Sourcery

Unify bus communication APIs by extracting shared buffer management into a common module, refactoring the UART driver into generic and hardware-specific layers, and aligning the USB driver to the same interface with callbacks and buffer status functions.

Enhancements:
- Extract common circular buffer and utility functions into a new bus_common module for reuse across UART and USB drivers
- Refactor UART driver into hardware-independent API and separate hardware-specific implementation
- Standardize USB driver API to mirror UART with non-blocking operations, RX callbacks, and buffer query functions
- Update application logic to register USB RX callbacks alongside UART

Build:
- Include bus_common.c in build and adjust include paths for bus modules via CMakeLists updates