### PR TITLE
Formatting tweaks

### DIFF
--- a/src/.clang-format
+++ b/src/.clang-format
@@ -29,6 +29,27 @@ PenaltyReturnTypeOnItsOwnLine: 1000
 # Attach braces to surrounding context, except on functions.
 BreakBeforeBraces: Linux
 
+# Braces on separate lines in struct initializers:
+# struct MyStruct my_struct = {
+#     .member_a = 1,
+#     .member_b = 2,
+# }
+# Note that this REQUIRES a trailing comma on the last member, otherwise you
+# get this:
+# struct MyStruct my_struct = { .member_a = 1,
+#                               .member_b = 2 }
+# A side-effect of this rule is that all braced initializers get space padded:
+# int arr[5] = { 0 }; // instead of {0}
+# which is fine, I guess.
+Cpp11BracedListStyle: false
+
+# This inserts trailing commas in container literals, which should be useful
+# to get the abovementioned struct initialization behavior.
+# This rule currently does nothing, because it is only enabled for JavaScript
+# in the tool itself. By keeping it here, it may become active in the future
+# if and when clang-format enables it for other languages.
+InsertTrailingCommas: Wrapped
+
 AllowShortLoopsOnASingleLine: true
 
 BitFieldColonSpacing: Before

--- a/src/application/main.c
+++ b/src/application/main.c
@@ -24,9 +24,9 @@ enum { STLINK_UART = 2 };
  * Static variables
  ******************************************************************************/
 
-static uint8_t uart_rx_buffer_data[RX_BUFFER_SIZE] = {0};
-static uint8_t uart_tx_buffer_data[TX_BUFFER_SIZE] = {0};
-static uint8_t usb_rx_buffer_data[RX_BUFFER_SIZE] = {0};
+static uint8_t uart_rx_buffer_data[RX_BUFFER_SIZE] = { 0 };
+static uint8_t uart_tx_buffer_data[TX_BUFFER_SIZE] = { 0 };
+static uint8_t usb_rx_buffer_data[RX_BUFFER_SIZE] = { 0 };
 
 static bool uart_service_requested = false;
 static bool usb_service_requested = false;
@@ -58,14 +58,14 @@ int main(void) // NOLINT
     SYSTEM_init();
 
     // Initialize UART
-    circular_buffer_t uart_rx_buf = {nullptr};
-    circular_buffer_t uart_tx_buf = {nullptr};
+    circular_buffer_t uart_rx_buf = { nullptr };
+    circular_buffer_t uart_tx_buf = { nullptr };
     circular_buffer_init(&uart_rx_buf, uart_rx_buffer_data, RX_BUFFER_SIZE);
     circular_buffer_init(&uart_tx_buf, uart_tx_buffer_data, TX_BUFFER_SIZE);
     uart_handle_t *huart = UART_init(STLINK_UART, &uart_rx_buf, &uart_tx_buf);
 
     // Initialize USB
-    circular_buffer_t usb_rx_buf = {nullptr};
+    circular_buffer_t usb_rx_buf = { nullptr };
     circular_buffer_init(&usb_rx_buf, usb_rx_buffer_data, RX_BUFFER_SIZE);
     usb_handle_t *husb = USB_init(0, &usb_rx_buf);
 
@@ -88,7 +88,7 @@ int main(void) // NOLINT
         if (uart_service_requested) {
             uart_service_requested = false;
             LED_toggle();
-            uint8_t buf[CB_THRESHOLD + 1] = {0};
+            uint8_t buf[CB_THRESHOLD + 1] = { 0 };
             uint32_t bytes_read =
                 UART_read(huart, (uint8_t *)buf, CB_THRESHOLD);
             buf[bytes_read] = '\0';
@@ -103,7 +103,7 @@ int main(void) // NOLINT
         if (usb_service_requested) {
             usb_service_requested = false;
             LED_toggle();
-            uint8_t buf[CB_THRESHOLD + 1] = {0};
+            uint8_t buf[CB_THRESHOLD + 1] = { 0 };
             uint32_t bytes_read = USB_read(husb, buf, CB_THRESHOLD);
             buf[bytes_read] = '\0';
 

--- a/src/platform/h563xx/led_ll.c
+++ b/src/platform/h563xx/led_ll.c
@@ -32,7 +32,7 @@
  */
 void LED_LL_init(void)
 {
-    GPIO_InitTypeDef GPIO_InitStruct = {0};
+    GPIO_InitTypeDef GPIO_InitStruct = { 0 };
 
     /* GPIO ports clock enable. */
     __HAL_RCC_GPIOB_CLK_ENABLE();

--- a/src/platform/h563xx/platform.c
+++ b/src/platform/h563xx/platform.c
@@ -56,8 +56,8 @@
  */
 static void system_clock_config(void)
 {
-    RCC_OscInitTypeDef RCC_OscInitStruct = {0};
-    RCC_ClkInitTypeDef RCC_ClkInitStruct = {0};
+    RCC_OscInitTypeDef RCC_OscInitStruct = { 0 };
+    RCC_ClkInitTypeDef RCC_ClkInitStruct = { 0 };
 
     /* Configure the main internal regulator output voltage. */
     __HAL_PWR_VOLTAGESCALING_CONFIG(PWR_REGULATOR_VOLTAGE_SCALE0);

--- a/src/platform/h563xx/uart_ll.c
+++ b/src/platform/h563xx/uart_ll.c
@@ -42,32 +42,34 @@ typedef struct {
 } uart_instance_t;
 
 /* HAL UART handles */
-static UART_HandleTypeDef huart1 = {0};
-static UART_HandleTypeDef huart2 = {0};
-static UART_HandleTypeDef huart3 = {0};
+static UART_HandleTypeDef huart1 = { 0 };
+static UART_HandleTypeDef huart2 = { 0 };
+static UART_HandleTypeDef huart3 = { 0 };
 
 /* DMA handles */
-static DMA_HandleTypeDef hdma_usart1_tx = {0};
-static DMA_HandleTypeDef hdma_usart1_rx = {0};
-static DMA_HandleTypeDef hdma_usart2_tx = {0};
-static DMA_HandleTypeDef hdma_usart2_rx = {0};
-static DMA_HandleTypeDef hdma_usart3_tx = {0};
-static DMA_HandleTypeDef hdma_usart3_rx = {0};
+static DMA_HandleTypeDef hdma_usart1_tx = { 0 };
+static DMA_HandleTypeDef hdma_usart1_rx = { 0 };
+static DMA_HandleTypeDef hdma_usart2_tx = { 0 };
+static DMA_HandleTypeDef hdma_usart2_rx = { 0 };
+static DMA_HandleTypeDef hdma_usart3_tx = { 0 };
+static DMA_HandleTypeDef hdma_usart3_rx = { 0 };
 
 /* Instance array */
 static uart_instance_t uart_instances[UART_BUS_COUNT] = {
-    [UART_BUS_0] =
-        {.huart = &huart1,
-         .hdma_tx = &hdma_usart1_tx,
-         .hdma_rx = &hdma_usart1_rx},
-    [UART_BUS_1] =
-        {.huart = &huart2,
-         .hdma_tx = &hdma_usart2_tx,
-         .hdma_rx = &hdma_usart2_rx},
+    [UART_BUS_0] = {
+        .huart = &huart1,
+        .hdma_tx = &hdma_usart1_tx,
+        .hdma_rx = &hdma_usart1_rx,
+    },
+    [UART_BUS_1] = {
+        .huart = &huart2,
+        .hdma_tx = &hdma_usart2_tx,
+        .hdma_rx = &hdma_usart2_rx,
+    },
     [UART_BUS_2] = {
         .huart = &huart3,
         .hdma_tx = &hdma_usart3_tx,
-        .hdma_rx = &hdma_usart3_rx
+        .hdma_rx = &hdma_usart3_rx,
     },
 };
 
@@ -95,7 +97,7 @@ static uart_bus_t get_bus_from_handle(UART_HandleTypeDef *huart)
  */
 void HAL_UART_MspInit(UART_HandleTypeDef *uartHandle)
 {
-    GPIO_InitTypeDef GPIO_InitStruct = {0};
+    GPIO_InitTypeDef GPIO_InitStruct = { 0 };
 
     if (uartHandle->Instance == USART1) {
         /* USART1 clock enable */

--- a/src/platform/h563xx/usb_descriptors.c
+++ b/src/platform/h563xx/usb_descriptors.c
@@ -20,7 +20,7 @@
 
 #include "usb_ll.h"
 
-#define LANG ((char const[]){0x09, 0x04}) // English
+#define LANG ((char const[]){ 0x09, 0x04 }) // English
 #define MANU ("FOSSASIA")
 #define PROD ("Pocket Science Lab")
 #define SERI (NULL) // Unique identifier, calculated at runtime from MCU UID.
@@ -59,7 +59,7 @@ uint8_t const g_DESC_CONFIGURATION[] = {
 };
 
 // String descriptors
-char const *string_desc_arr[] = {LANG, MANU, PROD, SERI};
+char const *string_desc_arr[] = { LANG, MANU, PROD, SERI };
 
 uint8_t const *tud_descriptor_device_cb(void)
 {

--- a/src/platform/h563xx/usb_ll.c
+++ b/src/platform/h563xx/usb_ll.c
@@ -34,7 +34,7 @@ typedef struct {
 } usb_instance_t;
 
 /* Instance array for future multi-controller support */
-static usb_instance_t usb_instances[USB_BUS_COUNT] = {0};
+static usb_instance_t usb_instances[USB_BUS_COUNT] = { 0 };
 
 /**
  * @brief Enable USB clock recovery system
@@ -45,7 +45,7 @@ static void crs_enable(void)
 {
     __HAL_RCC_CRS_CLK_ENABLE();
 
-    RCC_CRSInitTypeDef CRSInit = {0};
+    RCC_CRSInitTypeDef CRSInit = { 0 };
     CRSInit.Prescaler = RCC_CRS_SYNC_DIV1;
     CRSInit.Source = RCC_CRS_SYNC_SOURCE_USB;
     CRSInit.Polarity = RCC_CRS_SYNC_POLARITY_RISING;
@@ -68,7 +68,7 @@ void USB_LL_init(usb_bus_t bus)
     HAL_PWREx_EnableVddUSB();
 
     // Initialize USB clock.
-    RCC_PeriphCLKInitTypeDef RCC_PeriphInitStruct = {0};
+    RCC_PeriphCLKInitTypeDef RCC_PeriphInitStruct = { 0 };
     RCC_PeriphInitStruct.PeriphClockSelection = RCC_PERIPHCLK_USB;
     RCC_PeriphInitStruct.UsbClockSelection = RCC_USBCLKSOURCE_HSI48;
     if (HAL_RCCEx_PeriphCLKConfig(&RCC_PeriphInitStruct) != HAL_OK) {
@@ -85,7 +85,7 @@ void USB_LL_init(usb_bus_t bus)
     // it under the hood. The following code is to keep HAL's state consistent
     // with the actual system state.
     // PA11 = DM, PA12 = DP
-    GPIO_InitTypeDef gpio = {0};
+    GPIO_InitTypeDef gpio = { 0 };
     gpio.Pin = GPIO_PIN_11 | GPIO_PIN_12;
     gpio.Mode = GPIO_MODE_AF_PP;
     gpio.Pull = GPIO_NOPULL;
@@ -155,22 +155,8 @@ size_t USB_LL_get_serial(uint16_t desc_str1[], size_t const max_chars)
     size_t uid_len = get_unique_id(uid);
     uid_len = uid_len > max_chars / 2 ? max_chars / 2 : uid_len;
     static char const nibble_to_hex[16] = {
-        '0',
-        '1',
-        '2',
-        '3',
-        '4',
-        '5',
-        '6',
-        '7',
-        '8',
-        '9',
-        'A',
-        'B',
-        'C',
-        'D',
-        'E',
-        'F'
+        '0', '1', '2', '3', '4', '5', '6', '7',
+        '8', '9', 'A', 'B', 'C', 'D', 'E', 'F',
     };
 
     for (size_t i = 0; i < uid_len; ++i) {

--- a/src/system/bus/uart.c
+++ b/src/system/bus/uart.c
@@ -45,7 +45,7 @@ struct uart_handle_t {
 };
 
 /* Global array to keep track of active UART handles */
-static uart_handle_t *active_handles[UART_BUS_COUNT] = {nullptr};
+static uart_handle_t *active_handles[UART_BUS_COUNT] = { nullptr };
 
 /**
  * @brief Get the number of available UART bus instances.
@@ -216,8 +216,7 @@ static void tx_complete_callback(uart_bus_t bus, uint32_t bytes_transferred)
 
     /* Update TX buffer tail with the number of bytes that were sent */
     handle->tx_buffer->tail =
-        ((handle->tx_buffer->tail + bytes_transferred) %
-         handle->tx_buffer->size);
+        (handle->tx_buffer->tail + bytes_transferred) % handle->tx_buffer->size;
 
     /* Try to start another transmission if there's more data */
     start_transmission(handle);

--- a/src/system/bus/usb.c
+++ b/src/system/bus/usb.c
@@ -50,7 +50,7 @@ struct usb_handle_t {
 };
 
 /* Global array to keep track of active USB handles */
-static usb_handle_t *active_handles[USB_INTERFACE_COUNT] = {nullptr};
+static usb_handle_t *active_handles[USB_INTERFACE_COUNT] = { nullptr };
 
 /**
  * @brief Get the number of available USB interfaces.


### PR DESCRIPTION
This PR tweaks the clang-format rules with regards to where to linebreak in braced initializers.

## Summary by Sourcery

Update clang-format rules for brace initializers and reformat code to add spaces inside braces and enforce trailing commas in initializer lists.

Enhancements:
- Enforce spaces after '{' and before '}' in single-line brace initializers
- Add trailing commas in multi-line initializer lists
- Apply formatting changes across UART, USB, main, and platform source files

Build:
- Update .clang-format configuration to adjust linebreak behavior for brace initializers