### PR TITLE
chore: fix formatting

### DIFF
--- a/src/platform/h563xx/uart_ll.c
+++ b/src/platform/h563xx/uart_ll.c
@@ -64,11 +64,10 @@ static uart_instance_t uart_instances[UART_BUS_COUNT] = {
         {.huart = &huart2,
          .hdma_tx = &hdma_usart2_tx,
          .hdma_rx = &hdma_usart2_rx},
-    [UART_BUS_2] = {
-        .huart = &huart3,
-        .hdma_tx = &hdma_usart3_tx,
-        .hdma_rx = &hdma_usart3_rx
-    },
+    [UART_BUS_2] =
+        {.huart = &huart3,
+         .hdma_tx = &hdma_usart3_tx,
+         .hdma_rx = &hdma_usart3_rx},
 };
 
 /**

--- a/src/system/bus/uart.c
+++ b/src/system/bus/uart.c
@@ -216,8 +216,8 @@ static void tx_complete_callback(uart_bus_t bus, uint32_t bytes_transferred)
 
     /* Update TX buffer tail with the number of bytes that were sent */
     handle->tx_buffer->tail =
-        ((handle->tx_buffer->tail + bytes_transferred) %
-         handle->tx_buffer->size);
+        ((handle->tx_buffer->tail + bytes_transferred) % handle->tx_buffer->size
+        );
 
     /* Try to start another transmission if there's more data */
     start_transmission(handle);


### PR DESCRIPTION
@bessman The pipeline uses version 18.1.3 of clang-format, available through `apt-get`, in ubuntu:latest.
I spun up a docker container using the same configs and tried formatting the code inside the container. It does format it.
Here's a PR fixing the formatting if you need this.

## Summary by Sourcery

Chores:
- Reformat UART source files (uart_ll.c and uart.c) to conform to clang-format 18.1.3 style guidelines