### PR TITLE
Disable overzealous bool conversion check

### DIFF
--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -38,6 +38,8 @@ Checks: [
   performance*,
 
   readability*,
+  # This check wants 'return (a > 0) != 0' instead of just 'return a > 0' ???
+  -readability-implicit-bool-conversion,
 ]
 
 CheckOptions:


### PR DESCRIPTION
When I lint locally, I get warnings like

pslab-mini-firmware/src/system/bus/bus.c:37:12: warning: implicit conversion 'int' -> 'bool' [readability-implicit-bool-conversion]
   37 |     return cb->head == cb->tail;
      |            ^
      |            (                   ) != 0

I.e. the linter wants `return (cb->head == cb->tail) != 0;` instead of the current `return cb->head == cb->tail;`, which is ridiculous.

This check doesn't seem to trigger in the pipeline? No idea why. I'm running clang-tidy 18.1.3 from Ubuntu 24.04, which I'm pretty sure is the same as the pipeline.

## Summary by Sourcery

Enhancements:
- Remove the readability-implicit-bool-conversion lint rule from the clang-tidy configuration