### PR TITLE
Set C23 standard globally

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,8 @@ if(NOT CMAKE_BUILD_TYPE)
 endif()
 
 project(pslab-mini C ASM)
+set(CMAKE_C_STANDARD 23)
+set(CMAKE_C_STANDARD_REQUIRED ON)
 
 # Platform selection option
 set(PLATFORM "h563xx" CACHE STRING "Target platform")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,4 @@
 add_executable(pslab-mini-firmware)
-set_property(TARGET pslab-mini-firmware PROPERTY C_STANDARD 23)
 
 # Glob all C source files in the current directory and subdirectories
 # for clang-format and clang-tidy

--- a/src/platform/CMakeLists.txt
+++ b/src/platform/CMakeLists.txt
@@ -1,7 +1,5 @@
 # Create platform library
 add_library(pslab-platform STATIC)
-set_property(TARGET pslab-platform PROPERTY C_STANDARD 23)
-
 
 # Include the selected platform subdirectory
 if(PLATFORM STREQUAL "h563xx")


### PR DESCRIPTION
Set the C standard globally for all targets instead of per-target.

## Summary by Sourcery

Standardize the C23 language standard globally in the build system by configuring it at the top-level CMakeLists and removing redundant per-target settings.

Enhancements:
- Set CMAKE_C_STANDARD to 23 and mark it required in the top-level CMakeLists.txt
- Remove individual C_STANDARD properties from the platform and firmware target CMakeLists