### PR TITLE
Implement basic stdio functionality

### DIFF
--- a/boot/lib/TinyUSB/cfg/usb_descriptors.c
+++ b/boot/lib/TinyUSB/cfg/usb_descriptors.c
@@ -1,4 +1,4 @@
-/* 
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2019 Ha Thach (tinyusb.org)
@@ -269,7 +269,7 @@ bool tud_vendor_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb_control_requ
       }
     break;
 
-    default: 
+    default:
       break;
   }
 

--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -75,7 +75,7 @@ CheckOptions:
   # Public functions have capitalized prefix
   - key: readability-identifier-naming.GlobalFunctionCase
     value: 'aNy_CasE'
-  # Interrupt service routines
+  # PIC24 Interrupt service routines
   - key: readability-identifier-naming.GlobalFunctionIgnoredRegexp
     value: '_[A-Z0-9]+Interrupt'
   - key: readability-identifier-naming.VariableCase
@@ -83,6 +83,12 @@ CheckOptions:
   # Register names
   - key: readability-identifier-naming.VariableIgnoredRegexp
     value: '[A-Z][A-Z0-9]+(bits)?'
+  - key: readability-identifier-naming.GlobalVariableCase
+    value: 'lower_case'
+  - key: readability-identifier-naming.GlobalVariablePrefix
+    value: 'g_'
+  - key: readability-identifier-naming.GlobalVariableIgnoredRegexp
+    value: '(g_)[A-Z_]+[a-z0-9_]+'
   - key: readability-identifier-naming.StructCase
     value: 'CamelCase'
   - key: readability-identifier-naming.TypedefCase

--- a/src/application/main.c
+++ b/src/application/main.c
@@ -11,7 +11,6 @@
 #include "bus.h"
 #include "led.h"
 #include "system.h"
-#include "uart.h"
 #include "usb.h"
 
 /*****************************************************************************
@@ -58,32 +57,20 @@ int main(void) // NOLINT
     // Initialize ADC
     ADC_init();
 
-    /* Basic UART/USB/LED example:
-     * - Register callbacks for both UART and USB
-     * - Process incoming bytes when callbacks are triggered
+    /* Basic USB/LED example:
+     * - Process incoming bytes when USB callback is triggered
      * - If a byte is received, toggle the LED
-     * - Try to read five bytes (this may timeout)
      * - If the read bytes equal "Hello", then respond "World"
      * - Otherwise echo back what was received
+     * - Use printf for debugging output to UART
      */
     while (1) {
         USB_task(husb);
-        uint8_t buf[CB_THRESHOLD + 1] = { 0 };
-        uint32_t bytes_read = 0;
 
-        if ((bytes_read = scanf("%5s", buf))) {
-            LED_toggle();
-
-            if (strcmp((char *)buf, "Hello") == 0) {
-                uint32_t adc_value = 0;
-                uint32_t temp = 0;
-                adc_value = ADC_read(&temp);
-                printf("\r\nADC_Value:%lu\r\n", (unsigned long)adc_value);
-                // Send "World" after ADC value
-                printf("World");
-            } else {
-                printf("%s", buf);
-            }
+        // Log system status periodically (optional)
+        static uint32_t log_counter = 0;
+        if (++log_counter % 1000000 == 0) {
+            printf("System running, USB active\r\n");
         }
 
         if (usb_service_requested) {

--- a/src/application/main.c
+++ b/src/application/main.c
@@ -103,15 +103,7 @@ int main(void) // NOLINT
                 uint32_t adc_value = 0;
                 uint32_t temp = 0;
                 adc_value = ADC_read(&temp);
-                // Convert ADC value to string and send it
-                char adc_str[ADC_STRING_SIZE];
-                (void)snprintf(
-                    adc_str,
-                    sizeof(adc_str),
-                    "\r\nADC_Value:%lu\r\n",
-                    (unsigned long)adc_value
-                );
-                UART_write(huart, (uint8_t *)adc_str, strlen(adc_str));
+                printf("\r\nADC_Value:%lu\r\n", (unsigned long)adc_value);
                 // Send "World" after ADC value
                 UART_write(huart, (uint8_t *)"World", CB_THRESHOLD);
             } else {

--- a/src/platform/h563xx/adc_ll.c
+++ b/src/platform/h563xx/adc_ll.c
@@ -18,9 +18,9 @@
 
 #include "adc_ll.h"
 
-static ADC_HandleTypeDef hadc = { nullptr };
+static ADC_HandleTypeDef g_hadc = { nullptr };
 
-static ADC_ChannelConfTypeDef s_config = { 0 };
+static ADC_ChannelConfTypeDef g_config = { 0 };
 
 /**
  * @brief Initializes the ADC MSP (MCU Support Package).
@@ -60,26 +60,26 @@ void HAL_ADC_MspInit(ADC_HandleTypeDef *hadc)
 void ADC_LL_init(void)
 {
     // Initialize the ADC peripheral
-    hadc.Instance = ADC1;
-    hadc.Init.ClockPrescaler = ADC_CLOCK_SYNC_PCLK_DIV4;
-    hadc.Init.Resolution = ADC_RESOLUTION_12B;
-    hadc.Init.DataAlign = ADC_DATAALIGN_RIGHT;
-    hadc.Init.ScanConvMode = DISABLE;
-    hadc.Init.EOCSelection = ADC_EOC_SINGLE_CONV;
-    hadc.Init.LowPowerAutoWait = DISABLE;
-    hadc.Init.ContinuousConvMode = DISABLE;
-    hadc.Init.NbrOfConversion = 1;
-    hadc.Init.DiscontinuousConvMode = DISABLE;
-    hadc.Init.ExternalTrigConvEdge = ADC_EXTERNALTRIGCONVEDGE_NONE;
-    hadc.Init.ExternalTrigConv = ADC_SOFTWARE_START;
+    g_hadc.Instance = ADC1;
+    g_hadc.Init.ClockPrescaler = ADC_CLOCK_SYNC_PCLK_DIV4;
+    g_hadc.Init.Resolution = ADC_RESOLUTION_12B;
+    g_hadc.Init.DataAlign = ADC_DATAALIGN_RIGHT;
+    g_hadc.Init.ScanConvMode = DISABLE;
+    g_hadc.Init.EOCSelection = ADC_EOC_SINGLE_CONV;
+    g_hadc.Init.LowPowerAutoWait = DISABLE;
+    g_hadc.Init.ContinuousConvMode = DISABLE;
+    g_hadc.Init.NbrOfConversion = 1;
+    g_hadc.Init.DiscontinuousConvMode = DISABLE;
+    g_hadc.Init.ExternalTrigConvEdge = ADC_EXTERNALTRIGCONVEDGE_NONE;
+    g_hadc.Init.ExternalTrigConv = ADC_SOFTWARE_START;
 
-    HAL_ADC_Init(&hadc);
+    HAL_ADC_Init(&g_hadc);
 
     // Configure ADC channel
-    s_config.Channel = ADC_CHANNEL_0; // ADC1_IN0
-    s_config.Rank = ADC_REGULAR_RANK_1;
-    s_config.SamplingTime = ADC_SAMPLETIME_640CYCLES_5;
-    HAL_ADC_ConfigChannel(&hadc, &s_config);
+    g_config.Channel = ADC_CHANNEL_0; // ADC1_IN0
+    g_config.Rank = ADC_REGULAR_RANK_1;
+    g_config.SamplingTime = ADC_SAMPLETIME_640CYCLES_5;
+    HAL_ADC_ConfigChannel(&g_hadc, &g_config);
 }
 
 /**
@@ -89,7 +89,7 @@ void ADC_LL_init(void)
 void ADC_LL_deinit(void)
 {
     // Deinitialize the ADC peripheral
-    HAL_ADC_DeInit(&hadc);
+    HAL_ADC_DeInit(&g_hadc);
 }
 
 /**
@@ -102,7 +102,7 @@ void ADC_LL_deinit(void)
 void ADC_LL_start(void)
 {
     // Start the ADC conversion
-    HAL_ADC_Start(&hadc);
+    HAL_ADC_Start(&g_hadc);
 }
 
 /**
@@ -115,20 +115,20 @@ void ADC_LL_start(void)
 void ADC_LL_stop(void)
 {
     // Stop the ADC conversion
-    HAL_ADC_Stop(&hadc);
+    HAL_ADC_Stop(&g_hadc);
 }
 
 uint32_t ADC_LL_read(uint32_t *buffer)
 {
     // Start the ADC conversion
-    HAL_ADC_Start(&hadc);
+    HAL_ADC_Start(&g_hadc);
 
-    HAL_ADC_PollForConversion(&hadc, HAL_MAX_DELAY);
+    HAL_ADC_PollForConversion(&g_hadc, HAL_MAX_DELAY);
 
     // Read the converted value
-    *buffer = HAL_ADC_GetValue(&hadc);
+    *buffer = HAL_ADC_GetValue(&g_hadc);
 
-    HAL_ADC_Stop(&hadc); // Stop the ADC conversion
+    HAL_ADC_Stop(&g_hadc); // Stop the ADC conversion
 
     return *buffer; // Return the converted value
 }

--- a/src/platform/h563xx/uart_ll.c
+++ b/src/platform/h563xx/uart_ll.c
@@ -45,34 +45,34 @@ typedef struct {
 } UARTInstance;
 
 /* HAL UART handles */
-static UART_HandleTypeDef huart1 = { nullptr };
-static UART_HandleTypeDef huart2 = { nullptr };
-static UART_HandleTypeDef huart3 = { nullptr };
+static UART_HandleTypeDef g_huart1 = { nullptr };
+static UART_HandleTypeDef g_huart2 = { nullptr };
+static UART_HandleTypeDef g_huart3 = { nullptr };
 
 /* DMA handles */
-static DMA_HandleTypeDef hdma_usart1_tx = { nullptr };
-static DMA_HandleTypeDef hdma_usart1_rx = { nullptr };
-static DMA_HandleTypeDef hdma_usart2_tx = { nullptr };
-static DMA_HandleTypeDef hdma_usart2_rx = { nullptr };
-static DMA_HandleTypeDef hdma_usart3_tx = { nullptr };
-static DMA_HandleTypeDef hdma_usart3_rx = { nullptr };
+static DMA_HandleTypeDef g_hdma_usart1_tx = { nullptr };
+static DMA_HandleTypeDef g_hdma_usart1_rx = { nullptr };
+static DMA_HandleTypeDef g_hdma_usart2_tx = { nullptr };
+static DMA_HandleTypeDef g_hdma_usart2_rx = { nullptr };
+static DMA_HandleTypeDef g_hdma_usart3_tx = { nullptr };
+static DMA_HandleTypeDef g_hdma_usart3_rx = { nullptr };
 
 /* Instance array */
-static UARTInstance uart_instances[UART_BUS_COUNT] = {
+static UARTInstance g_uart_instances[UART_BUS_COUNT] = {
     [UART_BUS_0] = {
-        .huart = &huart1,
-        .hdma_tx = &hdma_usart1_tx,
-        .hdma_rx = &hdma_usart1_rx,
+        .huart = &g_huart1,
+        .hdma_tx = &g_hdma_usart1_tx,
+        .hdma_rx = &g_hdma_usart1_rx,
     },
     [UART_BUS_1] = {
-        .huart = &huart2,
-        .hdma_tx = &hdma_usart2_tx,
-        .hdma_rx = &hdma_usart2_rx,
+        .huart = &g_huart2,
+        .hdma_tx = &g_hdma_usart2_tx,
+        .hdma_rx = &g_hdma_usart2_rx,
     },
     [UART_BUS_2] = {
-        .huart = &huart3,
-        .hdma_tx = &hdma_usart3_tx,
-        .hdma_rx = &hdma_usart3_rx,
+        .huart = &g_huart3,
+        .hdma_tx = &g_hdma_usart3_tx,
+        .hdma_rx = &g_hdma_usart3_rx,
     },
 };
 
@@ -120,42 +120,42 @@ void HAL_UART_MspInit(UART_HandleTypeDef *huart)
         HAL_GPIO_Init(GPIOA, &gpio_init);
 
         /* Configure DMA for TX */
-        hdma_usart1_tx.Instance = GPDMA1_Channel0;
-        hdma_usart1_tx.Init.Request = GPDMA1_REQUEST_USART1_TX;
-        hdma_usart1_tx.Init.BlkHWRequest = DMA_BREQ_SINGLE_BURST;
-        hdma_usart1_tx.Init.Direction = DMA_MEMORY_TO_PERIPH;
-        hdma_usart1_tx.Init.SrcInc = DMA_SINC_INCREMENTED;
-        hdma_usart1_tx.Init.DestInc = DMA_DINC_FIXED;
-        hdma_usart1_tx.Init.SrcDataWidth = DMA_SRC_DATAWIDTH_BYTE;
-        hdma_usart1_tx.Init.DestDataWidth = DMA_DEST_DATAWIDTH_BYTE;
-        hdma_usart1_tx.Init.Priority = DMA_LOW_PRIORITY_LOW_WEIGHT;
-        hdma_usart1_tx.Init.SrcBurstLength = 1;
-        hdma_usart1_tx.Init.DestBurstLength = 1;
-        hdma_usart1_tx.Init.TransferAllocatedPort =
+        g_hdma_usart1_tx.Instance = GPDMA1_Channel0;
+        g_hdma_usart1_tx.Init.Request = GPDMA1_REQUEST_USART1_TX;
+        g_hdma_usart1_tx.Init.BlkHWRequest = DMA_BREQ_SINGLE_BURST;
+        g_hdma_usart1_tx.Init.Direction = DMA_MEMORY_TO_PERIPH;
+        g_hdma_usart1_tx.Init.SrcInc = DMA_SINC_INCREMENTED;
+        g_hdma_usart1_tx.Init.DestInc = DMA_DINC_FIXED;
+        g_hdma_usart1_tx.Init.SrcDataWidth = DMA_SRC_DATAWIDTH_BYTE;
+        g_hdma_usart1_tx.Init.DestDataWidth = DMA_DEST_DATAWIDTH_BYTE;
+        g_hdma_usart1_tx.Init.Priority = DMA_LOW_PRIORITY_LOW_WEIGHT;
+        g_hdma_usart1_tx.Init.SrcBurstLength = 1;
+        g_hdma_usart1_tx.Init.DestBurstLength = 1;
+        g_hdma_usart1_tx.Init.TransferAllocatedPort =
             (DMA_SRC_ALLOCATED_PORT0 | DMA_DEST_ALLOCATED_PORT0);
-        hdma_usart1_tx.Init.TransferEventMode = DMA_TCEM_BLOCK_TRANSFER;
-        hdma_usart1_tx.Init.Mode = DMA_NORMAL;
-        HAL_DMA_Init(&hdma_usart1_tx);
-        __HAL_LINKDMA(huart, hdmatx, hdma_usart1_tx);
+        g_hdma_usart1_tx.Init.TransferEventMode = DMA_TCEM_BLOCK_TRANSFER;
+        g_hdma_usart1_tx.Init.Mode = DMA_NORMAL;
+        HAL_DMA_Init(&g_hdma_usart1_tx);
+        __HAL_LINKDMA(huart, hdmatx, g_hdma_usart1_tx);
 
         /* Configure DMA for RX */
-        hdma_usart1_rx.Instance = GPDMA1_Channel1;
-        hdma_usart1_rx.Init.Request = GPDMA1_REQUEST_USART1_RX;
-        hdma_usart1_rx.Init.BlkHWRequest = DMA_BREQ_SINGLE_BURST;
-        hdma_usart1_rx.Init.Direction = DMA_PERIPH_TO_MEMORY;
-        hdma_usart1_rx.Init.SrcInc = DMA_SINC_FIXED;
-        hdma_usart1_rx.Init.DestInc = DMA_DINC_INCREMENTED;
-        hdma_usart1_rx.Init.SrcDataWidth = DMA_SRC_DATAWIDTH_BYTE;
-        hdma_usart1_rx.Init.DestDataWidth = DMA_DEST_DATAWIDTH_BYTE;
-        hdma_usart1_rx.Init.Priority = DMA_LOW_PRIORITY_LOW_WEIGHT;
-        hdma_usart1_rx.Init.SrcBurstLength = 1;
-        hdma_usart1_rx.Init.DestBurstLength = 1;
-        hdma_usart1_rx.Init.TransferAllocatedPort =
+        g_hdma_usart1_rx.Instance = GPDMA1_Channel1;
+        g_hdma_usart1_rx.Init.Request = GPDMA1_REQUEST_USART1_RX;
+        g_hdma_usart1_rx.Init.BlkHWRequest = DMA_BREQ_SINGLE_BURST;
+        g_hdma_usart1_rx.Init.Direction = DMA_PERIPH_TO_MEMORY;
+        g_hdma_usart1_rx.Init.SrcInc = DMA_SINC_FIXED;
+        g_hdma_usart1_rx.Init.DestInc = DMA_DINC_INCREMENTED;
+        g_hdma_usart1_rx.Init.SrcDataWidth = DMA_SRC_DATAWIDTH_BYTE;
+        g_hdma_usart1_rx.Init.DestDataWidth = DMA_DEST_DATAWIDTH_BYTE;
+        g_hdma_usart1_rx.Init.Priority = DMA_LOW_PRIORITY_LOW_WEIGHT;
+        g_hdma_usart1_rx.Init.SrcBurstLength = 1;
+        g_hdma_usart1_rx.Init.DestBurstLength = 1;
+        g_hdma_usart1_rx.Init.TransferAllocatedPort =
             (DMA_SRC_ALLOCATED_PORT0 | DMA_DEST_ALLOCATED_PORT0);
-        hdma_usart1_rx.Init.TransferEventMode = DMA_TCEM_BLOCK_TRANSFER;
-        hdma_usart1_rx.Init.Mode = DMA_NORMAL;
-        HAL_DMA_Init(&hdma_usart1_rx);
-        __HAL_LINKDMA(huart, hdmarx, hdma_usart1_rx);
+        g_hdma_usart1_rx.Init.TransferEventMode = DMA_TCEM_BLOCK_TRANSFER;
+        g_hdma_usart1_rx.Init.Mode = DMA_NORMAL;
+        HAL_DMA_Init(&g_hdma_usart1_rx);
+        __HAL_LINKDMA(huart, hdmarx, g_hdma_usart1_rx);
 
         /* UART interrupt init */
         HAL_NVIC_SetPriority(USART1_IRQn, UART_IRQ_PRIO, 0);
@@ -181,42 +181,42 @@ void HAL_UART_MspInit(UART_HandleTypeDef *huart)
         HAL_GPIO_Init(GPIOA, &gpio_init);
 
         /* Configure DMA for TX */
-        hdma_usart2_tx.Instance = GPDMA1_Channel2;
-        hdma_usart2_tx.Init.Request = GPDMA1_REQUEST_USART2_TX;
-        hdma_usart2_tx.Init.BlkHWRequest = DMA_BREQ_SINGLE_BURST;
-        hdma_usart2_tx.Init.Direction = DMA_MEMORY_TO_PERIPH;
-        hdma_usart2_tx.Init.SrcInc = DMA_SINC_INCREMENTED;
-        hdma_usart2_tx.Init.DestInc = DMA_DINC_FIXED;
-        hdma_usart2_tx.Init.SrcDataWidth = DMA_SRC_DATAWIDTH_BYTE;
-        hdma_usart2_tx.Init.DestDataWidth = DMA_DEST_DATAWIDTH_BYTE;
-        hdma_usart2_tx.Init.Priority = DMA_LOW_PRIORITY_LOW_WEIGHT;
-        hdma_usart2_tx.Init.SrcBurstLength = 1;
-        hdma_usart2_tx.Init.DestBurstLength = 1;
-        hdma_usart2_tx.Init.TransferAllocatedPort =
+        g_hdma_usart2_tx.Instance = GPDMA1_Channel2;
+        g_hdma_usart2_tx.Init.Request = GPDMA1_REQUEST_USART2_TX;
+        g_hdma_usart2_tx.Init.BlkHWRequest = DMA_BREQ_SINGLE_BURST;
+        g_hdma_usart2_tx.Init.Direction = DMA_MEMORY_TO_PERIPH;
+        g_hdma_usart2_tx.Init.SrcInc = DMA_SINC_INCREMENTED;
+        g_hdma_usart2_tx.Init.DestInc = DMA_DINC_FIXED;
+        g_hdma_usart2_tx.Init.SrcDataWidth = DMA_SRC_DATAWIDTH_BYTE;
+        g_hdma_usart2_tx.Init.DestDataWidth = DMA_DEST_DATAWIDTH_BYTE;
+        g_hdma_usart2_tx.Init.Priority = DMA_LOW_PRIORITY_LOW_WEIGHT;
+        g_hdma_usart2_tx.Init.SrcBurstLength = 1;
+        g_hdma_usart2_tx.Init.DestBurstLength = 1;
+        g_hdma_usart2_tx.Init.TransferAllocatedPort =
             (DMA_SRC_ALLOCATED_PORT0 | DMA_DEST_ALLOCATED_PORT0);
-        hdma_usart2_tx.Init.TransferEventMode = DMA_TCEM_BLOCK_TRANSFER;
-        hdma_usart2_tx.Init.Mode = DMA_NORMAL;
-        HAL_DMA_Init(&hdma_usart2_tx);
-        __HAL_LINKDMA(huart, hdmatx, hdma_usart2_tx);
+        g_hdma_usart2_tx.Init.TransferEventMode = DMA_TCEM_BLOCK_TRANSFER;
+        g_hdma_usart2_tx.Init.Mode = DMA_NORMAL;
+        HAL_DMA_Init(&g_hdma_usart2_tx);
+        __HAL_LINKDMA(huart, hdmatx, g_hdma_usart2_tx);
 
         /* Configure DMA for RX */
-        hdma_usart2_rx.Instance = GPDMA1_Channel3;
-        hdma_usart2_rx.Init.Request = GPDMA1_REQUEST_USART2_RX;
-        hdma_usart2_rx.Init.BlkHWRequest = DMA_BREQ_SINGLE_BURST;
-        hdma_usart2_rx.Init.Direction = DMA_PERIPH_TO_MEMORY;
-        hdma_usart2_rx.Init.SrcInc = DMA_SINC_FIXED;
-        hdma_usart2_rx.Init.DestInc = DMA_DINC_INCREMENTED;
-        hdma_usart2_rx.Init.SrcDataWidth = DMA_SRC_DATAWIDTH_BYTE;
-        hdma_usart2_rx.Init.DestDataWidth = DMA_DEST_DATAWIDTH_BYTE;
-        hdma_usart2_rx.Init.Priority = DMA_LOW_PRIORITY_LOW_WEIGHT;
-        hdma_usart2_rx.Init.SrcBurstLength = 1;
-        hdma_usart2_rx.Init.DestBurstLength = 1;
-        hdma_usart2_rx.Init.TransferAllocatedPort =
+        g_hdma_usart2_rx.Instance = GPDMA1_Channel3;
+        g_hdma_usart2_rx.Init.Request = GPDMA1_REQUEST_USART2_RX;
+        g_hdma_usart2_rx.Init.BlkHWRequest = DMA_BREQ_SINGLE_BURST;
+        g_hdma_usart2_rx.Init.Direction = DMA_PERIPH_TO_MEMORY;
+        g_hdma_usart2_rx.Init.SrcInc = DMA_SINC_FIXED;
+        g_hdma_usart2_rx.Init.DestInc = DMA_DINC_INCREMENTED;
+        g_hdma_usart2_rx.Init.SrcDataWidth = DMA_SRC_DATAWIDTH_BYTE;
+        g_hdma_usart2_rx.Init.DestDataWidth = DMA_DEST_DATAWIDTH_BYTE;
+        g_hdma_usart2_rx.Init.Priority = DMA_LOW_PRIORITY_LOW_WEIGHT;
+        g_hdma_usart2_rx.Init.SrcBurstLength = 1;
+        g_hdma_usart2_rx.Init.DestBurstLength = 1;
+        g_hdma_usart2_rx.Init.TransferAllocatedPort =
             (DMA_SRC_ALLOCATED_PORT0 | DMA_DEST_ALLOCATED_PORT0);
-        hdma_usart2_rx.Init.TransferEventMode = DMA_TCEM_BLOCK_TRANSFER;
-        hdma_usart2_rx.Init.Mode = DMA_NORMAL;
-        HAL_DMA_Init(&hdma_usart2_rx);
-        __HAL_LINKDMA(huart, hdmarx, hdma_usart2_rx);
+        g_hdma_usart2_rx.Init.TransferEventMode = DMA_TCEM_BLOCK_TRANSFER;
+        g_hdma_usart2_rx.Init.Mode = DMA_NORMAL;
+        HAL_DMA_Init(&g_hdma_usart2_rx);
+        __HAL_LINKDMA(huart, hdmarx, g_hdma_usart2_rx);
 
         /* UART interrupt init */
         HAL_NVIC_SetPriority(USART2_IRQn, UART_IRQ_PRIO, 0);
@@ -242,42 +242,42 @@ void HAL_UART_MspInit(UART_HandleTypeDef *huart)
         HAL_GPIO_Init(GPIOD, &gpio_init);
 
         /* Configure DMA for TX */
-        hdma_usart3_tx.Instance = GPDMA1_Channel4;
-        hdma_usart3_tx.Init.Request = GPDMA1_REQUEST_USART3_TX;
-        hdma_usart3_tx.Init.BlkHWRequest = DMA_BREQ_SINGLE_BURST;
-        hdma_usart3_tx.Init.Direction = DMA_MEMORY_TO_PERIPH;
-        hdma_usart3_tx.Init.SrcInc = DMA_SINC_INCREMENTED;
-        hdma_usart3_tx.Init.DestInc = DMA_DINC_FIXED;
-        hdma_usart3_tx.Init.SrcDataWidth = DMA_SRC_DATAWIDTH_BYTE;
-        hdma_usart3_tx.Init.DestDataWidth = DMA_DEST_DATAWIDTH_BYTE;
-        hdma_usart3_tx.Init.Priority = DMA_LOW_PRIORITY_LOW_WEIGHT;
-        hdma_usart3_tx.Init.SrcBurstLength = 1;
-        hdma_usart3_tx.Init.DestBurstLength = 1;
-        hdma_usart3_tx.Init.TransferAllocatedPort =
+        g_hdma_usart3_tx.Instance = GPDMA1_Channel4;
+        g_hdma_usart3_tx.Init.Request = GPDMA1_REQUEST_USART3_TX;
+        g_hdma_usart3_tx.Init.BlkHWRequest = DMA_BREQ_SINGLE_BURST;
+        g_hdma_usart3_tx.Init.Direction = DMA_MEMORY_TO_PERIPH;
+        g_hdma_usart3_tx.Init.SrcInc = DMA_SINC_INCREMENTED;
+        g_hdma_usart3_tx.Init.DestInc = DMA_DINC_FIXED;
+        g_hdma_usart3_tx.Init.SrcDataWidth = DMA_SRC_DATAWIDTH_BYTE;
+        g_hdma_usart3_tx.Init.DestDataWidth = DMA_DEST_DATAWIDTH_BYTE;
+        g_hdma_usart3_tx.Init.Priority = DMA_LOW_PRIORITY_LOW_WEIGHT;
+        g_hdma_usart3_tx.Init.SrcBurstLength = 1;
+        g_hdma_usart3_tx.Init.DestBurstLength = 1;
+        g_hdma_usart3_tx.Init.TransferAllocatedPort =
             (DMA_SRC_ALLOCATED_PORT0 | DMA_DEST_ALLOCATED_PORT0);
-        hdma_usart3_tx.Init.TransferEventMode = DMA_TCEM_BLOCK_TRANSFER;
-        hdma_usart3_tx.Init.Mode = DMA_NORMAL;
-        HAL_DMA_Init(&hdma_usart3_tx);
-        __HAL_LINKDMA(huart, hdmatx, hdma_usart3_tx);
+        g_hdma_usart3_tx.Init.TransferEventMode = DMA_TCEM_BLOCK_TRANSFER;
+        g_hdma_usart3_tx.Init.Mode = DMA_NORMAL;
+        HAL_DMA_Init(&g_hdma_usart3_tx);
+        __HAL_LINKDMA(huart, hdmatx, g_hdma_usart3_tx);
 
         /* Configure DMA for RX */
-        hdma_usart3_rx.Instance = GPDMA1_Channel5;
-        hdma_usart3_rx.Init.Request = GPDMA1_REQUEST_USART3_RX;
-        hdma_usart3_rx.Init.BlkHWRequest = DMA_BREQ_SINGLE_BURST;
-        hdma_usart3_rx.Init.Direction = DMA_PERIPH_TO_MEMORY;
-        hdma_usart3_rx.Init.SrcInc = DMA_SINC_FIXED;
-        hdma_usart3_rx.Init.DestInc = DMA_DINC_INCREMENTED;
-        hdma_usart3_rx.Init.SrcDataWidth = DMA_SRC_DATAWIDTH_BYTE;
-        hdma_usart3_rx.Init.DestDataWidth = DMA_DEST_DATAWIDTH_BYTE;
-        hdma_usart3_rx.Init.Priority = DMA_LOW_PRIORITY_LOW_WEIGHT;
-        hdma_usart3_rx.Init.SrcBurstLength = 1;
-        hdma_usart3_rx.Init.DestBurstLength = 1;
-        hdma_usart3_rx.Init.TransferAllocatedPort =
+        g_hdma_usart3_rx.Instance = GPDMA1_Channel5;
+        g_hdma_usart3_rx.Init.Request = GPDMA1_REQUEST_USART3_RX;
+        g_hdma_usart3_rx.Init.BlkHWRequest = DMA_BREQ_SINGLE_BURST;
+        g_hdma_usart3_rx.Init.Direction = DMA_PERIPH_TO_MEMORY;
+        g_hdma_usart3_rx.Init.SrcInc = DMA_SINC_FIXED;
+        g_hdma_usart3_rx.Init.DestInc = DMA_DINC_INCREMENTED;
+        g_hdma_usart3_rx.Init.SrcDataWidth = DMA_SRC_DATAWIDTH_BYTE;
+        g_hdma_usart3_rx.Init.DestDataWidth = DMA_DEST_DATAWIDTH_BYTE;
+        g_hdma_usart3_rx.Init.Priority = DMA_LOW_PRIORITY_LOW_WEIGHT;
+        g_hdma_usart3_rx.Init.SrcBurstLength = 1;
+        g_hdma_usart3_rx.Init.DestBurstLength = 1;
+        g_hdma_usart3_rx.Init.TransferAllocatedPort =
             (DMA_SRC_ALLOCATED_PORT0 | DMA_DEST_ALLOCATED_PORT0);
-        hdma_usart3_rx.Init.TransferEventMode = DMA_TCEM_BLOCK_TRANSFER;
-        hdma_usart3_rx.Init.Mode = DMA_NORMAL;
-        HAL_DMA_Init(&hdma_usart3_rx);
-        __HAL_LINKDMA(huart, hdmarx, hdma_usart3_rx);
+        g_hdma_usart3_rx.Init.TransferEventMode = DMA_TCEM_BLOCK_TRANSFER;
+        g_hdma_usart3_rx.Init.Mode = DMA_NORMAL;
+        HAL_DMA_Init(&g_hdma_usart3_rx);
+        __HAL_LINKDMA(huart, hdmarx, g_hdma_usart3_rx);
 
         /* UART interrupt init */
         HAL_NVIC_SetPriority(USART3_IRQn, UART_IRQ_PRIO, 0);
@@ -299,11 +299,11 @@ void HAL_UART_MspInit(UART_HandleTypeDef *huart)
  */
 void UART_LL_init(UART_Bus bus, uint8_t *rx_buf, uint32_t sz)
 {
-    if (bus >= UART_BUS_COUNT || uart_instances[bus].initialized) {
+    if (bus >= UART_BUS_COUNT || g_uart_instances[bus].initialized) {
         return;
     }
 
-    UARTInstance *instance = &uart_instances[bus];
+    UARTInstance *instance = &g_uart_instances[bus];
 
     /* Configure UART instance based on bus */
     if (bus == UART_BUS_0) {
@@ -351,11 +351,11 @@ void UART_LL_init(UART_Bus bus, uint8_t *rx_buf, uint32_t sz)
  */
 void UART_LL_deinit(UART_Bus bus)
 {
-    if (bus >= UART_BUS_COUNT || !uart_instances[bus].initialized) {
+    if (bus >= UART_BUS_COUNT || !g_uart_instances[bus].initialized) {
         return;
     }
 
-    UARTInstance *instance = &uart_instances[bus];
+    UARTInstance *instance = &g_uart_instances[bus];
 
     /* Disable interrupts */
     if (bus == UART_BUS_0) {
@@ -389,11 +389,11 @@ void UART_LL_deinit(UART_Bus bus)
  */
 void UART_LL_start_dma_tx(UART_Bus bus, uint8_t *buffer, uint32_t size)
 {
-    if (bus >= UART_BUS_COUNT || !uart_instances[bus].initialized) {
+    if (bus >= UART_BUS_COUNT || !g_uart_instances[bus].initialized) {
         return;
     }
 
-    UARTInstance *instance = &uart_instances[bus];
+    UARTInstance *instance = &g_uart_instances[bus];
     instance->tx_in_progress = true;
     instance->tx_dma_size = size;
     HAL_UART_Transmit_DMA(instance->huart, buffer, size);
@@ -407,11 +407,11 @@ void UART_LL_start_dma_tx(UART_Bus bus, uint8_t *buffer, uint32_t size)
  */
 uint32_t UART_LL_get_dma_position(UART_Bus bus)
 {
-    if (bus >= UART_BUS_COUNT || !uart_instances[bus].initialized) {
+    if (bus >= UART_BUS_COUNT || !g_uart_instances[bus].initialized) {
         return 0;
     }
 
-    UARTInstance *instance = &uart_instances[bus];
+    UARTInstance *instance = &g_uart_instances[bus];
     return instance->rx_buffer_size - __HAL_DMA_GET_COUNTER(instance->hdma_rx);
 }
 
@@ -423,11 +423,11 @@ uint32_t UART_LL_get_dma_position(UART_Bus bus)
  */
 bool UART_LL_tx_busy(UART_Bus bus)
 {
-    if (bus >= UART_BUS_COUNT || !uart_instances[bus].initialized) {
+    if (bus >= UART_BUS_COUNT || !g_uart_instances[bus].initialized) {
         return false;
     }
 
-    return uart_instances[bus].tx_in_progress;
+    return g_uart_instances[bus].tx_in_progress;
 }
 
 /**
@@ -443,7 +443,7 @@ void UART_LL_set_tx_complete_callback(
     if (bus >= UART_BUS_COUNT) {
         return;
     }
-    uart_instances[bus].tx_complete_callback = callback;
+    g_uart_instances[bus].tx_complete_callback = callback;
 }
 
 /**
@@ -459,7 +459,7 @@ void UART_LL_set_rx_complete_callback(
     if (bus >= UART_BUS_COUNT) {
         return;
     }
-    uart_instances[bus].rx_complete_callback = callback;
+    g_uart_instances[bus].rx_complete_callback = callback;
 }
 
 /**
@@ -472,7 +472,7 @@ void UART_LL_set_idle_callback(UART_Bus bus, UART_LL_IdleCallback callback)
     if (bus >= UART_BUS_COUNT) {
         return;
     }
-    uart_instances[bus].idle_callback = callback;
+    g_uart_instances[bus].idle_callback = callback;
 }
 
 /**
@@ -487,7 +487,7 @@ void HAL_UART_TxCpltCallback(UART_HandleTypeDef *huart)
         return;
     }
 
-    UARTInstance *instance = &uart_instances[bus];
+    UARTInstance *instance = &g_uart_instances[bus];
     instance->tx_in_progress = false;
 
     /* Notify the hardware-independent layer */
@@ -508,7 +508,7 @@ void HAL_UART_RxCpltCallback(UART_HandleTypeDef *huart)
         return;
     }
 
-    UARTInstance *instance = &uart_instances[bus];
+    UARTInstance *instance = &g_uart_instances[bus];
 
     /* Restart DMA reception */
     HAL_UART_Receive_DMA(
@@ -532,7 +532,7 @@ static void uart_irq_handler(UART_HandleTypeDef *huart)
         return;
     }
 
-    UARTInstance *instance = &uart_instances[bus];
+    UARTInstance *instance = &g_uart_instances[bus];
 
     /* Check for idle line detection */
     if (__HAL_UART_GET_FLAG(huart, UART_FLAG_IDLE) != RESET) {
@@ -554,44 +554,44 @@ static void uart_irq_handler(UART_HandleTypeDef *huart)
 /**
  * @brief USART1 interrupt handler
  */
-void USART1_IRQHandler(void) { uart_irq_handler(&huart1); }
+void USART1_IRQHandler(void) { uart_irq_handler(&g_huart1); }
 
 /**
  * @brief USART2 interrupt handler
  */
-void USART2_IRQHandler(void) { uart_irq_handler(&huart2); }
+void USART2_IRQHandler(void) { uart_irq_handler(&g_huart2); }
 
 /**
  * @brief USART3 interrupt handler
  */
-void USART3_IRQHandler(void) { uart_irq_handler(&huart3); }
+void USART3_IRQHandler(void) { uart_irq_handler(&g_huart3); }
 
 /**
  * @brief GPDMA1 Channel0 interrupt handler (USART1 TX)
  */
-void GPDMA1_Channel0_IRQHandler(void) { HAL_DMA_IRQHandler(&hdma_usart1_tx); }
+void GPDMA1_Channel0_IRQHandler(void) { HAL_DMA_IRQHandler(&g_hdma_usart1_tx); }
 
 /**
  * @brief GPDMA1 Channel1 interrupt handler (USART1 RX)
  */
-void GPDMA1_Channel1_IRQHandler(void) { HAL_DMA_IRQHandler(&hdma_usart1_rx); }
+void GPDMA1_Channel1_IRQHandler(void) { HAL_DMA_IRQHandler(&g_hdma_usart1_rx); }
 
 /**
  * @brief GPDMA1 Channel2 interrupt handler (USART2 TX)
  */
-void GPDMA1_Channel2_IRQHandler(void) { HAL_DMA_IRQHandler(&hdma_usart2_tx); }
+void GPDMA1_Channel2_IRQHandler(void) { HAL_DMA_IRQHandler(&g_hdma_usart2_tx); }
 
 /**
  * @brief GPDMA1 Channel3 interrupt handler (USART2 RX)
  */
-void GPDMA1_Channel3_IRQHandler(void) { HAL_DMA_IRQHandler(&hdma_usart2_rx); }
+void GPDMA1_Channel3_IRQHandler(void) { HAL_DMA_IRQHandler(&g_hdma_usart2_rx); }
 
 /**
  * @brief GPDMA1 Channel4 interrupt handler (USART3 TX)
  */
-void GPDMA1_Channel4_IRQHandler(void) { HAL_DMA_IRQHandler(&hdma_usart3_tx); }
+void GPDMA1_Channel4_IRQHandler(void) { HAL_DMA_IRQHandler(&g_hdma_usart3_tx); }
 
 /**
  * @brief GPDMA1 Channel5 interrupt handler (USART3 RX)
  */
-void GPDMA1_Channel5_IRQHandler(void) { HAL_DMA_IRQHandler(&hdma_usart3_rx); }
+void GPDMA1_Channel5_IRQHandler(void) { HAL_DMA_IRQHandler(&g_hdma_usart3_rx); }

--- a/src/platform/h563xx/usb_descriptors.c
+++ b/src/platform/h563xx/usb_descriptors.c
@@ -59,7 +59,7 @@ uint8_t const g_DESC_CONFIGURATION[] = {
 };
 
 // String descriptors
-char const *string_desc_arr[] = { LANG, MANU, PROD, SERI };
+char const *g_string_desc_arr[] = { LANG, MANU, PROD, SERI };
 
 uint8_t const *tud_descriptor_device_cb(void)
 {
@@ -93,10 +93,10 @@ uint16_t const *tud_descriptor_string_cb(uint8_t index, uint16_t langid)
         break;
     case IDX_LANG:
         len = 1;
-        memcpy(_desc_str + 1, string_desc_arr[index], 2 * len);
+        memcpy(_desc_str + 1, g_string_desc_arr[index], 2 * len);
         break;
     default:
-        char const *str = string_desc_arr[index];
+        char const *str = g_string_desc_arr[index];
         len = strlen(str);
         // Convert ASCII string into UTF-16
         for (size_t i = 0; i < len; ++i) {

--- a/src/platform/h563xx/usb_ll.c
+++ b/src/platform/h563xx/usb_ll.c
@@ -37,7 +37,7 @@ typedef struct {
 } USBInstance;
 
 /* Instance array for future multi-controller support */
-static USBInstance usb_instances[USB_BUS_COUNT] = { 0 };
+static USBInstance g_usb_instances[USB_BUS_COUNT] = { 0 };
 
 /**
  * @brief Enable USB clock recovery system
@@ -66,7 +66,7 @@ static void crs_enable(void)
 
 void USB_LL_init(USB_Bus bus)
 {
-    if (bus >= USB_BUS_COUNT || usb_instances[bus].initialized) {
+    if (bus >= USB_BUS_COUNT || g_usb_instances[bus].initialized) {
         return;
     }
 
@@ -110,7 +110,7 @@ void USB_LL_init(USB_Bus bus)
         crs_enable();
     }
 
-    usb_instances[bus].initialized = true;
+    g_usb_instances[bus].initialized = true;
 }
 
 /**
@@ -120,7 +120,7 @@ void USB_LL_init(USB_Bus bus)
  */
 void USB_LL_deinit(USB_Bus bus)
 {
-    if (bus >= USB_BUS_COUNT || !usb_instances[bus].initialized) {
+    if (bus >= USB_BUS_COUNT || !g_usb_instances[bus].initialized) {
         return;
     }
 
@@ -136,7 +136,7 @@ void USB_LL_deinit(USB_Bus bus)
     // Disable USB power
     HAL_PWREx_DisableVddUSB();
 
-    usb_instances[bus].initialized = false;
+    g_usb_instances[bus].initialized = false;
 }
 
 static size_t get_unique_id(uint8_t id[])
@@ -235,7 +235,7 @@ void USB_LL_set_line_state_callback(
 )
 {
     if (interface_id < USB_BUS_COUNT) {
-        usb_instances[interface_id].line_state_callback = callback;
+        g_usb_instances[interface_id].line_state_callback = callback;
     }
 }
 
@@ -252,7 +252,7 @@ void USB_LL_set_line_state_callback(
 void tud_cdc_line_state_cb(uint8_t itf, bool dtr, bool rts)
 {
     if (itf < USB_BUS_COUNT) {
-        USBInstance instance = usb_instances[itf];
+        USBInstance instance = g_usb_instances[itf];
 
         if (!instance.initialized) {
             return;

--- a/src/system/CMakeLists.target.txt
+++ b/src/system/CMakeLists.target.txt
@@ -8,6 +8,7 @@ target_sources(pslab-mini-firmware
         led.c
         system.c
         stubs.c
+        syscalls.c
 )
 
 target_include_directories(pslab-mini-firmware

--- a/src/system/README.md
+++ b/src/system/README.md
@@ -5,14 +5,14 @@ This directory contains system-level components and utilities for the PSLab Mini
 ## Files
 
 - `stubs.c` - System call stubs for newlib (basic stubs for _close_r, _lseek_r)
-- `syscalls.c` - UART-based system call implementations for stdio functionality
+- `syscalls.c` - UART-based system call implementations for write-only stdio functionality
 - `syscalls_config.h.example` - Example configuration for UART I/O
 - `system.c` - Main system initialization and management
 - `led.c` - LED control utilities
 
 ## UART-based stdio Configuration
 
-The `syscalls.c` file provides implementations of `_read_r` and `_write_r` that enable `printf()`, `scanf()`, and other stdio functions to work over UART.
+The `syscalls.c` file provides write-only implementations of system calls that enable `printf()` and other output stdio functions to work over UART. Input functions like `scanf()` are not supported and will return errors.
 
 ### Configuration
 
@@ -20,16 +20,18 @@ To enable UART-based stdio:
 
 1. Copy `syscalls_config.h.example` to `syscalls_config.h`
 2. Modify the configuration as needed:
+
    ```c
    #define SYSCALLS_UART_BUS 0  // Use UART bus 0
-   #define SYSCALLS_UART_RX_BUFFER_SIZE 512  // Optional: custom buffer size
    #define SYSCALLS_UART_TX_BUFFER_SIZE 512  // Optional: custom buffer size
    ```
+
 3. Include the config header in your main application or build configuration
 
 ### Disabling UART stdio
 
 To disable UART stdio (syscalls become no-ops):
+
 ```c
 #define SYSCALLS_UART_BUS -1
 // or simply don't define SYSCALLS_UART_BUS
@@ -37,19 +39,18 @@ To disable UART stdio (syscalls become no-ops):
 
 ### Usage Example
 
-Once configured, standard stdio functions work automatically:
+Once configured, standard output functions work automatically:
 
 ```c
 #include <stdio.h>
 
 int main(void) {
     printf("Hello, PSLab Mini!\n");
-    
-    int value;
-    printf("Enter a number: ");
-    scanf("%d", &value);
-    printf("You entered: %d\n", value);
-    
+    printf("System initialized successfully\n");
+
+    int value = 42;
+    printf("Current value: %d\n", value);
+
     return 0;
 }
 ```
@@ -57,6 +58,8 @@ int main(void) {
 ### Notes
 
 - UART initialization is automatic on first stdio use
-- All operations are non-blocking
-- Input/output is buffered using circular buffers
+- Only output operations are supported (printf, fprintf, etc.)
+- Input operations (scanf, fgets, etc.) will return errors
+- Output is buffered using circular buffers
 - UART configuration (baud rate, etc.) is handled by the platform layer
+- Designed for logging and debugging output

--- a/src/system/README.md
+++ b/src/system/README.md
@@ -1,0 +1,62 @@
+# System Layer
+
+This directory contains system-level components and utilities for the PSLab Mini firmware.
+
+## Files
+
+- `stubs.c` - System call stubs for newlib (basic stubs for _close_r, _lseek_r)
+- `syscalls.c` - UART-based system call implementations for stdio functionality
+- `syscalls_config.h.example` - Example configuration for UART I/O
+- `system.c` - Main system initialization and management
+- `led.c` - LED control utilities
+
+## UART-based stdio Configuration
+
+The `syscalls.c` file provides implementations of `_read_r` and `_write_r` that enable `printf()`, `scanf()`, and other stdio functions to work over UART.
+
+### Configuration
+
+To enable UART-based stdio:
+
+1. Copy `syscalls_config.h.example` to `syscalls_config.h`
+2. Modify the configuration as needed:
+   ```c
+   #define SYSCALLS_UART_BUS 0  // Use UART bus 0
+   #define SYSCALLS_UART_RX_BUFFER_SIZE 512  // Optional: custom buffer size
+   #define SYSCALLS_UART_TX_BUFFER_SIZE 512  // Optional: custom buffer size
+   ```
+3. Include the config header in your main application or build configuration
+
+### Disabling UART stdio
+
+To disable UART stdio (syscalls become no-ops):
+```c
+#define SYSCALLS_UART_BUS -1
+// or simply don't define SYSCALLS_UART_BUS
+```
+
+### Usage Example
+
+Once configured, standard stdio functions work automatically:
+
+```c
+#include <stdio.h>
+
+int main(void) {
+    printf("Hello, PSLab Mini!\n");
+    
+    int value;
+    printf("Enter a number: ");
+    scanf("%d", &value);
+    printf("You entered: %d\n", value);
+    
+    return 0;
+}
+```
+
+### Notes
+
+- UART initialization is automatic on first stdio use
+- All operations are non-blocking
+- Input/output is buffered using circular buffers
+- UART configuration (baud rate, etc.) is handled by the platform layer

--- a/src/system/bus/CMakeLists.tests.txt
+++ b/src/system/bus/CMakeLists.tests.txt
@@ -10,4 +10,5 @@ target_include_directories(pslab-bus
     PUBLIC
         ${CMAKE_CURRENT_SOURCE_DIR}
         ${CMAKE_SOURCE_DIR}/src/platform  # For platform interface headers
+        ${CMAKE_SOURCE_DIR}/src/system
 )

--- a/src/system/bus/uart.c
+++ b/src/system/bus/uart.c
@@ -28,8 +28,12 @@
 #include <string.h>
 
 #include "bus.h"
+#include "syscalls_config.h"
 #include "uart.h"
 #include "uart_ll.h"
+
+/* syscalls module sets this when claiming its bus */
+extern bool SYSCALLS_uart_claim;
 
 /**
  * @brief UART bus handle structure
@@ -239,6 +243,14 @@ UART_Handle *UART_init(
     if (!rx_buffer || !tx_buffer || bus >= UART_BUS_COUNT) {
         return nullptr;
     }
+
+    /* Check if syscalls is claiming the UART */
+    #if defined (SYSCALLS_UART_BUS) && SYSCALLS_UART_BUS >= 0
+    if (bus == SYSCALLS_UART_BUS && !SYSCALLS_uart_claim) {
+        /* Only syscalls can claim this bus */
+        return nullptr;
+    }
+    #endif
 
     UART_Bus bus_id = (UART_Bus)bus;
 

--- a/src/system/bus/usb.c
+++ b/src/system/bus/usb.c
@@ -48,7 +48,7 @@ struct USB_Handle {
 };
 
 /* Global array to keep track of active USB handles */
-static USB_Handle *active_handles[USB_INTERFACE_COUNT] = { nullptr };
+static USB_Handle *g_active_handles[USB_INTERFACE_COUNT] = { nullptr };
 
 /**
  * @brief Get the number of available USB interfaces.
@@ -68,7 +68,7 @@ static USB_Handle *get_handle_from_interface(uint8_t interface_id)
     if (interface_id >= USB_INTERFACE_COUNT) {
         return nullptr;
     }
-    return active_handles[interface_id];
+    return g_active_handles[interface_id];
 }
 
 /**
@@ -173,7 +173,7 @@ USB_Handle *USB_init(size_t interface, BUS_CircBuffer *rx_buffer)
     uint8_t interface_id = (uint8_t)interface;
 
     /* Check if interface is already initialized */
-    if (active_handles[interface_id] != nullptr) {
+    if (g_active_handles[interface_id] != nullptr) {
         return nullptr;
     }
 
@@ -192,7 +192,7 @@ USB_Handle *USB_init(size_t interface, BUS_CircBuffer *rx_buffer)
     handle->initialized = true;
 
     /* Store handle in global array */
-    active_handles[interface_id] = handle;
+    g_active_handles[interface_id] = handle;
 
     USB_LL_init((USB_Bus)interface_id);
     USB_LL_set_line_state_callback((USB_Bus)interface_id, line_state_callback);
@@ -218,7 +218,7 @@ void USB_deinit(USB_Handle *handle)
 
     /* Clear from global array */
     if (handle->interface_id < USB_INTERFACE_COUNT) {
-        active_handles[handle->interface_id] = nullptr;
+        g_active_handles[handle->interface_id] = nullptr;
     }
 
     /* Mark as uninitialized */

--- a/src/system/stubs.c
+++ b/src/system/stubs.c
@@ -6,22 +6,10 @@
  * requires. These stubs are minimal implementations that return error codes,
  * allowing the program to compile and link successfully.
  *
- * To enable stdio.h functionality (printf, scanf, etc.), proper implementations
- * of these system calls can be added:
- * - _write_r: Implement to redirect output to UART, USB, or other interface
- * - _read_r: Implement to read input from UART, USB, or other interface
- * - _close_r, _lseek_r: Can remain as stubs for basic stdio functionality
- *
- * Example implementation for UART output:
- * _ssize_t _write_r(struct _reent *r, int fd, const void *buf, size_t cnt) {
- *     if (fd == STDOUT_FILENO || fd == STDERR_FILENO) {
- *         // Send data via UART
- *         cnt = UART_write((uint8_t *)buf, cnt);
- *         return cnt;
- *     }
- *     errno = EBADF;
- *     return -1;
- * }
+ * Note: _read_r and _write_r are implemented in syscalls.c to provide
+ * actual UART-based I/O functionality for stdio.h (printf, scanf, etc.).
+ * The remaining stubs (_close_r, _lseek_r) can remain as stubs for basic
+ * stdio functionality.
  */
 
 #include <errno.h>
@@ -44,24 +32,4 @@ _off_t _lseek_r(struct _reent *r, int fd, _off_t offset, int whence)
     (void)whence;
     errno = ENOSYS;
     return (_off_t)-1;
-}
-
-_ssize_t _read_r(struct _reent *r, int fd, void *buf, size_t cnt)
-{
-    (void)r;
-    (void)fd;
-    (void)buf;
-    (void)cnt;
-    errno = ENOSYS;
-    return -1;
-}
-
-_ssize_t _write_r(struct _reent *r, int fd, void const *buf, size_t cnt)
-{
-    (void)r;
-    (void)fd;
-    (void)buf;
-    (void)cnt;
-    errno = ENOSYS;
-    return -1;
 }

--- a/src/system/syscalls.c
+++ b/src/system/syscalls.c
@@ -60,10 +60,10 @@ static uint8_t rx_data[SYSCALLS_UART_RX_BUFFER_SIZE];
 static uint8_t tx_data[SYSCALLS_UART_TX_BUFFER_SIZE];
 static bool uart_initialized = false;
 
-static int check_args(void const *buf, size_t cnt)
+static int check_args(struct _reent *r, void const *buf, size_t cnt)
 {
     if (buf == nullptr) {
-        errno = EFAULT;
+        r->_errno = EFAULT;
         return -1;
     }
 
@@ -113,10 +113,8 @@ void syscalls_uart_deinit(void)
  */
 _ssize_t _read_r(struct _reent *r, int fd, void *buf, size_t cnt)
 {
-    (void)r;
-
     // Check for invalid parameters
-    int ret = check_args(buf, cnt);
+    int ret = check_args(r, buf, cnt);
     if (ret < 1) {
         return ret;
     }
@@ -128,7 +126,7 @@ _ssize_t _read_r(struct _reent *r, int fd, void *buf, size_t cnt)
         }
 
         if (uart_handle == nullptr) {
-            errno = EIO;
+            r->_errno = EIO;
             return -1;
         }
 
@@ -140,7 +138,7 @@ _ssize_t _read_r(struct _reent *r, int fd, void *buf, size_t cnt)
     (void)fd;
 #endif
 
-    errno = EBADF;
+    r->_errno = EBADF;
     return -1;
 }
 
@@ -152,10 +150,8 @@ _ssize_t _read_r(struct _reent *r, int fd, void *buf, size_t cnt)
  */
 _ssize_t _write_r(struct _reent *r, int fd, void const *buf, size_t cnt)
 {
-    (void)r;
-
     // Check for invalid parameters
-    int ret = check_args(buf, cnt);
+    int ret = check_args(r, buf, cnt);
     if (ret < 1) {
         return ret;
     }
@@ -167,7 +163,7 @@ _ssize_t _write_r(struct _reent *r, int fd, void const *buf, size_t cnt)
         }
 
         if (uart_handle == nullptr) {
-            errno = EIO;
+            r->_errno = EIO;
             return -1;
         }
 
@@ -177,7 +173,7 @@ _ssize_t _write_r(struct _reent *r, int fd, void const *buf, size_t cnt)
 
         // If no bytes were written, it likely means the buffer is full
         if (bytes_written == 0 && cnt > 0) {
-            errno = EAGAIN;
+            r->_errno = EAGAIN;
             return -1;
         }
 
@@ -187,7 +183,7 @@ _ssize_t _write_r(struct _reent *r, int fd, void const *buf, size_t cnt)
     (void)fd;
 #endif
 
-    errno = EBADF;
+    r->_errno = EBADF;
     return -1;
 }
 
@@ -199,10 +195,8 @@ _ssize_t _write_r(struct _reent *r, int fd, void const *buf, size_t cnt)
  */
 int _fstat_r(struct _reent *r, int fd, struct stat *st)
 {
-    (void)r;
-
     if (st == nullptr) {
-        errno = EFAULT;
+        r->_errno = EFAULT;
         return -1;
     }
 
@@ -217,7 +211,7 @@ int _fstat_r(struct _reent *r, int fd, struct stat *st)
     }
 
     // For other file descriptors, return error
-    errno = EBADF;
+    r->_errno = EBADF;
     return -1;
 }
 
@@ -229,14 +223,12 @@ int _fstat_r(struct _reent *r, int fd, struct stat *st)
  */
 int _isatty_r(struct _reent *r, int fd)
 {
-    (void)r;
-
     // stdin, stdout, stderr are treated as terminals
     if (fd == STDIN_FILENO || fd == STDOUT_FILENO || fd == STDERR_FILENO) {
         return 1;
     }
 
     // Other file descriptors are not terminals
-    errno = ENOTTY;
+    r->_errno = ENOTTY;
     return 0;
 }

--- a/src/system/syscalls.c
+++ b/src/system/syscalls.c
@@ -118,13 +118,23 @@ void syscalls_uart_deinit(void)
  * @brief Read data from file descriptor (stub - reads not supported)
  *
  * Since UART is used only for write-only logging/debugging,
- * reading is not implemented.
+ * reading is not implemented. However, 0-length reads always succeed
+ * per POSIX semantics.
  */
 _ssize_t _read_r(struct _reent *r, int fd, void *buf, size_t cnt)
 {
     (void)fd;
-    (void)buf;
-    (void)cnt;
+
+    // POSIX: reading 0 bytes should always succeed
+    if (cnt == 0) {
+        return 0;
+    }
+
+    // Check for null buffer
+    if (buf == nullptr) {
+        r->_errno = EFAULT;
+        return -1;
+    }
 
     r->_errno = ENOSYS; // Function not implemented
     return -1;

--- a/src/system/syscalls.c
+++ b/src/system/syscalls.c
@@ -1,0 +1,242 @@
+/**
+ * @file syscalls.c
+ * @brief System call implementations for newlib using UART
+ *
+ * This file provides implementations for system calls that newlib requires
+ * for stdio functionality, using the UART API for I/O operations.
+ *
+ * Implemented syscalls:
+ * - _read_r: Read from stdin via UART
+ * - _write_r: Write to stdout/stderr via UART
+ * - _fstat_r: File status (stub - identifies stdin/stdout/stderr as character
+ *   devices)
+ * - _isatty_r: Terminal check (stub - treats stdin/stdout/stderr as terminals)
+ *
+ * The UART bus used for I/O can be configured via the SYSCALLS_UART_BUS
+ * preprocessor macro:
+ * - Define SYSCALLS_UART_BUS to specify the UART bus number (0, 1, 2, etc.)
+ * - Define SYSCALLS_UART_BUS as -1 or leave undefined to disable UART I/O
+ *   (functions will be no-ops returning error codes)
+ *
+ * Buffer sizes for RX/TX can be configured via:
+ * - SYSCALLS_UART_RX_BUFFER_SIZE (default: 256)
+ * - SYSCALLS_UART_TX_BUFFER_SIZE (default: 256)
+ *
+ * Example configuration:
+ * #define SYSCALLS_UART_BUS 0
+ * #define SYSCALLS_UART_RX_BUFFER_SIZE 512
+ * #define SYSCALLS_UART_TX_BUFFER_SIZE 512
+ */
+
+#include <errno.h>
+#include <reent.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "syscalls_config.h"
+
+// Only include UART headers if UART I/O is enabled
+#ifndef SYSCALLS_UART_BUS
+#define SYSCALLS_UART_BUS -1 /* Disabled by default */
+#endif
+
+#if SYSCALLS_UART_BUS >= 0
+#include "bus/bus.h"
+#include "bus/uart.h"
+
+#ifndef SYSCALLS_UART_RX_BUFFER_SIZE
+#define SYSCALLS_UART_RX_BUFFER_SIZE 256
+#endif
+
+#ifndef SYSCALLS_UART_TX_BUFFER_SIZE
+#define SYSCALLS_UART_TX_BUFFER_SIZE 256
+#endif
+
+// Static buffers and handle for UART I/O
+static UART_Handle *uart_handle = nullptr;
+static BUS_CircBuffer rx_buffer, tx_buffer;
+static uint8_t rx_data[SYSCALLS_UART_RX_BUFFER_SIZE];
+static uint8_t tx_data[SYSCALLS_UART_TX_BUFFER_SIZE];
+static bool uart_initialized = false;
+
+static int check_args(void const *buf, size_t cnt)
+{
+    if (buf == nullptr) {
+        errno = EFAULT;
+        return -1;
+    }
+
+    // POSIX: reading 0 bytes should return 0 immediately
+    if (cnt == 0) {
+        return 0;
+    }
+
+    return 1;
+}
+
+/**
+ * @brief Initialize UART for syscalls (called automatically on first use)
+ */
+static void syscalls_uart_init(void)
+{
+    if (uart_initialized) {
+        return;
+    }
+
+    circular_buffer_init(&rx_buffer, rx_data, SYSCALLS_UART_RX_BUFFER_SIZE);
+    circular_buffer_init(&tx_buffer, tx_data, SYSCALLS_UART_TX_BUFFER_SIZE);
+
+    uart_handle = UART_init(SYSCALLS_UART_BUS, &rx_buffer, &tx_buffer);
+    uart_initialized = true;
+}
+
+/**
+ * @brief Deinitialize UART for syscalls
+ */
+void syscalls_uart_deinit(void)
+{
+    if (uart_handle != nullptr) {
+        UART_deinit(uart_handle);
+        uart_handle = nullptr;
+    }
+    uart_initialized = false;
+}
+
+#endif /* SYSCALLS_UART_BUS >= 0 */
+
+/**
+ * @brief Read data from file descriptor
+ *
+ * For stdin (fd 0), reads from UART if enabled, otherwise returns error.
+ * For other file descriptors, returns error.
+ */
+_ssize_t _read_r(struct _reent *r, int fd, void *buf, size_t cnt)
+{
+    (void)r;
+
+    // Check for invalid parameters
+    int ret = check_args(buf, cnt);
+    if (ret < 1) {
+        return ret;
+    }
+
+#if SYSCALLS_UART_BUS >= 0
+    if (fd == STDIN_FILENO) {
+        if (!uart_initialized) {
+            syscalls_uart_init();
+        }
+
+        if (uart_handle == nullptr) {
+            errno = EIO;
+            return -1;
+        }
+
+        // Non-blocking read from UART
+        uint32_t bytes_read = UART_read(uart_handle, (uint8_t *)buf, cnt);
+        return (_ssize_t)bytes_read;
+    }
+#else
+    (void)fd;
+#endif
+
+    errno = EBADF;
+    return -1;
+}
+
+/**
+ * @brief Write data to file descriptor
+ *
+ * For stdout/stderr (fd 1/2), writes to UART if enabled, otherwise returns
+ * error. For other file descriptors, returns error.
+ */
+_ssize_t _write_r(struct _reent *r, int fd, void const *buf, size_t cnt)
+{
+    (void)r;
+
+    // Check for invalid parameters
+    int ret = check_args(buf, cnt);
+    if (ret < 1) {
+        return ret;
+    }
+
+#if SYSCALLS_UART_BUS >= 0
+    if (fd == STDOUT_FILENO || fd == STDERR_FILENO) {
+        if (!uart_initialized) {
+            syscalls_uart_init();
+        }
+
+        if (uart_handle == nullptr) {
+            errno = EIO;
+            return -1;
+        }
+
+        // Write to UART
+        uint32_t bytes_written =
+            UART_write(uart_handle, (uint8_t const *)buf, cnt);
+
+        // If no bytes were written, it likely means the buffer is full
+        if (bytes_written == 0 && cnt > 0) {
+            errno = EAGAIN;
+            return -1;
+        }
+
+        return (_ssize_t)bytes_written;
+    }
+#else
+    (void)fd;
+#endif
+
+    errno = EBADF;
+    return -1;
+}
+
+/**
+ * @brief Get file status (stub implementation)
+ *
+ * This is a stub implementation that identifies stdin/stdout/stderr as
+ * character devices and returns an error for other file descriptors.
+ */
+int _fstat_r(struct _reent *r, int fd, struct stat *st)
+{
+    (void)r;
+
+    if (st == nullptr) {
+        errno = EFAULT;
+        return -1;
+    }
+
+    // Clear the stat structure
+    memset(st, 0, sizeof(struct stat));
+
+    // For stdin, stdout, stderr - treat as character device
+    if (fd == STDIN_FILENO || fd == STDOUT_FILENO || fd == STDERR_FILENO) {
+        st->st_mode = S_IFCHR; // Character device
+        st->st_size = 0;
+        return 0;
+    }
+
+    // For other file descriptors, return error
+    errno = EBADF;
+    return -1;
+}
+
+/**
+ * @brief Check if file descriptor is a terminal (stub implementation)
+ *
+ * This stub implementation returns 1 (true) for stdin/stdout/stderr
+ * and 0 (false) for other file descriptors.
+ */
+int _isatty_r(struct _reent *r, int fd)
+{
+    (void)r;
+
+    // stdin, stdout, stderr are treated as terminals
+    if (fd == STDIN_FILENO || fd == STDOUT_FILENO || fd == STDERR_FILENO) {
+        return 1;
+    }
+
+    // Other file descriptors are not terminals
+    errno = ENOTTY;
+    return 0;
+}

--- a/src/system/syscalls.c
+++ b/src/system/syscalls.c
@@ -60,6 +60,9 @@ static uint8_t rx_data[SYSCALLS_UART_RX_BUFFER_SIZE];
 static uint8_t tx_data[SYSCALLS_UART_TX_BUFFER_SIZE];
 static bool uart_initialized = false;
 
+// Set to tell UART driver that syscalls is claiming the UART bus
+bool SYSCALLS_uart_claim = false;
+
 static int check_args(struct _reent *r, void const *buf, size_t cnt)
 {
     if (buf == nullptr) {
@@ -87,7 +90,9 @@ static void syscalls_uart_init(void)
     circular_buffer_init(&rx_buffer, rx_data, SYSCALLS_UART_RX_BUFFER_SIZE);
     circular_buffer_init(&tx_buffer, tx_data, SYSCALLS_UART_TX_BUFFER_SIZE);
 
+    SYSCALLS_uart_claim = true; // Claim UART for syscalls
     uart_handle = UART_init(SYSCALLS_UART_BUS, &rx_buffer, &tx_buffer);
+    SYSCALLS_uart_claim = false; // Prevent further claims
     uart_initialized = true;
 }
 

--- a/src/system/syscalls.c
+++ b/src/system/syscalls.c
@@ -4,6 +4,7 @@
  *
  * This file provides implementations for system calls that newlib requires
  * for stdio functionality, using the UART API for write-only I/O operations.
+ * Writes are non-blocking.
  *
  * Implemented syscalls:
  * - _read_r: Stub that returns ENOSYS (reads not supported)

--- a/src/system/syscalls_config.h
+++ b/src/system/syscalls_config.h
@@ -1,0 +1,9 @@
+#ifndef SYSCALLS_CONFIG_H
+#define SYSCALLS_CONFIG_H
+
+#ifndef SYSCALLS_UART_BUS
+// USART3 is connected to the ST-Link USB on Nucleo-H563ZI
+#define SYSCALLS_UART_BUS 3
+#endif
+
+#endif // SYSCALLS_CONFIG_H

--- a/src/system/syscalls_config.h
+++ b/src/system/syscalls_config.h
@@ -3,7 +3,7 @@
 
 #ifndef SYSCALLS_UART_BUS
 // USART3 is connected to the ST-Link USB on Nucleo-H563ZI
-#define SYSCALLS_UART_BUS 3
+#define SYSCALLS_UART_BUS 2
 #endif
 
 #endif // SYSCALLS_CONFIG_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,27 +14,20 @@ cmock_generate_mock(mock_uart_ll ${CMAKE_CURRENT_SOURCE_DIR}/../src/platform/uar
 
 # Add UART test
 cmock_add_test(test_uart test_uart.c mock_uart_ll)
-target_sources(test_uart PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src/system/bus/uart.c)
-target_sources(test_uart PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src/system/bus/bus.c)
-target_include_directories(test_uart PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src/system/bus/)
-target_include_directories(test_uart PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src/platform/)
+target_link_libraries(test_uart pslab-bus)
 
 # Add syscalls test (reuses uart_ll mock and tests real syscalls.c)
 cmock_add_test(test_syscalls test_syscalls.c mock_uart_ll)
 # Include the actual syscalls.c implementation
 target_sources(test_syscalls PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src/system/syscalls.c)
-target_sources(test_syscalls PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src/system/bus/uart.c)
-target_sources(test_syscalls PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src/system/bus/bus.c)
 target_sources(test_syscalls PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/test_headers/reent-stub.c)
+target_link_libraries(test_syscalls pslab-bus)
 
 # Add test-specific include directory BEFORE system includes to override headers
 target_include_directories(test_syscalls PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/test_headers)
-target_include_directories(test_syscalls PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src/system/)
-target_include_directories(test_syscalls PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src/system/bus/)
-target_include_directories(test_syscalls PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src/platform/)
 
 # Define configuration for testing
-target_compile_definitions(test_syscalls PRIVATE 
+target_compile_definitions(test_syscalls PRIVATE
     SYSCALLS_UART_BUS=0
     SYSCALLS_UART_RX_BUFFER_SIZE=256
     SYSCALLS_UART_TX_BUFFER_SIZE=256

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,6 +29,5 @@ target_include_directories(test_syscalls PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/tes
 # Define configuration for testing
 target_compile_definitions(test_syscalls PRIVATE
     SYSCALLS_UART_BUS=0
-    SYSCALLS_UART_RX_BUFFER_SIZE=256
     SYSCALLS_UART_TX_BUFFER_SIZE=256
 )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,3 +18,24 @@ target_sources(test_uart PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src/system/bus/u
 target_sources(test_uart PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src/system/bus/bus.c)
 target_include_directories(test_uart PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src/system/bus/)
 target_include_directories(test_uart PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src/platform/)
+
+# Add syscalls test (reuses uart_ll mock and tests real syscalls.c)
+cmock_add_test(test_syscalls test_syscalls.c mock_uart_ll)
+# Include the actual syscalls.c implementation
+target_sources(test_syscalls PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src/system/syscalls.c)
+target_sources(test_syscalls PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src/system/bus/uart.c)
+target_sources(test_syscalls PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src/system/bus/bus.c)
+target_sources(test_syscalls PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/test_headers/reent-stub.c)
+
+# Add test-specific include directory BEFORE system includes to override headers
+target_include_directories(test_syscalls PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/test_headers)
+target_include_directories(test_syscalls PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src/system/)
+target_include_directories(test_syscalls PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src/system/bus/)
+target_include_directories(test_syscalls PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src/platform/)
+
+# Define configuration for testing
+target_compile_definitions(test_syscalls PRIVATE 
+    SYSCALLS_UART_BUS=0
+    SYSCALLS_UART_RX_BUFFER_SIZE=256
+    SYSCALLS_UART_TX_BUFFER_SIZE=256
+)

--- a/tests/test_headers/errno.h
+++ b/tests/test_headers/errno.h
@@ -1,0 +1,22 @@
+#ifndef TEST_ERRNO_H
+#define TEST_ERRNO_H
+
+/**
+ * @file errno.h
+ * @brief Test replacement for system errno.h
+ * 
+ * This file provides minimal error code definitions for testing.
+ */
+
+// Error codes
+#define EBADF   9    // Bad file descriptor
+#define EIO     5    // I/O error
+#define ENOSYS  38   // Function not implemented
+#define EAGAIN  11   // Resource temporarily unavailable
+#define EFAULT  14   // Bad address
+#define ENOTTY  25   // Not a terminal
+
+// Forward errno to our fake reent
+#define errno (__impure_ptr->_errno)
+
+#endif /* TEST_ERRNO_H */

--- a/tests/test_headers/reent-stub.c
+++ b/tests/test_headers/reent-stub.c
@@ -1,0 +1,8 @@
+/**
+ * @file reent-stub.c
+ * @brief Test implementation of reent and errno for testing
+ */
+
+#include "reent.h"
+_reent _reent_stub;
+_reent * __impure_ptr = &_reent_stub;

--- a/tests/test_headers/reent.h
+++ b/tests/test_headers/reent.h
@@ -1,0 +1,21 @@
+#ifndef TEST_REENT_H
+#define TEST_REENT_H
+
+/**
+ * @file reent.h
+ * @brief Test replacement for newlib's reent.h
+ * 
+ * This file provides minimal replacements for newlib's reent functionality
+ * to enable testing of syscalls without requiring the full newlib environment.
+ */
+
+typedef struct _reent {
+    int _errno;
+} _reent;
+
+extern _reent *__impure_ptr;
+
+typedef long _ssize_t;
+typedef long _off_t;
+
+#endif /* TEST_REENT_H */

--- a/tests/test_headers/unistd.h
+++ b/tests/test_headers/unistd.h
@@ -1,0 +1,18 @@
+#ifndef TEST_UNISTD_H
+#define TEST_UNISTD_H
+
+/**
+ * @file unistd.h
+ * @brief Test replacement for system unistd.h
+ * 
+ * This file provides minimal POSIX definitions for testing.
+ */
+
+#include <stddef.h>
+
+// Standard file descriptors
+#define STDIN_FILENO    0   // Standard input
+#define STDOUT_FILENO   1   // Standard output  
+#define STDERR_FILENO   2   // Standard error
+
+#endif /* TEST_UNISTD_H */

--- a/tests/test_syscalls.c
+++ b/tests/test_syscalls.c
@@ -1,0 +1,369 @@
+#include "unity.h"
+#include "mock_uart_ll.h"
+#include "uart.h"
+#include <stdio.h>
+#include <string.h>
+#include <stdbool.h>
+#include <reent.h>
+#include <errno.h>
+#include <unistd.h>
+#include <sys/stat.h>
+
+// Test configuration - define before including syscalls.c
+#define SYSCALLS_UART_BUS 0
+#define SYSCALLS_UART_RX_BUFFER_SIZE 256
+#define SYSCALLS_UART_TX_BUFFER_SIZE 256
+
+// Forward declarations of functions we'll test
+struct _reent;
+struct stat;
+typedef long _ssize_t;
+
+_ssize_t _read_r(struct _reent *r, int fd, void *buf, size_t cnt);
+_ssize_t _write_r(struct _reent *r, int fd, void const *buf, size_t cnt);
+int _fstat_r(struct _reent *r, int fd, struct stat *st);
+int _isatty_r(struct _reent *r, int fd);
+void syscalls_uart_deinit(void);
+
+// Test fixtures
+static struct _reent test_reent;
+
+void setUp(void)
+{
+    // point the global errno‐macro into our local reent
+    __impure_ptr = &test_reent;
+    // Initialize the test reent structure
+    test_reent._errno = 0;
+
+    // Initialize mocks
+    mock_uart_ll_Init();
+
+    // Set up default ignores for all UART_LL functions to avoid argument validation issues
+    UART_LL_init_Ignore();
+    UART_LL_set_idle_callback_Ignore();
+    UART_LL_set_rx_complete_callback_Ignore();
+    UART_LL_set_tx_complete_callback_Ignore();
+    UART_LL_deinit_Ignore();
+}
+
+void tearDown(void)
+{
+    // Deinitialize UART to reset state between tests
+    syscalls_uart_deinit();
+
+    // Clean up mocks
+    mock_uart_ll_Destroy();
+}
+
+// Test _write_r function for stdout
+void test_write_r_stdout_success(void)
+{
+    // Arrange
+    char test_data[] = "Hello, World!";
+    size_t data_len = strlen(test_data);
+
+    // Set up expectations for write operation only
+    UART_LL_tx_busy_ExpectAndReturn(UART_BUS_0, false);
+    UART_LL_start_dma_tx_Expect(UART_BUS_0, (uint8_t*)test_data, data_len);
+
+    // Act
+    _ssize_t result = _write_r(&test_reent, STDOUT_FILENO, test_data, data_len);
+
+    // Assert
+    TEST_ASSERT_EQUAL(data_len, result);
+    TEST_ASSERT_EQUAL(0, test_reent._errno);
+}
+
+// Test _write_r function for stderr
+void test_write_r_stderr_success(void)
+{
+    // Arrange
+    char test_data[] = "Error message";
+    size_t data_len = strlen(test_data);
+
+    // Set up expectations for write operation only
+    UART_LL_tx_busy_ExpectAndReturn(UART_BUS_0, false);
+    UART_LL_start_dma_tx_Expect(UART_BUS_0, (uint8_t*)test_data, data_len);
+
+    // Act
+    _ssize_t result = _write_r(&test_reent, STDERR_FILENO, test_data, data_len);
+
+    // Assert
+    TEST_ASSERT_EQUAL(data_len, result);
+    TEST_ASSERT_EQUAL(0, test_reent._errno);
+}
+
+// Test _write_r function with invalid file descriptor
+void test_write_r_invalid_fd(void)
+{
+    // Arrange
+    char test_data[] = "Test data";
+    size_t data_len = strlen(test_data);
+    int invalid_fd = 5; // Not stdout or stderr
+
+    // Act
+    _ssize_t result = _write_r(&test_reent, invalid_fd, test_data, data_len);
+
+    // Assert
+    TEST_ASSERT_EQUAL(-1, result);
+    TEST_ASSERT_EQUAL(EBADF, test_reent._errno);
+}
+
+// Test _read_r function for stdin
+void test_read_r_stdin_success(void)
+{
+    // Arrange
+    uint8_t read_buffer[32];
+    size_t buffer_size = sizeof(read_buffer);
+
+    // Set up expectations for UART initialization
+    UART_LL_init_Ignore();
+    UART_LL_set_idle_callback_Ignore();
+    UART_LL_set_rx_complete_callback_Ignore();
+    UART_LL_set_tx_complete_callback_Ignore();
+
+    // Set up expectations for read operation (no data available)
+    UART_LL_get_dma_position_ExpectAndReturn(UART_BUS_0, 0);
+
+    // Act
+    _ssize_t result = _read_r(&test_reent, STDIN_FILENO, read_buffer, buffer_size);
+
+    // Assert
+    TEST_ASSERT_EQUAL(0, result); // No data available initially
+    TEST_ASSERT_EQUAL(0, test_reent._errno);
+}
+
+// Test _read_r function with invalid file descriptor
+void test_read_r_invalid_fd(void)
+{
+    // Arrange
+    uint8_t read_buffer[32];
+    size_t buffer_size = sizeof(read_buffer);
+    int invalid_fd = 5; // Not stdin
+
+    // Act
+    _ssize_t result = _read_r(&test_reent, invalid_fd, read_buffer, buffer_size);
+
+    // Assert
+    TEST_ASSERT_EQUAL(-1, result);
+    TEST_ASSERT_EQUAL(EBADF, test_reent._errno);
+}
+
+// Test _read_r function with data available
+void test_read_r_stdin_with_data(void)
+{
+    // Arrange
+    uint8_t read_buffer[32];
+    size_t buffer_size = sizeof(read_buffer);
+
+    // Set up expectations for UART initialization
+    UART_LL_init_Ignore();
+    UART_LL_set_idle_callback_Ignore();
+    UART_LL_set_rx_complete_callback_Ignore();
+    UART_LL_set_tx_complete_callback_Ignore();
+
+    // Simulate data in the RX buffer by setting up DMA position
+    UART_LL_get_dma_position_ExpectAndReturn(UART_BUS_0, 5); // 5 bytes received
+
+    // Act
+    _ssize_t result = _read_r(&test_reent, STDIN_FILENO, read_buffer, buffer_size);
+
+    // Assert
+    TEST_ASSERT_GREATER_THAN(0, result); // Should read some bytes
+    TEST_ASSERT_EQUAL(0, test_reent._errno);
+}
+
+// Test with TX buffer full scenario
+void test_write_r_tx_buffer_full(void)
+{
+    // Arrange
+    char test_data[] = "Test data";
+    size_t data_len = strlen(test_data);
+
+    // Set up expectations for UART initialization
+    UART_LL_init_Ignore();
+    UART_LL_set_idle_callback_Ignore();
+    UART_LL_set_rx_complete_callback_Ignore();
+    UART_LL_set_tx_complete_callback_Ignore();
+
+    // Simulate TX not busy initially, so transmission can start
+    UART_LL_tx_busy_ExpectAndReturn(UART_BUS_0, false);
+
+    // First, fill the TX buffer with data (255 bytes to leave 1 slot free)
+    // The buffer size is 256, and full condition is when (head + 1) % size == tail
+    // So we can write 255 bytes before it becomes full
+    char filler_data[255];
+    memset(filler_data, 'X', sizeof(filler_data));
+
+    // Expect start_dma_tx to be called for the initial filler data
+    UART_LL_start_dma_tx_Expect(UART_BUS_0, (uint8_t*)filler_data, 255);
+
+    // Write filler data to fill the buffer
+    _ssize_t filler_result = _write_r(&test_reent, 1, filler_data, 255);
+    TEST_ASSERT_EQUAL(255, filler_result); // Should write all filler data
+
+    // Now try to write more data - this should fail or write less
+    // TX should still be busy from the previous operation
+    UART_LL_tx_busy_ExpectAndReturn(UART_BUS_0, true);
+
+    // Act - try to write when buffer is full
+    _ssize_t result = _write_r(&test_reent, 1, test_data, data_len);
+
+    // Assert - should return -1 and set EAGAIN since buffer is full
+    TEST_ASSERT_EQUAL(-1, result);
+    TEST_ASSERT_EQUAL(EAGAIN, test_reent._errno);
+}
+
+// Test multiple consecutive writes
+void test_multiple_writes(void)
+{
+    // Arrange
+    char test_data1[] = "First ";
+    char test_data2[] = "Second";
+
+    // Set up expectations for UART initialization (only once)
+    UART_LL_init_Ignore();
+    UART_LL_set_idle_callback_Ignore();
+    UART_LL_set_rx_complete_callback_Ignore();
+    UART_LL_set_tx_complete_callback_Ignore();
+
+    // Set up expectations for first write
+    UART_LL_tx_busy_ExpectAndReturn(UART_BUS_0, false);
+    UART_LL_start_dma_tx_Expect(UART_BUS_0, (uint8_t*)test_data1, 6);
+
+    // Act - first write
+    _ssize_t result1 = _write_r(&test_reent, STDOUT_FILENO, test_data1, 6);
+
+    // For the second write, TX is now busy from the first write
+    // So the data will be queued but no new DMA transfer will start
+    UART_LL_tx_busy_ExpectAndReturn(UART_BUS_0, true);
+
+    // Act - second write (should queue data but not start new transmission)
+    _ssize_t result2 = _write_r(&test_reent, STDOUT_FILENO, test_data2, 6);
+
+    // Assert
+    TEST_ASSERT_EQUAL(6, result1);
+    TEST_ASSERT_EQUAL(6, result2); // Should still return 6 (data was queued)
+    TEST_ASSERT_EQUAL(0, test_reent._errno);
+}
+
+// Test _fstat_r function for stdin
+void test_fstat_r_stdin_success(void)
+{
+    // Arrange
+    struct stat st;
+
+    // Act
+    int result = _fstat_r(&test_reent, STDIN_FILENO, &st);
+
+    // Assert
+    TEST_ASSERT_EQUAL(0, result);
+    TEST_ASSERT_EQUAL(S_IFCHR, st.st_mode); // Should be character device
+    TEST_ASSERT_EQUAL(0, st.st_size);
+    TEST_ASSERT_EQUAL(0, test_reent._errno);
+}
+
+// Test _fstat_r function for stdout
+void test_fstat_r_stdout_success(void)
+{
+    // Arrange
+    struct stat st;
+
+    // Act
+    int result = _fstat_r(&test_reent, STDOUT_FILENO, &st);
+
+    // Assert
+    TEST_ASSERT_EQUAL(0, result);
+    TEST_ASSERT_EQUAL(S_IFCHR, st.st_mode); // Should be character device
+    TEST_ASSERT_EQUAL(0, st.st_size);
+    TEST_ASSERT_EQUAL(0, test_reent._errno);
+}
+
+// Test _fstat_r function for stderr
+void test_fstat_r_stderr_success(void)
+{
+    // Arrange
+    struct stat st;
+
+    // Act
+    int result = _fstat_r(&test_reent, STDERR_FILENO, &st);
+
+    // Assert
+    TEST_ASSERT_EQUAL(0, result);
+    TEST_ASSERT_EQUAL(S_IFCHR, st.st_mode); // Should be character device
+    TEST_ASSERT_EQUAL(0, st.st_size);
+    TEST_ASSERT_EQUAL(0, test_reent._errno);
+}
+
+// Test _fstat_r function with invalid file descriptor
+void test_fstat_r_invalid_fd(void)
+{
+    // Arrange
+    struct stat st;
+    int invalid_fd = 5; // Not stdin, stdout, or stderr
+
+    // Act
+    int result = _fstat_r(&test_reent, invalid_fd, &st);
+
+    // Assert
+    TEST_ASSERT_EQUAL(-1, result);
+    TEST_ASSERT_EQUAL(EBADF, test_reent._errno);
+}
+
+// Test _fstat_r function with null stat pointer
+void test_fstat_r_null_stat(void)
+{
+    // Act
+    int result = _fstat_r(&test_reent, STDIN_FILENO, nullptr);
+
+    // Assert
+    TEST_ASSERT_EQUAL(-1, result);
+    TEST_ASSERT_EQUAL(EFAULT, test_reent._errno);
+}
+
+// Test _isatty_r function for stdin
+void test_isatty_r_stdin_is_tty(void)
+{
+    // Act
+    int result = _isatty_r(&test_reent, STDIN_FILENO);
+
+    // Assert
+    TEST_ASSERT_EQUAL(1, result); // Should return 1 (true)
+    TEST_ASSERT_EQUAL(0, test_reent._errno);
+}
+
+// Test _isatty_r function for stdout
+void test_isatty_r_stdout_is_tty(void)
+{
+    // Act
+    int result = _isatty_r(&test_reent, STDOUT_FILENO);
+
+    // Assert
+    TEST_ASSERT_EQUAL(1, result); // Should return 1 (true)
+    TEST_ASSERT_EQUAL(0, test_reent._errno);
+}
+
+// Test _isatty_r function for stderr
+void test_isatty_r_stderr_is_tty(void)
+{
+    // Act
+    int result = _isatty_r(&test_reent, STDERR_FILENO);
+
+    // Assert
+    TEST_ASSERT_EQUAL(1, result); // Should return 1 (true)
+    TEST_ASSERT_EQUAL(0, test_reent._errno);
+}
+
+// Test _isatty_r function with invalid file descriptor
+void test_isatty_r_invalid_fd_not_tty(void)
+{
+    // Arrange
+    int invalid_fd = 5; // Not stdin, stdout, or stderr
+
+    // Act
+    int result = _isatty_r(&test_reent, invalid_fd);
+
+    // Assert
+    TEST_ASSERT_EQUAL(0, result); // Should return 0 (false)
+    TEST_ASSERT_EQUAL(ENOTTY, test_reent._errno);
+}

--- a/tests/test_syscalls.c
+++ b/tests/test_syscalls.c
@@ -114,7 +114,21 @@ void test_read_r_null_buffer(void)
 
     // Assert
     TEST_ASSERT_EQUAL(-1, result);
-    TEST_ASSERT_EQUAL(ENOSYS, test_reent._errno); // Reads not supported
+    TEST_ASSERT_EQUAL(EFAULT, test_reent._errno); // Null buffer should return EFAULT
+}
+
+// Test _read_r function with zero-length read (should succeed)
+void test_read_r_zero_length(void)
+{
+    // Arrange
+    uint8_t read_buffer[32];
+
+    // Act
+    _ssize_t result = _read_r(&test_reent, STDIN_FILENO, read_buffer, 0);
+
+    // Assert
+    TEST_ASSERT_EQUAL(0, result); // Zero-length reads should always succeed
+    TEST_ASSERT_EQUAL(0, test_reent._errno);
 }
 
 // Test _read_r function for stdin (should fail - reads not supported)

--- a/tests/test_syscalls.c
+++ b/tests/test_syscalls.c
@@ -9,11 +9,6 @@
 #include <unistd.h>
 #include <sys/stat.h>
 
-// Test configuration - define before including syscalls.c
-#define SYSCALLS_UART_BUS 0
-#define SYSCALLS_UART_RX_BUFFER_SIZE 256
-#define SYSCALLS_UART_TX_BUFFER_SIZE 256
-
 // Forward declarations of functions we'll test
 struct _reent;
 struct stat;

--- a/tests/test_syscalls.c
+++ b/tests/test_syscalls.c
@@ -114,31 +114,22 @@ void test_read_r_null_buffer(void)
 
     // Assert
     TEST_ASSERT_EQUAL(-1, result);
-    TEST_ASSERT_EQUAL(EFAULT, test_reent._errno);
+    TEST_ASSERT_EQUAL(ENOSYS, test_reent._errno); // Reads not supported
 }
 
-// Test _read_r function for stdin
-void test_read_r_stdin_success(void)
+// Test _read_r function for stdin (should fail - reads not supported)
+void test_read_r_stdin_not_supported(void)
 {
     // Arrange
     uint8_t read_buffer[32];
     size_t buffer_size = sizeof(read_buffer);
 
-    // Set up expectations for UART initialization
-    UART_LL_init_Ignore();
-    UART_LL_set_idle_callback_Ignore();
-    UART_LL_set_rx_complete_callback_Ignore();
-    UART_LL_set_tx_complete_callback_Ignore();
-
-    // Set up expectations for read operation (no data available)
-    UART_LL_get_dma_position_ExpectAndReturn(UART_BUS_0, 0);
-
     // Act
     _ssize_t result = _read_r(&test_reent, STDIN_FILENO, read_buffer, buffer_size);
 
     // Assert
-    TEST_ASSERT_EQUAL(0, result); // No data available initially
-    TEST_ASSERT_EQUAL(0, test_reent._errno);
+    TEST_ASSERT_EQUAL(-1, result); // Should fail
+    TEST_ASSERT_EQUAL(ENOSYS, test_reent._errno); // Function not implemented
 }
 
 // Test _read_r function with invalid file descriptor
@@ -154,31 +145,7 @@ void test_read_r_invalid_fd(void)
 
     // Assert
     TEST_ASSERT_EQUAL(-1, result);
-    TEST_ASSERT_EQUAL(EBADF, test_reent._errno);
-}
-
-// Test _read_r function with data available
-void test_read_r_stdin_with_data(void)
-{
-    // Arrange
-    uint8_t read_buffer[32];
-    size_t buffer_size = sizeof(read_buffer);
-
-    // Set up expectations for UART initialization
-    UART_LL_init_Ignore();
-    UART_LL_set_idle_callback_Ignore();
-    UART_LL_set_rx_complete_callback_Ignore();
-    UART_LL_set_tx_complete_callback_Ignore();
-
-    // Simulate data in the RX buffer by setting up DMA position
-    UART_LL_get_dma_position_ExpectAndReturn(UART_BUS_0, 5); // 5 bytes received
-
-    // Act
-    _ssize_t result = _read_r(&test_reent, STDIN_FILENO, read_buffer, buffer_size);
-
-    // Assert
-    TEST_ASSERT_GREATER_THAN(0, result); // Should read some bytes
-    TEST_ASSERT_EQUAL(0, test_reent._errno);
+    TEST_ASSERT_EQUAL(ENOSYS, test_reent._errno); // All reads not supported
 }
 
 // Test with TX buffer full scenario
@@ -255,8 +222,8 @@ void test_multiple_writes(void)
     TEST_ASSERT_EQUAL(0, test_reent._errno);
 }
 
-// Test _fstat_r function for stdin
-void test_fstat_r_stdin_success(void)
+// Test _fstat_r function for stdin (should fail - reads not supported)
+void test_fstat_r_stdin_not_supported(void)
 {
     // Arrange
     struct stat st;
@@ -265,10 +232,8 @@ void test_fstat_r_stdin_success(void)
     int result = _fstat_r(&test_reent, STDIN_FILENO, &st);
 
     // Assert
-    TEST_ASSERT_EQUAL(0, result);
-    TEST_ASSERT_EQUAL(S_IFCHR, st.st_mode); // Should be character device
-    TEST_ASSERT_EQUAL(0, st.st_size);
-    TEST_ASSERT_EQUAL(0, test_reent._errno);
+    TEST_ASSERT_EQUAL(-1, result); // Should fail
+    TEST_ASSERT_EQUAL(EBADF, test_reent._errno); // Bad file descriptor
 }
 
 // Test _fstat_r function for stdout
@@ -329,15 +294,15 @@ void test_fstat_r_null_stat(void)
     TEST_ASSERT_EQUAL(EFAULT, test_reent._errno);
 }
 
-// Test _isatty_r function for stdin
-void test_isatty_r_stdin_is_tty(void)
+// Test _isatty_r function for stdin (should fail - reads not supported)
+void test_isatty_r_stdin_not_tty(void)
 {
     // Act
     int result = _isatty_r(&test_reent, STDIN_FILENO);
 
     // Assert
-    TEST_ASSERT_EQUAL(1, result); // Should return 1 (true)
-    TEST_ASSERT_EQUAL(0, test_reent._errno);
+    TEST_ASSERT_EQUAL(0, result); // Should return 0 (false)
+    TEST_ASSERT_EQUAL(ENOTTY, test_reent._errno);
 }
 
 // Test _isatty_r function for stdout

--- a/tests/test_syscalls.c
+++ b/tests/test_syscalls.c
@@ -109,6 +109,19 @@ void test_write_r_invalid_fd(void)
     TEST_ASSERT_EQUAL(EBADF, test_reent._errno);
 }
 
+void test_read_r_null_buffer(void)
+{
+    // Arrange
+    size_t buffer_size = 32;
+
+    // Act
+    _ssize_t result = _read_r(&test_reent, STDIN_FILENO, nullptr, buffer_size);
+
+    // Assert
+    TEST_ASSERT_EQUAL(-1, result);
+    TEST_ASSERT_EQUAL(EFAULT, test_reent._errno);
+}
+
 // Test _read_r function for stdin
 void test_read_r_stdin_success(void)
 {

--- a/tests/test_uart.c
+++ b/tests/test_uart.c
@@ -6,20 +6,20 @@
 #include <stdbool.h>
 
 // Test fixtures
-static BUS_CircBuffer rx_buffer;
-static BUS_CircBuffer tx_buffer;
-static uint8_t rx_data[256];
-static uint8_t tx_data[256];
-static UART_Handle *test_handle;
+static BUS_CircBuffer g_rx_buffer;
+static BUS_CircBuffer g_tx_buffer;
+static uint8_t g_rx_data[256];
+static uint8_t g_tx_data[256];
+static UART_Handle *g_test_handle;
 
 // This flag is normally set by syscalls.c when claiming the UART bus
-bool SYSCALLS_uart_claim = false;
+bool g_SYSCALLS_uart_claim = false;
 
 void setUp(void)
 {
     // Initialize buffers for each test
-    circular_buffer_init(&rx_buffer, rx_data, 256);
-    circular_buffer_init(&tx_buffer, tx_data, 256);
+    circular_buffer_init(&g_rx_buffer, g_rx_data, 256);
+    circular_buffer_init(&g_tx_buffer, g_tx_data, 256);
 
     // Initialize mocks
     mock_uart_ll_Init();
@@ -28,15 +28,15 @@ void setUp(void)
 void tearDown(void)
 {
     // Clean up UART handle if it exists
-    if (test_handle != nullptr) {
+    if (g_test_handle != nullptr) {
         // Set up expectations for deinit - use Ignore to be flexible
         UART_LL_deinit_Ignore();
         UART_LL_set_idle_callback_Ignore();
         UART_LL_set_rx_complete_callback_Ignore();
         UART_LL_set_tx_complete_callback_Ignore();
 
-        UART_deinit(test_handle);
-        test_handle = nullptr;
+        UART_deinit(g_test_handle);
+        g_test_handle = nullptr;
     }
 
     // Clean up mocks after each test
@@ -50,16 +50,16 @@ void test_UART_init_success(void)
     size_t bus = 0;
 
     // Set expectations for UART_LL calls - use Ignore for callbacks to avoid linking issues
-    UART_LL_init_Expect(UART_BUS_0, rx_data, 256);
+    UART_LL_init_Expect(UART_BUS_0, g_rx_data, 256);
     UART_LL_set_idle_callback_Ignore();
     UART_LL_set_rx_complete_callback_Ignore();
     UART_LL_set_tx_complete_callback_Ignore();
 
     // Act
-    test_handle = UART_init(bus, &rx_buffer, &tx_buffer);
+    g_test_handle = UART_init(bus, &g_rx_buffer, &g_tx_buffer);
 
     // Assert
-    TEST_ASSERT_NOT_NULL(test_handle);
+    TEST_ASSERT_NOT_NULL(g_test_handle);
 }
 
 void test_UART_init_null_rx_buffer(void)
@@ -69,7 +69,7 @@ void test_UART_init_null_rx_buffer(void)
     UART_Handle *handle;
 
     // Act - pass nullptr rx_buffer
-    handle = UART_init(bus, nullptr, &tx_buffer);
+    handle = UART_init(bus, nullptr, &g_tx_buffer);
 
     // Assert
     TEST_ASSERT_NULL(handle);
@@ -82,7 +82,7 @@ void test_UART_init_null_tx_buffer(void)
     UART_Handle *handle;
 
     // Act - pass nullptr tx_buffer
-    handle = UART_init(bus, &rx_buffer, nullptr);
+    handle = UART_init(bus, &g_rx_buffer, nullptr);
 
     // Assert
     TEST_ASSERT_NULL(handle);
@@ -95,7 +95,7 @@ void test_UART_init_invalid_bus(void)
     UART_Handle *handle;
 
     // Act
-    handle = UART_init(bus, &rx_buffer, &tx_buffer);
+    handle = UART_init(bus, &g_rx_buffer, &g_tx_buffer);
 
     // Assert
     TEST_ASSERT_NULL(handle);
@@ -107,16 +107,16 @@ void test_UART_init_syscalls_bus(void)
     size_t bus = SYSCALLS_UART_BUS;
 
     // Set up expectations for init
-    UART_LL_init_Expect(SYSCALLS_UART_BUS, rx_data, 256);
+    UART_LL_init_Expect(SYSCALLS_UART_BUS, g_rx_data, 256);
     UART_LL_set_idle_callback_Ignore();
     UART_LL_set_rx_complete_callback_Ignore();
     UART_LL_set_tx_complete_callback_Ignore();
 
     // Act
-    test_handle = UART_init(bus, &rx_buffer, &tx_buffer);
+    g_test_handle = UART_init(bus, &g_rx_buffer, &g_tx_buffer);
 
     // Assert - Should fail since only syscalls can claim this bus
-    TEST_ASSERT_NULL(test_handle);
+    TEST_ASSERT_NULL(g_test_handle);
 }
 
 void test_UART_get_bus_count(void)
@@ -135,22 +135,22 @@ void test_UART_write_with_valid_handle(void)
     uint8_t test_data[] = {0x01, 0x02, 0x03, 0x04};
 
     // Set up expectations for init
-    UART_LL_init_Expect(UART_BUS_0, rx_data, 256);
+    UART_LL_init_Expect(UART_BUS_0, g_rx_data, 256);
     UART_LL_set_idle_callback_Ignore();
     UART_LL_set_rx_complete_callback_Ignore();
     UART_LL_set_tx_complete_callback_Ignore();
 
-    test_handle = UART_init(bus, &rx_buffer, &tx_buffer);
+    g_test_handle = UART_init(bus, &g_rx_buffer, &g_tx_buffer);
 
     // Assert that init succeeded
-    TEST_ASSERT_NOT_NULL(test_handle);
+    TEST_ASSERT_NOT_NULL(g_test_handle);
 
     // Expect the TX functions to be called when data is available
     UART_LL_tx_busy_ExpectAndReturn(UART_BUS_0, false);
     UART_LL_start_dma_tx_Expect(UART_BUS_0, test_data, sizeof(test_data));
 
     // Act
-    uint32_t bytes_written = UART_write(test_handle, test_data, sizeof(test_data));
+    uint32_t bytes_written = UART_write(g_test_handle, test_data, sizeof(test_data));
 
     // Assert - Initially buffer should be able to accept data
     TEST_ASSERT_GREATER_OR_EQUAL(4, bytes_written);
@@ -164,24 +164,24 @@ void test_UART_write_with_full_buffer(void)
     uint8_t test_data[] = {0x01, 0x02, 0x03, 0x04};
 
     // Set up expectations for init
-    UART_LL_init_Expect(UART_BUS_0, rx_data, 256);
+    UART_LL_init_Expect(UART_BUS_0, g_rx_data, 256);
     UART_LL_set_idle_callback_Ignore();
     UART_LL_set_rx_complete_callback_Ignore();
     UART_LL_set_tx_complete_callback_Ignore();
 
-    test_handle = UART_init(bus, &rx_buffer, &tx_buffer);
+    g_test_handle = UART_init(bus, &g_rx_buffer, &g_tx_buffer);
 
     // Assert that init succeeded
-    TEST_ASSERT_NOT_NULL(test_handle);
+    TEST_ASSERT_NOT_NULL(g_test_handle);
 
     // Advance TX buffer head to simulate a full buffer
-    tx_buffer.head = tx_buffer.size - 1;
+    g_tx_buffer.head = g_tx_buffer.size - 1;
 
     // Simulate TX busy state
     UART_LL_tx_busy_ExpectAndReturn(UART_BUS_0, true);
 
     // Act
-    uint32_t bytes_written = UART_write(test_handle, test_data, sizeof(test_data));
+    uint32_t bytes_written = UART_write(g_test_handle, test_data, sizeof(test_data));
 
     // Assert - Should return 0 since buffer is full
     TEST_ASSERT_EQUAL(0, bytes_written);
@@ -206,7 +206,7 @@ void test_UART_read_with_valid_handle(void)
     uint8_t read_buffer[10];
 
     // Set up expectations for init
-    UART_LL_init_Expect(UART_BUS_0, rx_data, 256);
+    UART_LL_init_Expect(UART_BUS_0, g_rx_data, 256);
     UART_LL_set_idle_callback_Ignore();
     UART_LL_set_rx_complete_callback_Ignore();
     UART_LL_set_tx_complete_callback_Ignore();
@@ -214,10 +214,10 @@ void test_UART_read_with_valid_handle(void)
     // Mock DMA position for read operation
     UART_LL_get_dma_position_ExpectAndReturn(UART_BUS_0, 0);
 
-    test_handle = UART_init(bus, &rx_buffer, &tx_buffer);
+    g_test_handle = UART_init(bus, &g_rx_buffer, &g_tx_buffer);
 
     // Act
-    uint32_t bytes_read = UART_read(test_handle, read_buffer, sizeof(read_buffer));
+    uint32_t bytes_read = UART_read(g_test_handle, read_buffer, sizeof(read_buffer));
 
     // Assert
     TEST_ASSERT_EQUAL(0, bytes_read); // Buffer is empty initially
@@ -241,7 +241,7 @@ void test_UART_rx_ready_with_valid_handle(void)
     size_t bus = 0;
 
     // Set up expectations for init
-    UART_LL_init_Expect(UART_BUS_0, rx_data, 256);
+    UART_LL_init_Expect(UART_BUS_0, g_rx_data, 256);
     UART_LL_set_idle_callback_Ignore();
     UART_LL_set_rx_complete_callback_Ignore();
     UART_LL_set_tx_complete_callback_Ignore();
@@ -249,10 +249,10 @@ void test_UART_rx_ready_with_valid_handle(void)
     // Mock DMA position for rx_ready check
     UART_LL_get_dma_position_ExpectAndReturn(UART_BUS_0, 0);
 
-    test_handle = UART_init(bus, &rx_buffer, &tx_buffer);
+    g_test_handle = UART_init(bus, &g_rx_buffer, &g_tx_buffer);
 
     // Act
-    bool ready = UART_rx_ready(test_handle);
+    bool ready = UART_rx_ready(g_test_handle);
 
     // Assert
     TEST_ASSERT_FALSE(ready); // Buffer is empty initially
@@ -264,12 +264,12 @@ void test_UART_deinit_with_valid_handle(void)
     size_t bus = 0;
 
     // Set up expectations for init
-    UART_LL_init_Expect(UART_BUS_0, rx_data, 256);
+    UART_LL_init_Expect(UART_BUS_0, g_rx_data, 256);
     UART_LL_set_idle_callback_Ignore();
     UART_LL_set_rx_complete_callback_Ignore();
     UART_LL_set_tx_complete_callback_Ignore();
 
-    test_handle = UART_init(bus, &rx_buffer, &tx_buffer);
+    g_test_handle = UART_init(bus, &g_rx_buffer, &g_tx_buffer);
 
     // Set up expectations for deinit - these MUST be called
     UART_LL_deinit_Expect(UART_BUS_0);
@@ -278,8 +278,8 @@ void test_UART_deinit_with_valid_handle(void)
     UART_LL_set_tx_complete_callback_Expect(UART_BUS_0, nullptr);
 
     // Act
-    UART_deinit(test_handle);
-    test_handle = nullptr; // Manually set to nullptr since we're testing explicit deinit
+    UART_deinit(g_test_handle);
+    g_test_handle = nullptr; // Manually set to nullptr since we're testing explicit deinit
 
     // Assert - Mock verification happens automatically in tearDown()
 }


### PR DESCRIPTION
This PR implements _write_r and _read_r via UART, and implements stubs for _isatty_r and _fstat_r. This allows us to use stdio functions like printf and scanf.

## Summary by Sourcery

Enable basic stdio functionality over UART by implementing newlib syscall handlers, auto-initializing UART via syscalls_config, and routing printf output through the UART driver. Standardize global naming across peripheral drivers, enforce exclusive syscalls bus ownership, update tests and build config to cover new syscalls behavior, and simplify the main application to leverage printf for logging.

New Features:
- Implement newlib syscalls (_write_r, _read_r, _fstat_r, _isatty_r) to route stdio over UART and enable printf output
- Add syscalls.c and syscalls_config.h to auto-initialize UART for stdio with configurable bus and buffer sizes
- Introduce test_syscalls.c and supporting test headers to validate stdout, stderr, fstat, and isatty behaviors

Enhancements:
- Prefix global low-level driver variables (UART, USB, ADC) and bus handles with "g_" to standardize naming
- Restrict UART bus claiming so only the syscalls module can initialize the designated stdio bus
- Refactor main application to use printf for periodic logging and remove manual UART init and echo logic

Documentation:
- Add system/README.md detailing configuration and usage of UART-based stdio

Tests:
- Update test_uart.c to adopt renamed globals and add a test for syscalls bus restriction
- Extend CMakeLists.txt to build and link syscalls tests and include the pslab-bus library