### PR TITLE
wrapper functionality for clocks of peripherals

### DIFF
--- a/src/platform/h563xx/platform.c
+++ b/src/platform/h563xx/platform.c
@@ -218,13 +218,16 @@ static uint32_t get_clock_speed(CLKType clk_type)
     }
 }
 
-uint32_t get_peripheral_clock_speed(PeripheralClock clock)
+uint32_t PLATFORM_get_peripheral_clock_speed(PLATFORM_PeripheralClock clock)
 {
-    if (clock == TIMER2 || clock == TIMER3 || clock == TIMER4 ||
-        clock == TIMER5 || clock == TIMER6 || clock == TIMER7) {
+    if (clock == PLATFORM_CLOCK_TIMER2 || clock == PLATFORM_CLOCK_TIMER3 ||
+        clock == PLATFORM_CLOCK_TIMER4 || clock == PLATFORM_CLOCK_TIMER5 ||
+        clock == PLATFORM_CLOCK_TIMER6 || clock == PLATFORM_CLOCK_TIMER7) {
         return get_clock_speed(APB1_CLK); // These timers use APB1 frequency
-    } else if (clock == TIMER1 || clock == TIMER8 || clock == TIMER16 ||
-               clock == TIMER17) {
+    } else if (clock == PLATFORM_CLOCK_TIMER1 ||
+               clock == PLATFORM_CLOCK_TIMER8 ||
+               clock == PLATFORM_CLOCK_TIMER16 ||
+               clock == PLATFORM_CLOCK_TIMER17) {
         return get_clock_speed(APB2_CLK); // These timers use APB2 frequency
     } else {
         return 0; // Invalid timer clock

--- a/src/platform/h563xx/platform.c
+++ b/src/platform/h563xx/platform.c
@@ -218,13 +218,13 @@ static uint32_t get_clock_speed(CLKType clk_type)
     }
 }
 
-uint32_t get_peripheral_clock_speed(PeripheralClock *clock)
+uint32_t get_peripheral_clock_speed(PeripheralClock clock)
 {
-    if (*clock == TIMER2 || *clock == TIMER3 || *clock == TIMER4 ||
-        *clock == TIMER5 || *clock == TIMER6 || *clock == TIMER7) {
+    if (clock == TIMER2 || clock == TIMER3 || clock == TIMER4 ||
+        clock == TIMER5 || clock == TIMER6 || clock == TIMER7) {
         return get_clock_speed(APB1_CLK); // These timers use APB1 frequency
-    } else if (*clock == TIMER1 || *clock == TIMER8 || *clock == TIMER16 ||
-               *clock == TIMER17 || *clock == TIMER16 || *clock == TIMER17) {
+    } else if (clock == TIMER1 || clock == TIMER8 || clock == TIMER16 ||
+               clock == TIMER17) {
         return get_clock_speed(APB2_CLK); // These timers use APB2 frequency
     } else {
         return 0; // Invalid timer clock

--- a/src/platform/platform.h
+++ b/src/platform/platform.h
@@ -65,6 +65,6 @@ typedef enum {
  * @return The clock speed in Hz for the specified peripheral clock type,
  *         or 0 if an invalid type is provided.
  */
-uint32_t get_peripheral_clock_speed(PeripheralClock *clock);
+uint32_t get_peripheral_clock_speed(PeripheralClock clock);
 
 #endif // PSLAB_LL_PLATFORM_H

--- a/src/platform/platform.h
+++ b/src/platform/platform.h
@@ -41,17 +41,17 @@
 void PLATFORM_init(void);
 
 typedef enum {
-    TIMER1,
-    TIMER2,
-    TIMER3,
-    TIMER4,
-    TIMER5,
-    TIMER6,
-    TIMER7,
-    TIMER8,
-    TIMER16,
-    TIMER17
-} PeripheralClock;
+    PLATFORM_CLOCK_TIMER1,
+    PLATFORM_CLOCK_TIMER2,
+    PLATFORM_CLOCK_TIMER3,
+    PLATFORM_CLOCK_TIMER4,
+    PLATFORM_CLOCK_TIMER5,
+    PLATFORM_CLOCK_TIMER6,
+    PLATFORM_CLOCK_TIMER7,
+    PLATFORM_CLOCK_TIMER8,
+    PLATFORM_CLOCK_TIMER16,
+    PLATFORM_CLOCK_TIMER17
+} PLATFORM_PeripheralClock;
 
 /**
  * @brief Get the clock speed for a specific peripheral clock
@@ -65,6 +65,6 @@ typedef enum {
  * @return The clock speed in Hz for the specified peripheral clock type,
  *         or 0 if an invalid type is provided.
  */
-uint32_t get_peripheral_clock_speed(PeripheralClock clock);
+uint32_t PLATFORM_get_peripheral_clock_speed(PLATFORM_PeripheralClock clock);
 
 #endif // PSLAB_LL_PLATFORM_H

--- a/src/platform/platform.h
+++ b/src/platform/platform.h
@@ -19,6 +19,8 @@
 #ifndef PSLAB_LL_PLATFORM_H
 #define PSLAB_LL_PLATFORM_H
 
+#include <stdint.h>
+
 /**
  * @brief Initialize the platform hardware
  *
@@ -37,5 +39,32 @@
  * @return None
  */
 void PLATFORM_init(void);
+
+typedef enum {
+    TIMER1,
+    TIMER2,
+    TIMER3,
+    TIMER4,
+    TIMER5,
+    TIMER6,
+    TIMER7,
+    TIMER8,
+    TIMER16,
+    TIMER17
+} PeripheralClock;
+
+/**
+ * @brief Get the clock speed for a specific peripheral clock
+ *
+ * This function retrieves the clock speed for the specified peripheral clock
+ * type. It can be used to determine the frequency of various system clocks (for
+ * now timers)
+ *
+ * @param clock The type of peripheral clock to query (TIM1, TIM2, etc.)
+ *
+ * @return The clock speed in Hz for the specified peripheral clock type,
+ *         or 0 if an invalid type is provided.
+ */
+uint32_t get_peripheral_clock_speed(PeripheralClock *clock);
 
 #endif // PSLAB_LL_PLATFORM_H


### PR DESCRIPTION
fixes: #79 

Added functionality for calling the clock speed for the required peripheral 
I have made this such that more peripherals can be easily added to the enum later, as per requirement

In platform.h, I have initialised an enum that will help call for any peripheral clock value required using the function get_peripheral_clock_speed();

In platform.c, I have defined different clock sources in an enum and called their clock speeds using HAL functions such as HAL_RCC_GetSysClockFreq();

Further, I defined get_peripheral_clock_speed, which uses the above function to define the clock speed for any required peripheral.

## Summary by Sourcery

Provide a unified wrapper for retrieving peripheral timer clock speeds by mapping PeripheralClock enums to underlying bus clocks and abstracting HAL_RCC calls

New Features:
- Introduce PeripheralClock enum and get_peripheral_clock_speed() API to query timer peripheral clock frequencies
- Add internal get_clock_speed() helper to wrap HAL_RCC_Get* calls for SYS, AHB, APB1, APB2, and APB3 clocks

Enhancements:
- Define CLKType enum to streamline addition of new clock sources for future peripherals