### PR TITLE
feat: Added ADC Driver

### DIFF
--- a/src/application/main.c
+++ b/src/application/main.c
@@ -76,6 +76,7 @@ int main(void) // NOLINT
     UART_set_rx_callback(huart, uart_cb, CB_THRESHOLD);
     USB_set_rx_callback(husb, usb_cb, CB_THRESHOLD);
 
+#define ADC_STRING_SIZE 26 // Size for ADC value string
     // Initialize ADC
     ADC_Init();
 
@@ -99,13 +100,16 @@ int main(void) // NOLINT
             buf[bytes_read] = '\0';
 
             if (strcmp((char *)buf, "Hello") == 0) {
-                uint32_t adc_value;
-                uint32_t temp;
+                uint32_t adc_value = 0;
+                uint32_t temp = 0;
                 adc_value = ADC_Read(&temp);
                 // Convert ADC value to string and send it
-                char adc_str[26];
-                snprintf(
-                    adc_str, sizeof(adc_str), "\r\nADC_Value:%lu\r\n", adc_value
+                char adc_str[ADC_STRING_SIZE];
+                (void)snprintf(
+                    adc_str,
+                    sizeof(adc_str),
+                    "\r\nADC_Value:%lu\r\n",
+                    (unsigned long)adc_value
                 );
                 UART_write(huart, (uint8_t *)adc_str, strlen(adc_str));
                 // Send "World" after ADC value

--- a/src/application/main.c
+++ b/src/application/main.c
@@ -78,7 +78,7 @@ int main(void) // NOLINT
 
 #define ADC_STRING_SIZE 26 // Size for ADC value string
     // Initialize ADC
-    ADC_Init();
+    ADC_init();
 
     /* Basic UART/USB/LED example:
      * - Register callbacks for both UART and USB
@@ -102,7 +102,7 @@ int main(void) // NOLINT
             if (strcmp((char *)buf, "Hello") == 0) {
                 uint32_t adc_value = 0;
                 uint32_t temp = 0;
-                adc_value = ADC_Read(&temp);
+                adc_value = ADC_read(&temp);
                 // Convert ADC value to string and send it
                 char adc_str[ADC_STRING_SIZE];
                 (void)snprintf(

--- a/src/application/main.c
+++ b/src/application/main.c
@@ -3,9 +3,11 @@
  *****************************************************************************/
 #include <stdbool.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
+#include "adc.h"
 #include "bus.h"
 #include "led.h"
 #include "system.h"
@@ -74,6 +76,9 @@ int main(void) // NOLINT
     UART_set_rx_callback(huart, uart_cb, CB_THRESHOLD);
     USB_set_rx_callback(husb, usb_cb, CB_THRESHOLD);
 
+    // Initialize ADC
+    ADC_Init();
+
     /* Basic UART/USB/LED example:
      * - Register callbacks for both UART and USB
      * - Process incoming bytes when callbacks are triggered
@@ -94,6 +99,16 @@ int main(void) // NOLINT
             buf[bytes_read] = '\0';
 
             if (strcmp((char *)buf, "Hello") == 0) {
+                uint32_t adc_value;
+                uint32_t temp;
+                adc_value = ADC_Read(&temp);
+                // Convert ADC value to string and send it
+                char adc_str[26];
+                snprintf(
+                    adc_str, sizeof(adc_str), "\r\nADC_Value:%lu\r\n", adc_value
+                );
+                UART_write(huart, (uint8_t *)adc_str, strlen(adc_str));
+                // Send "World" after ADC value
                 UART_write(huart, (uint8_t *)"World", CB_THRESHOLD);
             } else {
                 UART_write(huart, (uint8_t *)buf, bytes_read);

--- a/src/platform/adc_ll.h
+++ b/src/platform/adc_ll.h
@@ -10,7 +10,6 @@
 #ifndef PSLAB_ADC_LL_H
 #define PSLAB_ADC_LL_H
 
-#include <stdbool.h>
 #include <stdint.h>
 
 /**
@@ -18,7 +17,7 @@
  *
  * This function configures the ADC1 peripheral with the specified settings.
  */
-void ADC1_LL_Init(void);
+void ADC_LL_init(void);
 
 /**
  * @brief Deinitializes the ADC peripheral.
@@ -26,7 +25,7 @@ void ADC1_LL_Init(void);
  * This function deinitializes the ADC peripheral and releases any resources
  * used.
  */
-void ADC_LL_DeInit(void);
+void ADC_LL_deinit(void);
 
 /**
  * @brief Starts the ADC conversion.
@@ -34,7 +33,7 @@ void ADC_LL_DeInit(void);
  * This function starts the ADC conversion process. It must be called after
  * the ADC has been initialized and configured.
  */
-void ADC1_Start(void);
+void ADC_LL_start(void);
 
 /**
  * @brief Stops the ADC conversion.
@@ -42,7 +41,7 @@ void ADC1_Start(void);
  * This function stops the ongoing ADC conversion process. It can be called
  * to halt conversions before deinitializing the ADC or when no longer needed.
  */
-void ADC1_Stop(void);
+void ADC_LL_stop(void);
 
 /**
  * @brief Reads the ADC value into the provided buffer.
@@ -53,6 +52,6 @@ void ADC1_Stop(void);
  * @param buffer Pointer to a buffer where the ADC value will be stored.
  * @return The converted ADC value.
  */
-uint32_t ADC_LL_Read(uint32_t *buffer);
+uint32_t ADC_LL_read(uint32_t *buffer);
 
 #endif // ADC_LL_H

--- a/src/platform/adc_ll.h
+++ b/src/platform/adc_ll.h
@@ -1,0 +1,58 @@
+/**
+ * @file adc_ll.h
+ * @brief Hardware-specific ADC (Analog-to-Digital Converter) interface
+ *
+ * This header file defines the hardware-specific interface for the ADC driver.
+ *
+ * @author Tejas Garg
+ * @date 2025-07-02
+ */
+#ifndef PSLAB_ADC_LL_H
+#define PSLAB_ADC_LL_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/**
+ * @brief Initializes the ADC1 peripheral.
+ *
+ * This function configures the ADC1 peripheral with the specified settings.
+ */
+void ADC1_LL_Init(void);
+
+/**
+ * @brief Deinitializes the ADC peripheral.
+ *
+ * This function deinitializes the ADC peripheral and releases any resources
+ * used.
+ */
+void ADC_LL_DeInit(void);
+
+/**
+ * @brief Starts the ADC conversion.
+ *
+ * This function starts the ADC conversion process. It must be called after
+ * the ADC has been initialized and configured.
+ */
+void ADC1_Start(void);
+
+/**
+ * @brief Stops the ADC conversion.
+ *
+ * This function stops the ongoing ADC conversion process. It can be called
+ * to halt conversions before deinitializing the ADC or when no longer needed.
+ */
+void ADC1_Stop(void);
+
+/**
+ * @brief Reads the ADC value into the provided buffer.
+ *
+ * This function starts the ADC conversion, waits for it to complete,
+ * and reads the converted value into the provided buffer.
+ *
+ * @param buffer Pointer to a buffer where the ADC value will be stored.
+ * @return The converted ADC value.
+ */
+uint32_t ADC_LL_Read(uint32_t *buffer);
+
+#endif // ADC_LL_H

--- a/src/platform/h563xx/CMakeLists.txt
+++ b/src/platform/h563xx/CMakeLists.txt
@@ -41,4 +41,5 @@ target_link_libraries(pslab-platform
     # pslab-platform provides newlib for malloc etc.
     INTERFACE
         STM32::NoSys
+        STM32::Nano
 )

--- a/src/platform/h563xx/CMakeLists.txt
+++ b/src/platform/h563xx/CMakeLists.txt
@@ -1,5 +1,6 @@
 target_sources(pslab-platform
     PRIVATE
+        adc_ll.c
         led_ll.c
         platform.c
         uart_ll.c
@@ -29,6 +30,7 @@ target_link_libraries(pslab-platform
         CMSIS::STM32::H5
         tinyusb
     PRIVATE
+        HAL::STM32::H5::ADCEx
         HAL::STM32::H5::CORTEX
         HAL::STM32::H5::DMAEx
         HAL::STM32::H5::ICACHE

--- a/src/platform/h563xx/adc_ll.c
+++ b/src/platform/h563xx/adc_ll.c
@@ -1,0 +1,183 @@
+/**
+ * @file adc_ll.c
+ * @brief Hardware-specific ADC (Analog-to-Digital Converter) implementation
+ *
+ * This module provides the hardware-specific layer of the ADC driver.
+ *
+ * This implementation relies on the STM32 HAL library for ADC operations.
+ * It provides functions to initialize the ADC, configure channels, start
+ * conversions, and read ADC values.
+ *
+ * @author Tejas Garg
+ * @date 2025-07-02
+ */
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "stm32h5xx_hal.h"
+
+#include "adc_ll.h"
+
+ADC_HandleTypeDef hadc = { 0 };
+
+DMA_HandleTypeDef hdma_adc1 = { 0 };
+
+ADC_ChannelConfTypeDef sConfig = { 0 };
+
+/**
+ * @brief Initializes the ADC MSP (MCU Support Package).
+ *
+ * This function configures the ADC GPIO pins, DMA, and clock settings.
+ * It is called by the HAL_ADC_Init function to set up the ADC hardware.
+ *
+ * @param hadc Pointer to the ADC handle structure.
+ */
+void HAL_ADC_MspInit(ADC_HandleTypeDef *hadc)
+{
+    GPIO_InitTypeDef GPIO_InitStruct = { 0 };
+
+    // Enable ADC1 clock
+    __HAL_RCC_ADC_CLK_ENABLE();
+    // Enable GPIOA clock
+    __HAL_RCC_GPIOA_CLK_ENABLE();
+    // Enable GPDMA1 clock
+    __HAL_RCC_GPDMA1_CLK_ENABLE();
+
+    // Configure GPIO pin for ADC1_IN0 (PA0)
+    GPIO_InitStruct.Pin = GPIO_PIN_0; // PA0
+    GPIO_InitStruct.Mode = GPIO_MODE_ANALOG;
+    GPIO_InitStruct.Pull = GPIO_NOPULL;
+    HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
+
+    // Configure DMA for ADC1
+    hdma_adc1.Instance = GPDMA1_Channel6;
+    hdma_adc1.Init.Request = GPDMA1_REQUEST_ADC1;
+    hdma_adc1.Init.BlkHWRequest = DMA_BREQ_SINGLE_BURST;
+    hdma_adc1.Init.Direction = DMA_PERIPH_TO_MEMORY;
+    hdma_adc1.Init.SrcInc = DMA_SINC_FIXED;
+    hdma_adc1.Init.DestInc = DMA_DINC_INCREMENTED;
+    hdma_adc1.Init.SrcDataWidth = DMA_SRC_DATAWIDTH_WORD;
+    hdma_adc1.Init.DestDataWidth = DMA_DEST_DATAWIDTH_WORD;
+    hdma_adc1.Init.Priority = DMA_LOW_PRIORITY_HIGH_WEIGHT;
+    hdma_adc1.Init.SrcBurstLength = 1;
+    hdma_adc1.Init.DestBurstLength = 1;
+    hdma_adc1.Init.TransferAllocatedPort =
+        (DMA_SRC_ALLOCATED_PORT0 | DMA_DEST_ALLOCATED_PORT0);
+    hdma_adc1.Init.TransferEventMode = DMA_TCEM_BLOCK_TRANSFER;
+    hdma_adc1.Init.Mode = DMA_NORMAL;
+    HAL_DMA_Init(&hdma_adc1);
+
+    // Link DMA to ADC
+    __HAL_LINKDMA(hadc, DMA_Handle, hdma_adc1);
+
+    HAL_NVIC_SetPriority(ADC1_IRQn, 4, 1);
+    HAL_NVIC_EnableIRQ(ADC1_IRQn);
+
+    HAL_NVIC_SetPriority(GPDMA1_Channel6_IRQn, 4, 0);
+    HAL_NVIC_EnableIRQ(GPDMA1_Channel6_IRQn);
+}
+
+/**
+ * @brief Initializes the ADC1 peripheral.
+ *
+ * This function configures the ADC1 peripheral with the specified settings.
+ * It sets the clock prescaler, resolution, data alignment, and other
+ * parameters.
+ *
+ */
+void ADC1_LL_Init(void)
+{
+    // Initialize the ADC peripheral
+    hadc.Instance = ADC1;
+    hadc.Init.ClockPrescaler = ADC_CLOCK_SYNC_PCLK_DIV4;
+    hadc.Init.Resolution = ADC_RESOLUTION_12B;
+    hadc.Init.DataAlign = ADC_DATAALIGN_RIGHT;
+    hadc.Init.ScanConvMode = DISABLE;
+    hadc.Init.EOCSelection = ADC_EOC_SINGLE_CONV;
+    hadc.Init.LowPowerAutoWait = DISABLE;
+    hadc.Init.ContinuousConvMode = DISABLE;
+    hadc.Init.NbrOfConversion = 1;
+    hadc.Init.DiscontinuousConvMode = DISABLE;
+    hadc.Init.ExternalTrigConvEdge = ADC_EXTERNALTRIGCONVEDGE_NONE;
+    hadc.Init.ExternalTrigConv = ADC_SOFTWARE_START;
+
+    // Configure ADC channel
+    sConfig.Channel = ADC_CHANNEL_0; // ADC1_IN0
+    sConfig.Rank = ADC_REGULAR_RANK_1;
+    sConfig.SamplingTime = ADC_SAMPLETIME_640CYCLES_5;
+    HAL_ADC_ConfigChannel(&hadc, &sConfig);
+
+    HAL_ADC_Init(&hadc);
+}
+
+/**
+ * @brief Deinitializes the ADC
+ *
+ */
+void ADC_LL_DeInit(void)
+{
+    // Deinitialize the ADC peripheral
+    HAL_ADC_DeInit(&hadc);
+}
+
+/**
+ * @brief Starts the ADC conversion.
+ *
+ * This function starts the ADC conversion process. It must be called after
+ * the ADC has been initialized and configured.
+ *
+ */
+void ADC1_Start(void)
+{
+    // Start the ADC conversion
+    HAL_ADC_Start(&hadc);
+}
+
+/**
+ * @brief Stops the ADC conversion.
+ *
+ * This function stops the ongoing ADC conversion process. It can be called
+ * to halt conversions before deinitializing the ADC or when no longer needed.
+ *
+ */
+void ADC1_Stop(void)
+{
+    // Stop the ADC conversion
+    HAL_ADC_Stop(&hadc);
+}
+
+uint32_t ADC_LL_Read(uint32_t *buffer)
+{
+    // Start the ADC conversion
+    HAL_ADC_Start(&hadc);
+
+    HAL_ADC_PollForConversion(&hadc, HAL_MAX_DELAY);
+
+    // Read the converted value
+    *buffer = HAL_ADC_GetValue(&hadc);
+
+    HAL_ADC_Stop(&hadc); // Stop the ADC conversion
+
+    return *buffer; // Return the converted value
+}
+
+/**
+ * @brief ADC interrupt handler.
+ */
+void ADC1_IRQHandler(void)
+{
+    // Handle ADC interrupt
+    HAL_ADC_IRQHandler(&hadc);
+}
+
+/**
+ * @brief DMA interrupt handler for ADC.
+ */
+void GPDMA1_Channel6_IRQHandler(void)
+{
+    // Handle DMA interrupt for ADC
+    HAL_DMA_IRQHandler(&hdma_adc1);
+}

--- a/src/platform/h563xx/adc_ll.c
+++ b/src/platform/h563xx/adc_ll.c
@@ -12,18 +12,15 @@
  * @date 2025-07-02
  */
 
-#include <stdbool.h>
-#include <stddef.h>
 #include <stdint.h>
-#include <string.h>
 
 #include "stm32h5xx_hal.h"
 
 #include "adc_ll.h"
 
-ADC_HandleTypeDef hadc = { 0 };
+static ADC_HandleTypeDef hadc = { 0 };
 
-ADC_ChannelConfTypeDef sConfig = { 0 };
+static ADC_ChannelConfTypeDef sConfig = { 0 };
 
 /**
  * @brief Initializes the ADC MSP (MCU Support Package).
@@ -59,7 +56,7 @@ void HAL_ADC_MspInit(ADC_HandleTypeDef *hadc)
  * parameters.
  *
  */
-void ADC1_LL_Init(void)
+void ADC_LL_init(void)
 {
     // Initialize the ADC peripheral
     hadc.Instance = ADC1;
@@ -88,7 +85,7 @@ void ADC1_LL_Init(void)
  * @brief Deinitializes the ADC
  *
  */
-void ADC_LL_DeInit(void)
+void ADC_LL_deinit(void)
 {
     // Deinitialize the ADC peripheral
     HAL_ADC_DeInit(&hadc);
@@ -101,7 +98,7 @@ void ADC_LL_DeInit(void)
  * the ADC has been initialized and configured.
  *
  */
-void ADC1_Start(void)
+void ADC_LL_start(void)
 {
     // Start the ADC conversion
     HAL_ADC_Start(&hadc);
@@ -114,13 +111,13 @@ void ADC1_Start(void)
  * to halt conversions before deinitializing the ADC or when no longer needed.
  *
  */
-void ADC1_Stop(void)
+void ADC_LL_stop(void)
 {
     // Stop the ADC conversion
     HAL_ADC_Stop(&hadc);
 }
 
-uint32_t ADC_LL_Read(uint32_t *buffer)
+uint32_t ADC_LL_read(uint32_t *buffer)
 {
     // Start the ADC conversion
     HAL_ADC_Start(&hadc);

--- a/src/platform/h563xx/stm32h5xx_hal_conf.h
+++ b/src/platform/h563xx/stm32h5xx_hal_conf.h
@@ -38,7 +38,7 @@ extern "C" {
  * @brief This is the list of modules to be used in the HAL driver
  */
 #define HAL_MODULE_ENABLED
-// #define HAL_ADC_MODULE_ENABLED
+#define HAL_ADC_MODULE_ENABLED
 // #define HAL_CEC_MODULE_ENABLED
 // #define HAL_COMP_MODULE_ENABLED
 // #define HAL_CORDIC_MODULE_ENABLED

--- a/src/system/CMakeLists.txt
+++ b/src/system/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(bus)
+add_subdirectory(adc)
 
 target_sources(pslab-mini-firmware
     PRIVATE

--- a/src/system/adc/CMakeLists.txt
+++ b/src/system/adc/CMakeLists.txt
@@ -1,0 +1,9 @@
+target_sources(pslab-mini-firmware
+    PRIVATE
+        adc.c
+)
+
+target_include_directories(pslab-mini-firmware
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+)

--- a/src/system/adc/adc.c
+++ b/src/system/adc/adc.c
@@ -11,8 +11,6 @@
  * @date 2025-07-02
  */
 
-#include <stdbool.h>
-#include <stddef.h>
 #include <stdint.h>
 
 #include "adc.h"
@@ -25,10 +23,10 @@
  * It must be called before any ADC operations can be performed.
  *
  */
-void ADC_Init(void)
+void ADC_init(void)
 {
     // Initialize the ADC peripheral
-    ADC1_LL_Init();
+    ADC_LL_init();
 }
 
 /**
@@ -37,10 +35,10 @@ void ADC_Init(void)
  * This function deinitializes the ADC peripheral and releases any resources
  * used. It should be called when the ADC is no longer needed.
  */
-void ADC_DeInit(void)
+void ADC_deinit(void)
 {
     // Deinitialize the ADC peripheral
-    ADC_LL_DeInit();
+    ADC_LL_deinit();
 }
 
 /**
@@ -50,10 +48,10 @@ void ADC_DeInit(void)
  * the ADC has been initialized and configured.
  *
  */
-void ADC_Start(void)
+void ADC_start(void)
 {
     // Start the ADC conversion
-    ADC1_Start();
+    ADC_LL_start();
 }
 
 /**
@@ -63,10 +61,10 @@ void ADC_Start(void)
  * to halt conversions before deinitializing the ADC or when no longer needed.
  *
  */
-void ADC_Stop(void)
+void ADC_stop(void)
 {
     // Stop the ADC conversion
-    ADC1_Stop();
+    ADC_LL_stop();
 }
 
 /**
@@ -75,9 +73,9 @@ void ADC_Stop(void)
  *
  * @param data Pointer to store the converted value.
  */
-uint32_t ADC_Read(uint32_t *data)
+uint32_t ADC_read(uint32_t *data)
 {
-    *data = ADC_LL_Read(data);
+    *data = ADC_LL_read(data);
 
     return *data;
 }

--- a/src/system/adc/adc.c
+++ b/src/system/adc/adc.c
@@ -17,7 +17,6 @@
 
 #include "adc.h"
 #include "adc_ll.h"
-#include "bus.h"
 
 /**
  * @brief Initializes the ADC peripheral.

--- a/src/system/adc/adc.c
+++ b/src/system/adc/adc.c
@@ -1,0 +1,84 @@
+/**
+ * @file adc.c
+ * @brief Hardware-independent ADC (Analog-to-Digital Converter) implementation
+ *
+ * This module provides the hardware-independent layer of the ADC driver.
+ * It manages ADC initialization, configuration, and data acquisition.
+ * The implementation relies on hardware-specific functions defined in
+ * src/system/h563xx/adc_ll.c (or equivalent for other platforms).
+ *
+ * @author Tejas Garg
+ * @date 2025-07-02
+ */
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "adc.h"
+#include "adc_ll.h"
+#include "bus.h"
+
+/**
+ * @brief Initializes the ADC peripheral.
+ *
+ * This function initializes the ADC peripheral with the specified settings.
+ * It must be called before any ADC operations can be performed.
+ *
+ */
+void ADC_Init(void)
+{
+    // Initialize the ADC peripheral
+    ADC1_LL_Init();
+}
+
+/**
+ * @brief Deinitializes the ADC peripheral.
+ *
+ * This function deinitializes the ADC peripheral and releases any resources
+ * used. It should be called when the ADC is no longer needed.
+ */
+void ADC_DeInit(void)
+{
+    // Deinitialize the ADC peripheral
+    ADC_LL_DeInit();
+}
+
+/**
+ * @brief Starts the ADC conversion.
+ *
+ * This function starts the ADC conversion process. It must be called after
+ * the ADC has been initialized and configured.
+ *
+ */
+void ADC_Start(void)
+{
+    // Start the ADC conversion
+    ADC1_Start();
+}
+
+/**
+ * @brief Stops the ADC conversion.
+ *
+ * This function stops the ongoing ADC conversion process. It can be called
+ * to halt conversions before deinitializing the ADC or when no longer needed.
+ *
+ */
+void ADC_Stop(void)
+{
+    // Stop the ADC conversion
+    ADC1_Stop();
+}
+
+/**
+ * @brief Reads the converted ADC value.
+ * This function reads the converted ADC value from the specified channel.
+ *
+ * @param data Pointer to store the converted value.
+ */
+uint32_t ADC_Read(uint32_t *data)
+{
+    *data = ADC_LL_Read(data);
+
+    return *data;
+}

--- a/src/system/adc/adc.h
+++ b/src/system/adc/adc.h
@@ -15,8 +15,6 @@
 #ifndef ADC_H
 #define ADC_H
 
-#include <stdbool.h>
-#include <stddef.h>
 #include <stdint.h>
 
 #include "adc_ll.h"
@@ -31,7 +29,7 @@ extern "C" {
  * This function initializes the ADC peripheral with the specified settings.
  * It must be called before any ADC operations can be performed.
  */
-void ADC_Init(void);
+void ADC_init(void);
 
 /**
  * @brief Deinitializes the ADC peripheral.
@@ -39,7 +37,7 @@ void ADC_Init(void);
  * This function deinitializes the ADC peripheral and releases any resources
  * used. It should be called when the ADC is no longer needed.
  */
-void ADC_DeInit(void);
+void ADC_deinit(void);
 
 /**
  * @brief Starts the ADC conversion.
@@ -47,7 +45,7 @@ void ADC_DeInit(void);
  * This function starts the ADC conversion process. It must be called after
  * the ADC has been initialized and configured.
  */
-void ADC_Start(void);
+void ADC_start(void);
 
 /**
  * @brief Stops the ADC conversion.
@@ -56,7 +54,7 @@ void ADC_Start(void);
  * to halt conversions before deinitializing the ADC or when no longer needed.
 
  */
-void ADC_Stop(void);
+void ADC_stop(void);
 
 /**
  * @brief Reads the ADC value.
@@ -66,7 +64,7 @@ void ADC_Stop(void);
  *
  * @param data Pointer to store the read ADC value.
  */
-uint32_t ADC_Read(uint32_t *data);
+uint32_t ADC_read(uint32_t *data);
 
 #ifdef __cplusplus
 }

--- a/src/system/adc/adc.h
+++ b/src/system/adc/adc.h
@@ -1,0 +1,76 @@
+/**
+ * @file adc.h
+ * @brief Hardware-independent ADC (Analog-to-Digital Converter) interface
+ *
+ * This header file defines the public API for the ADC driver.
+ * It provides functions for initializing the ADC, configuring channels,
+ * starting conversions, and reading ADC values.
+ *
+ * This implementation relies on hardware-specific functions defined in
+ * src/system/h563xx/adc_ll.c (or equivalent for other platforms).
+ * @author Tejas Garg
+ * @date 2025-07-02
+ */
+
+#ifndef ADC_H
+#define ADC_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "adc_ll.h"
+#include "bus.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief ADC Initialization function.
+ *
+ * This function initializes the ADC peripheral with the specified settings.
+ * It must be called before any ADC operations can be performed.
+ */
+void ADC_Init(void);
+
+/**
+ * @brief Deinitializes the ADC peripheral.
+ *
+ * This function deinitializes the ADC peripheral and releases any resources
+ * used. It should be called when the ADC is no longer needed.
+ */
+void ADC_DeInit(void);
+
+/**
+ * @brief Starts the ADC conversion.
+ *
+ * This function starts the ADC conversion process. It must be called after
+ * the ADC has been initialized and configured.
+ */
+void ADC_Start(void);
+
+/**
+ * @brief Stops the ADC conversion.
+ *
+ * This function stops the ongoing ADC conversion process. It can be called
+ * to halt conversions before deinitializing the ADC or when no longer needed.
+
+ */
+void ADC_Stop(void);
+
+/**
+ * @brief Reads the ADC value.
+ *
+ * This function reads the converted ADC value from the specified channel.
+ * It should be called after starting the ADC conversion.
+ *
+ * @param data Pointer to store the read ADC value.
+ */
+uint32_t ADC_Read(uint32_t *data);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // ADC_H

--- a/src/system/adc/adc.h
+++ b/src/system/adc/adc.h
@@ -20,7 +20,6 @@
 #include <stdint.h>
 
 #include "adc_ll.h"
-#include "bus.h"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
This is the basic implementation for the ADC driver 
It still has some bugs that need some work, and I will be working and adding to this PR over the next couple of days.

I also plan to add multiple instances for ADCs, similar to how it is implemented for the UART driver.

For now, this driver is able to output values from the ADC input pin A0, like we discussed in the previous meet and output it onto a serial monitor using the UART bus.

## Summary by Sourcery

Add a complete ADC driver stack by providing both hardware-independent and STM32H5-specific implementations, integrate it into the build, and demonstrate basic sampling and UART output in the main application.

New Features:
- Add hardware-independent ADC driver API (ADC_Init, ADC_Start, ADC_Read, ADC_Stop)
- Implement STM32H5-specific ADC low-level driver with DMA and interrupt handling
- Integrate ADC driver into the firmware build and enable HAL ADC module

Enhancements:
- Initialize ADC in main and read PA0 value on "Hello" command, sending the sample over UART

Build:
- Add adc_ll.c and adc.c to CMakeLists, enable HAL_ADC_MODULE_ENABLED, and link HAL::STM32::H5::ADCEx library