### PR TITLE
Don't autofix linter warnings

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -71,7 +71,6 @@ if(CLANG_TIDY)
         --extra-arg=--target=arm-none-eabi
         --extra-arg=-isystem${ARM_INCLUDE_DIR}
         --extra-arg-before=-Qunused-arguments
-        --fix
     )
 
     set_target_properties(pslab-mini-firmware


### PR DESCRIPTION
clang-tidy shouldn't try to fix linter warnings. The flag was originally included by mistake.

## Summary by Sourcery

Bug Fixes:
- Disable automated clang-tidy fixes by removing the --fix flag from the CMake configuration