### PR TITLE
CException

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -4,10 +4,11 @@ The PSLab firmware is licensed under the Apache License 2.0. Please note that th
 
 Please review each license to ensure compliance when using or distributing this software.
 
-| Module/Directory                                                        | License         | Copyright Holder     |
-|-------------------------------------------------------------------------|-----------------|----------------------|
-| PSLab firmware (`src/`)                                                 | Apache 2.0      | FOSSASIA             |
-| Bootloader (`boot/`)                                                    | GPLv3           | Feaser               |
-| CMSIS (`lib/STM32H5_CMSIS_HAL-1.5.0/Drivers/CMSIS`)                     | Apache 2.0      | ARM                  |
-| STM32 HAL (`lib/STM32H5_CMSIS_HAL-1.5.0/Drivers/STM32H5xx_HAL_Driver`)  | BSD-3-Clause    | STMicroelectronics   |
-| TinyUSB (`lib/TinyUSB`)                                                 | MIT             | Ha Thach             |
+| Module/Directory                                                     | License         | Copyright Holder     |
+|----------------------------------------------------------------------|-----------------|----------------------|
+| PSLab firmware (`src/`)                                              | Apache 2.0      | FOSSASIA             |
+| Bootloader (`boot/`)                                                 | GPLv3           | Feaser               |
+| CMSIS (`lib/STM32H5_CMSIS_HAL-*/Drivers/CMSIS`)                      | Apache 2.0      | ARM                  |
+| STM32 HAL (`lib/STM32H5_CMSIS_HAL-*/Drivers/STM32H5xx_HAL_Driver`)   | BSD-3-Clause    | STMicroelectronics   |
+| TinyUSB (`lib/tinyusb-*`)                                            | MIT             | Ha Thach             |
+| CException (`lib/CException-*`)                                      | MIT             | ThrowTheSwitch       |

--- a/cmake/tests.cmake
+++ b/cmake/tests.cmake
@@ -8,9 +8,10 @@ set_property(CACHE PLATFORM PROPERTY STRINGS "mock")
 include(CTest)
 enable_testing()
 
-# Add test and source subdirectories
+# Add test subdirectory in addition to the main source directories
 add_subdirectory(tests)
 add_subdirectory(src)
+add_subdirectory(lib)
 
 # Set up code quality targets (without ARM-specific linting)
 setup_code_quality_targets()

--- a/doc/error_handling.md
+++ b/doc/error_handling.md
@@ -1,0 +1,76 @@
+# PSLab Firmware Error Handling Guide
+
+This document explains the error handling system used in the PSLab firmware, designed for robust and structured error management across all layers of the codebase.
+
+## Overview
+
+The PSLab firmware error handling system wraps the [CException](https://github.com/ThrowTheSwitch/CException) library, providing structured exception handling in C. It introduces a domain-specific `Error` enum for PSLab errors and integrates with standard `errno` codes for compatibility with system-level operations and newlib functions.
+
+## Key Features
+
+- **CException Wrapping:**
+  - The macros `TRY`, `CATCH`, and `THROW` map directly to CException's `Try`, `Catch`, and `Throw`.
+  - Enables exception-like control flow in C, allowing errors to be thrown and caught across function and module boundaries.
+
+- **Layer-Agnostic Usage:**
+  - Error handling can be used in all layers (application, platform, system, etc.).
+  - Exceptions (`THROW`) can cross layer boundaries, simplifying error propagation and handling.
+
+- **Error Codes:**
+  - Use PSLab-specific `Error` codes for domain logic and internal operations.
+  - Use standard `errno` codes when interacting with newlib or system-level APIs.
+  - Utility functions are provided to convert between `Error` and `errno` codes:
+    - `error_to_errno(Error error)`
+    - `errno_to_error(int errno_val)`
+
+## Example Usage
+
+```c
+#include "error.h"
+
+void example_function() {
+    Error ex;
+    TRY {
+        // ... code that may throw ...
+        if (some_error_condition) {
+            THROW(ERROR_INVALID_ARGUMENT);
+        }
+        // ... more code ...
+    } CATCH(ex) {
+        // Handle error
+        printf("Error: %s\n", error_to_string(ex));
+        // Optionally convert to errno for system calls
+        errno = error_to_errno(ex);
+    }
+}
+```
+
+## Guidelines
+
+- **Interacting with newlib/system APIs:**
+  - Use `errno` codes for errors returned to or received from newlib functions.
+  - Convert between PSLab `Error` and `errno` using the provided utility functions.
+
+- **Internal PSLab logic:**
+  - Use the `Error` enum for all internal error signaling and handling.
+  - Don't use CException types or functions directly; use the provided wrappers.
+
+## CException Limitations
+
+When using CException (and thus PSLab's error handling macros), be aware of the following limitations:
+
+- **Return & Goto:**
+  - Do not directly `return` from within a `TRY` block, nor `goto` into or out of a `TRY` block.
+  - The `TRY` macro allocates local memory and alters a global pointer, which are cleaned up at the top of the `CATCH` macro. Bypassing these steps (via return/goto) can cause memory leaks or unpredictable behavior.
+
+- **Local Variables:**
+  - If you change local (stack) variables within a `TRY` block and need to use their updated values after an exception is thrown, mark those variables as `volatile`.
+
+- **Memory Management:**
+  - Memory allocated (e.g., via `malloc`) within a `TRY` block is not automatically released if an error is thrown.
+  - It is your responsibility to clean up such resources in the `CATCH` block as needed.
+
+## References
+
+[CException Library](https://github.com/ThrowTheSwitch/CException)
+See `src/util/error.h` for implementation details and available error codes.

--- a/lib/CException-1.3.4/CException.c
+++ b/lib/CException-1.3.4/CException.c
@@ -1,0 +1,52 @@
+#include "CException.h"
+
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+#endif
+
+volatile CEXCEPTION_FRAME_T CExceptionFrames[CEXCEPTION_NUM_ID] = {{ 0 }};
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+
+//------------------------------------------------------------------------------------------
+//  Throw
+//------------------------------------------------------------------------------------------
+void Throw(CEXCEPTION_T ExceptionID)
+{
+    unsigned int MY_ID = CEXCEPTION_GET_ID;
+    CExceptionFrames[MY_ID].Exception = ExceptionID;
+    if (CExceptionFrames[MY_ID].pFrame)
+    {
+        longjmp(*CExceptionFrames[MY_ID].pFrame, 1);
+    }
+    CEXCEPTION_NO_CATCH_HANDLER(ExceptionID);
+}
+
+//------------------------------------------------------------------------------------------
+//  Explanation of what it's all for:
+//------------------------------------------------------------------------------------------
+/*
+#define Try
+    {                                                                   <- give us some local scope.  most compilers are happy with this
+        jmp_buf *PrevFrame, NewFrame;                                   <- prev frame points to the last try block's frame.  new frame gets created on stack for this Try block
+        unsigned int MY_ID = CEXCEPTION_GET_ID;                         <- look up this task's id for use in frame array.  always 0 if single-tasking
+        PrevFrame = CExceptionFrames[CEXCEPTION_GET_ID].pFrame;         <- set pointer to point at old frame (which array is currently pointing at)
+        CExceptionFrames[MY_ID].pFrame = &NewFrame;                     <- set array to point at my new frame instead, now
+        CExceptionFrames[MY_ID].Exception = CEXCEPTION_NONE;            <- initialize my exception id to be NONE
+        if (setjmp(NewFrame) == 0) {                                    <- do setjmp.  it returns 1 if longjump called, otherwise 0
+            if (&PrevFrame)                                             <- this is here to force proper scoping.  it requires braces or a single line to be but after Try, otherwise won't compile.  This is always true at this point.
+
+#define Catch(e)
+            else { }                                                    <- this also forces proper scoping.  Without this they could stick their own 'else' in and it would get ugly
+            CExceptionFrames[MY_ID].Exception = CEXCEPTION_NONE;        <- no errors happened, so just set the exception id to NONE (in case it was corrupted)
+        }
+        else                                                            <- an exception occurred
+        { e = CExceptionFrames[MY_ID].Exception; e=e;}                  <- assign the caught exception id to the variable passed in.
+        CExceptionFrames[MY_ID].pFrame = PrevFrame;                     <- make the pointer in the array point at the previous frame again, as if NewFrame never existed.
+    }                                                                   <- finish off that local scope we created to have our own variables
+    if (CExceptionFrames[CEXCEPTION_GET_ID].Exception != CEXCEPTION_NONE)  <- start the actual 'catch' processing if we have an exception id saved away
+ */
+

--- a/lib/CException-1.3.4/CException.h
+++ b/lib/CException-1.3.4/CException.h
@@ -1,0 +1,115 @@
+#ifndef _CEXCEPTION_H
+#define _CEXCEPTION_H
+
+#include <setjmp.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+
+#define CEXCEPTION_VERSION_MAJOR    1
+#define CEXCEPTION_VERSION_MINOR    3
+#define CEXCEPTION_VERSION_BUILD    4
+#define CEXCEPTION_VERSION          ((CEXCEPTION_VERSION_MAJOR << 16) | (CEXCEPTION_VERSION_MINOR << 8) | CEXCEPTION_VERSION_BUILD)
+
+//To Use CException, you have a number of options:
+//1. Just include it and run with the defaults
+//2. Define any of the following symbols at the command line to override them
+//3. Include a header file before CException.h everywhere which defines any of these
+//4. Create an Exception.h in your path, and just define EXCEPTION_USE_CONFIG_FILE first
+
+#ifdef CEXCEPTION_USE_CONFIG_FILE
+#include "CExceptionConfig.h"
+#endif
+
+//This is the value to assign when there isn't an exception
+#ifndef CEXCEPTION_NONE
+#define CEXCEPTION_NONE      (0x5A5A5A5A)
+#endif
+
+//This is number of exception stacks to keep track of (one per task)
+#ifndef CEXCEPTION_NUM_ID
+#define CEXCEPTION_NUM_ID    (1) //there is only the one stack by default
+#endif
+
+//This is the method of getting the current exception stack index (0 if only one stack)
+#ifndef CEXCEPTION_GET_ID
+#define CEXCEPTION_GET_ID    (0) //use the first index always because there is only one anyway
+#endif
+
+//The type to use to store the exception values.
+#ifndef CEXCEPTION_T
+#define CEXCEPTION_T         unsigned int
+#endif
+
+//This is an optional special handler for when there is no global Catch
+#ifndef CEXCEPTION_NO_CATCH_HANDLER
+#define CEXCEPTION_NO_CATCH_HANDLER(id)
+#endif
+
+//These hooks allow you to inject custom code into places, particularly useful for saving and restoring additional state
+#ifndef CEXCEPTION_HOOK_START_TRY
+#define CEXCEPTION_HOOK_START_TRY
+#endif
+#ifndef CEXCEPTION_HOOK_HAPPY_TRY
+#define CEXCEPTION_HOOK_HAPPY_TRY
+#endif
+#ifndef CEXCEPTION_HOOK_AFTER_TRY
+#define CEXCEPTION_HOOK_AFTER_TRY
+#endif
+#ifndef CEXCEPTION_HOOK_START_CATCH
+#define CEXCEPTION_HOOK_START_CATCH
+#endif
+
+//exception frame structures
+typedef struct {
+  jmp_buf* pFrame;
+  CEXCEPTION_T volatile Exception;
+} CEXCEPTION_FRAME_T;
+
+//actual root frame storage (only one if single-tasking)
+extern volatile CEXCEPTION_FRAME_T CExceptionFrames[];
+
+//Try (see C file for explanation)
+#define Try                                                         \
+    {                                                               \
+        jmp_buf *PrevFrame, NewFrame;                               \
+        unsigned int MY_ID = CEXCEPTION_GET_ID;                     \
+        PrevFrame = CExceptionFrames[MY_ID].pFrame;                 \
+        CExceptionFrames[MY_ID].pFrame = (jmp_buf*)(&NewFrame);     \
+        CExceptionFrames[MY_ID].Exception = CEXCEPTION_NONE;        \
+        CEXCEPTION_HOOK_START_TRY;                                  \
+        if (setjmp(NewFrame) == 0) {                                \
+            if (1)
+
+//Catch (see C file for explanation)
+#define Catch(e)                                                    \
+            else { }                                                \
+            CExceptionFrames[MY_ID].Exception = CEXCEPTION_NONE;    \
+            CEXCEPTION_HOOK_HAPPY_TRY;                              \
+        }                                                           \
+        else                                                        \
+        {                                                           \
+            e = CExceptionFrames[MY_ID].Exception;                  \
+            (void)e;                                                \
+            CEXCEPTION_HOOK_START_CATCH;                            \
+        }                                                           \
+        CExceptionFrames[MY_ID].pFrame = PrevFrame;                 \
+        CEXCEPTION_HOOK_AFTER_TRY;                                  \
+    }                                                               \
+    if (CExceptionFrames[CEXCEPTION_GET_ID].Exception != CEXCEPTION_NONE)
+
+//Throw an Error
+void Throw(CEXCEPTION_T ExceptionID);
+
+//Just exit the Try block and skip the Catch.
+#define ExitTry() Throw(CEXCEPTION_NONE)
+
+#ifdef __cplusplus
+}   // extern "C"
+#endif
+
+
+#endif // _CEXCEPTION_H

--- a/lib/CException-1.3.4/CMakeLists.txt
+++ b/lib/CException-1.3.4/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_library(cexception STATIC
+    CException.c
+    CException.h
+)
+
+target_include_directories(cexception
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}
+)

--- a/lib/CException-1.3.4/README.md
+++ b/lib/CException-1.3.4/README.md
@@ -1,0 +1,236 @@
+CException ![CI](https://github.com/ThrowTheSwitch/CException/workflows/CI/badge.svg)
+==========
+
+_This Documentation Is Released Under a Creative Commons 3.0 Attribution Share-Alike License_
+
+CException is simple exception handling in C. It is significantly faster than full-blown C++ exception handling 
+but loses some flexibility. It is portable to any platform supporting `setjmp`/`longjmp`.
+
+Getting Started
+================
+
+The simplest way to get started is to just grab the code and pull it into your project:
+
+```
+git clone https://github.com/throwtheswitch/cexception.git
+```
+
+If you want to contribute to this project, you'll also need to have Ruby and Ceedling installed to run the unit tests.
+
+Usage
+=====
+
+### So what's it good for?
+
+Mostly error handling. Passing errors down a long chain of function calls gets ugly. Sometimes really ugly. 
+So what if you could just specify certain places where you want to handle errors, and all your errors were 
+transferred there? Let's try a lame example:
+
+CException uses C standard library functions setjmp and longjmp to operate. As long as the target system 
+has these two functions defined, this library should be useable with very little configuration. It even 
+supports environments where multiple program flows are in use, such as real-time operating systems... 
+we started this project for use in embedded systems... but it obviously can be used for larger systems too.
+
+### Error Handling with CException:
+
+```
+void functionC(void) {
+  //do some stuff
+  if (there_was_a_problem)
+    Throw(ERR_BAD_BREATH);
+  //this stuff never gets called because of error
+}
+```
+
+There are about a gajillion exception frameworks using a similar setjmp/longjmp method out there... and there 
+will probably be more in the future. Unfortunately, when we started our last embedded project, all those that 
+existed either (a) did not support multiple tasks (therefore multiple stacks) or (b) were way more complex 
+than we really wanted. CException was born.
+
+Why?
+====
+
+### It's ANSI C
+
+...and it beats passing error codes around.
+
+### You want something simple...
+
+CException throws a single id. You can define those ID's to be whatever you like. 
+You might even choose which type that number is for your project. But that's as far as it goes. We weren't interested 
+in passing objects or structs or strings... just simple error codes. Fast. Easy to Use. Easy to Understand.
+
+### Performance...
+
+CException can be configured for single tasking or multitasking. In single tasking, there is 
+very little overhead past the setjmp/longjmp calls (which are already fast). In multitasking, your only additional 
+overhead is the time it takes you to determine a unique task id (0 to num_tasks).
+
+How?
+====
+
+Code that is to be protected are wrapped in `Try { }` blocks. The code inside the Try block is _protected_, 
+meaning that if any Throws occur, program control is directly transferred to the start of the Catch block. 
+The Catch block immediately follows the Try block. It's ignored if no errors have occurred.
+
+A numerical exception ID is included with Throw, and is passed into the Catch block. This allows you to handle 
+errors differently or to report which error has occurred... or maybe it just makes debugging easier so you 
+know where the problem was Thrown.
+
+Throws can occur from anywhere inside the Try block, directly in the function you're testing or even within 
+function calls (nested as deeply as you like). There can be as many Throws as you like, just remember that 
+execution of the guts of your Try block ends as soon as the first Throw is triggered. Once you throw, you're 
+transferred to the Catch block. A silly example:
+
+```
+void SillyExampleWhichPrintsZeroThroughFive(void) {
+  volatile CEXCEPTION_T e;
+  int i;
+  while (i = 0; i < 6; i++) {
+    Try {
+      Throw(i);
+      //This spot is never reached
+    } 
+    Catch(e) {
+      printf(“%i “, e);
+    }
+  }
+}
+```
+
+Limitations
+===========
+
+This library was made to be as fast as possible, and provide basic exception handling. It is not a full-blown 
+exception library like C++. Because of this, there are a few limitations that should be observed in order to 
+successfully utilize this library:
+
+### Return & Goto
+
+Do not directly `return` from within a `Try` block, nor `goto` into or out of a `Try` block.
+The `Try` macro allocates some local memory and alters a global pointer. These are cleaned up at the 
+top of the `Catch` macro. Gotos and returns would bypass some of these steps, resulting in memory leaks 
+or unpredictable behavior.
+
+### Local Variables
+
+If (a) you change local (stack) variables within your `Try` block, and (b) wish to make use of the updated 
+values after an exception is thrown, those variables should be made `volatile`.
+
+Note that this is ONLY for locals and ONLY when you need access to them after a `Throw`.
+
+Compilers optimize (and thank goodness they do). There is no way to guarantee that the actual memory 
+location was updated and not just a register unless the variable is marked volatile.
+
+### Memory Management
+
+Memory which is `malloc`'d within a `Try` block is not automatically released when an error is thrown. This 
+will sometimes be desirable, and other times may not. It will be the responsibility of the code you put in 
+the `Catch` block to perform this kind of cleanup.
+
+There's just no easy way to track `malloc`'d memory, etc., without replacing or wrapping `malloc` 
+calls or something like that. This is a lightweight framework, so these options were not desirable.
+
+CException API
+==============
+
+### `Try { ... }`
+
+`Try` is a macro which starts a protected block. It MUST be followed by a pair of braces or a single 
+protected line (similar to an 'if'), enclosing the data that is to be protected. It MUST be followed by 
+a `Catch` block (don't worry, you'll get compiler errors to let you know if you mess any of that up).
+
+The `Try` block is your protected block. It contains your main program flow, where you can ignore errors 
+(other than a quick `Throw` call). You may nest multiple `Try` blocks if you want to handle errors at
+multiple levels, and you can even rethrow an error from within a nested `Catch`.
+
+### `Catch(e) { }`
+
+`Catch` is a macro which ends the `Try` block and starts the error handling block. The `Catch` block 
+is executed if and only if an exception was thrown while within the `Try` block. This error was thrown 
+by a `Throw` call somewhere within `Try` (or within a function called within `Try`, or a function called 
+by a function called within `Try`... you get the idea.).
+
+`Catch` receives a single id of type `CEXCEPTION_T` which you can ignore or use to handle the error in 
+some way. You may throw errors from within Catches, but they will be caught by a `Try` wrapping the `Catch`, 
+not the one immediately preceeding.
+
+### `Throw(e)`
+
+`Throw` is the method used to throw an error. `Throw`s should only occur from within a protected 
+(`Try`...`Catch`) block, though it may easily be nested many function calls deep without an impact 
+on performance or functionality. `Throw` takes a single argument, which is an exception id which will be 
+ passed to `Catch` as the reason for the error. If you wish to _re-throw_ an error, this can be done by
+calling `Throw(e)` with the error code you just caught. It _IS_ valid to throw from a `Catch` block.
+
+### `ExitTry()`
+
+`ExitTry` is a method used to immediately exit your current Try block but NOT treat this as an error. Don't 
+run the Catch. Just start executing from after the Catch as if nothing had happened.
+
+Configuration
+=============
+
+CException is a mostly portable library. It has one universal dependency, plus some macros which are required if 
+working in a multi-tasking environment.
+
+The standard C library setjmp must be available. Since this is part of the standard library, it's all good.
+
+If working in a multitasking environment, you need a stack frame for each task. Therefore, you must define 
+methods for obtaining an index into an array of frames and to get the overall number of id's are required. If 
+the OS supports a method to retrieve task ID's, and those tasks are number 0, 1, 2... you are in an ideal 
+situation. Otherwise, a more creative mapping function may be required. Note that this function is likely to 
+be called twice for each protected block and once during a throw. This is the only added overhead in the system.
+
+You have options for configuring the library, if the defaults aren't good enough for you. You can add defines 
+at the command prompt directly. You can always include a configuration file before including `CException.h`. 
+You can make sure `CEXCEPTION_USE_CONFIG_FILE` is defined, which will force make CException look for 
+`CExceptionConfig.h`, where you can define whatever you like. However you do it, you can override any or 
+all of the following:
+
+### `CEXCEPTION_T`
+
+Set this to the type you want your exception id's to be. Defaults to an 'unsigned int'.
+
+### `CEXCEPTION_NONE`
+
+Set this to a number which will never be an exception id in your system. Defaults to `0x5a5a5a5a`.
+
+### `CEXCEPTION_GET_ID`
+
+If in a multi-tasking environment, this should be set to be a call to the function described in #2 above. 
+It defaults to just return 0 all the time (good for single tasking environments, not so good otherwise).
+
+### `CEXCEPTION_NUM_ID`
+
+If in a multi-tasking environment, this should be set to the number of ID's required (usually the number 
+of tasks in the system). Defaults to 1 (good for single tasking environments or systems where you will only 
+use this from one task).
+
+### `CEXCEPTION_NO_CATCH_HANDLER (id)`
+
+This macro can be optionally specified. It allows you to specify code to be called when a Throw is made 
+outside of Try...Catch protection. Consider this the emergency fallback plan for when something has gone 
+terribly wrong.
+
+### And More!
+
+You may also want to include any header files which will commonly be needed by the rest of your application 
+where it uses exception handling here. For example, OS header files or exception codes would be useful.
+
+Finally, there are some hook macros which you can implement to inject your own target-specific code in 
+particular places. It is a rare instance where you will need these, but they are here if you need them:
+
+* `CEXCEPTION_HOOK_START_TRY` - called immediately before the Try block
+* `CEXCEPTION_HOOK_HAPPY_TRY` - called immediately after the Try block if no exception was thrown
+* `CEXCEPTION_HOOK_AFTER_TRY` - called immediately after the Try block OR before an exception is caught
+* `CEXCEPTION_HOOK_START_CATCH` - called immediately before the catch
+
+Testing
+=======
+
+If you want to validate that CException works with your tools or that it works with your custom 
+configuration, you may want to run the included test suite. This is the test suite (along with real 
+projects we've used it on) that we use to make sure that things actually work the way we claim.
+The test suite makes use of Ceedling, which uses the Unity Test Framework. It will require a native C compiler. 
+The example makefile and rakefile both use gcc. 

--- a/lib/CException-1.3.4/license.txt
+++ b/lib/CException-1.3.4/license.txt
@@ -1,0 +1,24 @@
+Copyright (c) 2007-2024 Mark VanderVoord
+
+https://opensource.org/license/mit/
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/lib/CMakeLists.target.txt
+++ b/lib/CMakeLists.target.txt
@@ -1,0 +1,2 @@
+add_subdirectory(CException-1.3.4)
+add_subdirectory(tinyusb-0.18.0)

--- a/lib/CMakeLists.tests.txt
+++ b/lib/CMakeLists.tests.txt
@@ -1,0 +1,1 @@
+add_subdirectory(CException-1.3.4)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,1 +1,5 @@
-add_subdirectory(tinyusb-0.18.0)
+if(BUILD_TESTS)
+    include(${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.tests.txt)
+else()
+    include(${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.target.txt)
+endif()

--- a/src/application/main.c
+++ b/src/application/main.c
@@ -62,17 +62,13 @@ int main(void) // NOLINT
         CircularBuffer uart_tx_buf;
         circular_buffer_init(&uart_rx_buf, uart_rx_buffer_data, uart_buf_sz);
         circular_buffer_init(&uart_tx_buf, uart_tx_buffer_data, uart_buf_sz);
-        UART_Handle *huart =
-            UART_init(SYSCALLS_UART_BUS, &uart_rx_buf, &uart_tx_buf);
-        if (huart == nullptr) {
-            LOG_ERROR("Failed to initialize SYSCALLS_UART_BUS");
-            THROW(ERROR_RESOURCE_UNAVAILABLE);
-        }
+        // This will fail
+        (void)UART_init(SYSCALLS_UART_BUS, &uart_rx_buf, &uart_tx_buf);
     }
     CATCH(e)
     {
-        LOG_DEBUG("Caught exception during UART initialization:");
-        LOG_DEBUG("%d %s", e, error_to_string(e));
+        LOG_ERROR("Failed to initialize SYSCALLS_UART_BUS");
+        LOG_ERROR("%d %s", e, error_to_string(e));
     }
 
     // Initialize USB

--- a/src/platform/h563xx/adc_ll.c
+++ b/src/platform/h563xx/adc_ll.c
@@ -17,6 +17,7 @@
 #include "stm32h5xx_hal.h"
 
 #include "adc_ll.h"
+#include "error.h"
 
 static ADC_HandleTypeDef g_hadc = { nullptr };
 
@@ -73,13 +74,17 @@ void ADC_LL_init(void)
     g_hadc.Init.ExternalTrigConvEdge = ADC_EXTERNALTRIGCONVEDGE_NONE;
     g_hadc.Init.ExternalTrigConv = ADC_SOFTWARE_START;
 
-    HAL_ADC_Init(&g_hadc);
+    if (HAL_ADC_Init(&g_hadc) != HAL_OK) {
+        THROW(ERROR_HARDWARE_FAULT);
+    }
 
     // Configure ADC channel
     g_config.Channel = ADC_CHANNEL_0; // ADC1_IN0
     g_config.Rank = ADC_REGULAR_RANK_1;
     g_config.SamplingTime = ADC_SAMPLETIME_640CYCLES_5;
-    HAL_ADC_ConfigChannel(&g_hadc, &g_config);
+    if (HAL_ADC_ConfigChannel(&g_hadc, &g_config) != HAL_OK) {
+        THROW(ERROR_HARDWARE_FAULT);
+    }
 }
 
 /**
@@ -89,7 +94,9 @@ void ADC_LL_init(void)
 void ADC_LL_deinit(void)
 {
     // Deinitialize the ADC peripheral
-    HAL_ADC_DeInit(&g_hadc);
+    if (HAL_ADC_DeInit(&g_hadc) != HAL_OK) {
+        THROW(ERROR_HARDWARE_FAULT);
+    }
 }
 
 /**
@@ -102,7 +109,9 @@ void ADC_LL_deinit(void)
 void ADC_LL_start(void)
 {
     // Start the ADC conversion
-    HAL_ADC_Start(&g_hadc);
+    if (HAL_ADC_Start(&g_hadc) != HAL_OK) {
+        THROW(ERROR_HARDWARE_FAULT);
+    }
 }
 
 /**
@@ -115,20 +124,28 @@ void ADC_LL_start(void)
 void ADC_LL_stop(void)
 {
     // Stop the ADC conversion
-    HAL_ADC_Stop(&g_hadc);
+    if (HAL_ADC_Stop(&g_hadc) != HAL_OK) {
+        THROW(ERROR_HARDWARE_FAULT);
+    }
 }
 
 uint32_t ADC_LL_read(uint32_t *buffer)
 {
     // Start the ADC conversion
-    HAL_ADC_Start(&g_hadc);
+    if (HAL_ADC_Start(&g_hadc) != HAL_OK) {
+        THROW(ERROR_HARDWARE_FAULT);
+    }
 
-    HAL_ADC_PollForConversion(&g_hadc, HAL_MAX_DELAY);
+    if (HAL_ADC_PollForConversion(&g_hadc, HAL_MAX_DELAY) != HAL_OK) {
+        THROW(ERROR_TIMEOUT);
+    }
 
     // Read the converted value
     *buffer = HAL_ADC_GetValue(&g_hadc);
 
-    HAL_ADC_Stop(&g_hadc); // Stop the ADC conversion
+    if (HAL_ADC_Stop(&g_hadc) != HAL_OK) {
+        THROW(ERROR_HARDWARE_FAULT);
+    }
 
     return *buffer; // Return the converted value
 }

--- a/src/platform/h563xx/platform.c
+++ b/src/platform/h563xx/platform.c
@@ -22,6 +22,7 @@
 
 #include "stm32h5xx_hal.h"
 
+#include "error.h"
 #include "logging_ll.h"
 #include "platform.h"
 
@@ -90,10 +91,9 @@ static void system_clock_config(void)
     osc_init.PLL.PLLVCOSEL = RCC_PLL1_VCORANGE_WIDE;
     osc_init.PLL.PLLFRACN = 0;
     if (HAL_RCC_OscConfig(&osc_init) != HAL_OK) {
-        /* Clock configuration incorrect or hardware failure. Hang the system to
-         * prevent damage.
-         */
-        while (1);
+        /* Clock configuration incorrect or hardware failure */
+        THROW(ERROR_HARDWARE_FAULT);
+        return;
     }
 
     // Wait for HSI48.
@@ -110,10 +110,9 @@ static void system_clock_config(void)
     clk_init.APB2CLKDivider = RCC_HCLK_DIV1;
     clk_init.APB3CLKDivider = RCC_HCLK_DIV1;
     if (HAL_RCC_ClockConfig(&clk_init, FLASH_LATENCY_5) != HAL_OK) {
-        /* Clock configuration incorrect or hardware failure. Hang the system to
-         * prevent damage.
-         */
-        while (1);
+        /* Clock configuration incorrect or hardware failure */
+        THROW(ERROR_HARDWARE_FAULT);
+        return;
     }
 }
 
@@ -146,7 +145,10 @@ static void system_clock_config(void)
  */
 void PLATFORM_init(void)
 {
-    HAL_Init();
+    if (HAL_Init() != HAL_OK) {
+        THROW(ERROR_HARDWARE_FAULT);
+        return;
+    }
     system_clock_config();
     LOG_LL_init();
     LOG_LL_INFO("Platform hardware initialized");

--- a/src/system/adc/CMakeLists.tests.txt
+++ b/src/system/adc/CMakeLists.tests.txt
@@ -5,6 +5,11 @@ add_library(pslab-adc STATIC
     adc.c
 )
 
+target_link_libraries(pslab-adc
+    PRIVATE
+        pslab-util
+)
+
 target_include_directories(pslab-adc
     PUBLIC
         ${CMAKE_CURRENT_SOURCE_DIR}

--- a/src/system/adc/adc.c
+++ b/src/system/adc/adc.c
@@ -15,6 +15,7 @@
 
 #include "adc.h"
 #include "adc_ll.h"
+#include "error.h"
 
 /**
  * @brief Initializes the ADC peripheral.
@@ -75,7 +76,11 @@ void ADC_stop(void)
  */
 uint32_t ADC_read(uint32_t *data)
 {
-    *data = ADC_LL_read(data);
+    if (!data) {
+        THROW(ERROR_INVALID_ARGUMENT);
+        return 0;
+    }
 
+    *data = ADC_LL_read(data);
     return *data;
 }

--- a/src/system/bus/usb.c
+++ b/src/system/bus/usb.c
@@ -25,6 +25,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "error.h"
 #include "usb.h"
 #include "usb_ll.h"
 #include "util.h"
@@ -167,6 +168,7 @@ static void line_state_callback(USB_Bus itf, bool dtr, bool rts)
 USB_Handle *USB_init(size_t interface, CircularBuffer *rx_buffer)
 {
     if (!rx_buffer || interface >= USB_INTERFACE_COUNT) {
+        THROW(ERROR_INVALID_ARGUMENT);
         return nullptr;
     }
 
@@ -174,12 +176,14 @@ USB_Handle *USB_init(size_t interface, CircularBuffer *rx_buffer)
 
     /* Check if interface is already initialized */
     if (g_active_handles[interface_id] != nullptr) {
+        THROW(ERROR_RESOURCE_BUSY);
         return nullptr;
     }
 
     /* Allocate handle */
     USB_Handle *handle = malloc(sizeof(USB_Handle));
     if (!handle) {
+        THROW(ERROR_OUT_OF_MEMORY);
         return nullptr;
     }
 

--- a/src/system/led.c
+++ b/src/system/led.c
@@ -9,6 +9,7 @@
  */
 
 #include "led.h"
+#include "error.h"
 #include "led_ll.h"
 
 void LED_init(void) { LED_LL_init(); }

--- a/src/system/logging.h
+++ b/src/system/logging.h
@@ -25,7 +25,7 @@ typedef enum {
 
 // Default log level (can be overridden via preprocessor)
 #ifndef LOG_LEVEL
-#define LOG_LEVEL LOG_LEVEL_INFO
+#define LOG_LEVEL LOG_LEVEL_DEBUG
 #endif
 
 // Timestamp support (optional - define LOG_WITH_TIMESTAMP to enable)

--- a/src/system/stubs.c
+++ b/src/system/stubs.c
@@ -33,3 +33,40 @@ _off_t _lseek_r(struct _reent *r, int fd, _off_t offset, int whence)
     errno = ENOSYS;
     return (_off_t)-1;
 }
+
+/**
+ * @brief Reentrant version of getpid system call stub
+ *
+ * This stub is required by newlib's reentrant infrastructure when using
+ * setjmp/longjmp (as used by CException). In bare-metal embedded systems,
+ * there are no processes, so we return a fixed process ID.
+ *
+ * @param r Pointer to reentrant structure (unused)
+ * @return Always returns 1 (fixed process ID for embedded systems)
+ */
+int _getpid_r(struct _reent *r)
+{
+    (void)r;
+    return 1;
+}
+
+/**
+ * @brief Reentrant version of kill system call stub
+ *
+ * This stub is required by newlib's reentrant infrastructure when using
+ * setjmp/longjmp (as used by CException). In bare-metal embedded systems,
+ * there are no processes or signals, so this always fails.
+ *
+ * @param r Pointer to reentrant structure (unused)
+ * @param pid Process ID (unused)
+ * @param sig Signal number (unused)
+ * @return Always returns -1 with errno set to EINVAL
+ */ // NOLINTNEXTLINE: bugprone-easily-swappable-parameters
+int _kill_r(struct _reent *r, int pid, int sig)
+{
+    (void)r;
+    (void)pid;
+    (void)sig;
+    errno = EINVAL;
+    return -1;
+}

--- a/src/system/system.c
+++ b/src/system/system.c
@@ -7,6 +7,7 @@
  * other hardware access.
  */
 
+#include "error.h"
 #include "led.h"
 #include "logging.h"
 #include "platform.h"

--- a/src/system/system.c
+++ b/src/system/system.c
@@ -8,6 +8,7 @@
  */
 
 #include "led.h"
+#include "logging.h"
 #include "platform.h"
 
 #include "system.h"
@@ -15,5 +16,7 @@
 void SYSTEM_init(void)
 {
     PLATFORM_init();
+    // Read any logs that were generated during platform initialization
+    LOG_service_platform();
     LED_init();
 }

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -7,3 +7,7 @@ target_sources(pslab-util PRIVATE
 target_include_directories(pslab-util PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}
 )
+
+target_link_libraries(pslab-util PUBLIC
+    cexception
+)

--- a/src/util/circular_buffer.c
+++ b/src/util/circular_buffer.c
@@ -9,6 +9,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "error.h"
 #include "util.h"
 
 /**
@@ -20,13 +21,14 @@
  */
 void circular_buffer_init(CircularBuffer *cb, uint8_t *buffer, uint32_t size)
 {
+    if (!cb || !buffer) {
+        THROW(ERROR_INVALID_ARGUMENT);
+        return;
+    }
+
     // Require power of two size
     if ((size == 0) || (size & (size - 1)) != 0) {
-        cb->buffer = nullptr; // Invalid size
-        cb->head = 0;
-        cb->tail = 0;
-        cb->size = 0;
-        cb->mask = 0;
+        THROW(ERROR_INVALID_ARGUMENT);
         return;
     }
     cb->buffer = buffer;
@@ -44,6 +46,10 @@ void circular_buffer_init(CircularBuffer *cb, uint8_t *buffer, uint32_t size)
  */
 bool circular_buffer_is_empty(CircularBuffer *cb)
 {
+    if (!cb) {
+        THROW(ERROR_INVALID_ARGUMENT);
+        return true;
+    }
     return cb->head == cb->tail;
 }
 
@@ -55,6 +61,10 @@ bool circular_buffer_is_empty(CircularBuffer *cb)
  */
 bool circular_buffer_is_full(CircularBuffer *cb)
 {
+    if (!cb) {
+        THROW(ERROR_INVALID_ARGUMENT);
+        return true;
+    }
     return ((cb->head + 1) & cb->mask) == cb->tail;
 }
 
@@ -66,6 +76,10 @@ bool circular_buffer_is_full(CircularBuffer *cb)
  */
 uint32_t circular_buffer_available(CircularBuffer *cb)
 {
+    if (!cb) {
+        THROW(ERROR_INVALID_ARGUMENT);
+        return 0;
+    }
     return (cb->head - cb->tail) & cb->mask;
 }
 
@@ -78,6 +92,11 @@ uint32_t circular_buffer_available(CircularBuffer *cb)
  */
 bool circular_buffer_put(CircularBuffer *cb, uint8_t data)
 {
+    if (!cb) {
+        THROW(ERROR_INVALID_ARGUMENT);
+        return false;
+    }
+
     if (circular_buffer_is_full(cb)) {
         return false;
     }
@@ -96,6 +115,11 @@ bool circular_buffer_put(CircularBuffer *cb, uint8_t data)
  */
 bool circular_buffer_get(CircularBuffer *cb, uint8_t *data)
 {
+    if (!cb || !data) {
+        THROW(ERROR_INVALID_ARGUMENT);
+        return false;
+    }
+
     if (circular_buffer_is_empty(cb)) {
         return false;
     }
@@ -110,7 +134,14 @@ bool circular_buffer_get(CircularBuffer *cb, uint8_t *data)
  *
  * @param cb Pointer to circular buffer structure
  */
-void circular_buffer_reset(CircularBuffer *cb) { cb->head = cb->tail = 0; }
+void circular_buffer_reset(CircularBuffer *cb)
+{
+    if (!cb) {
+        THROW(ERROR_INVALID_ARGUMENT);
+        return;
+    }
+    cb->head = cb->tail = 0;
+}
 
 /**
  * @brief Write multiple bytes to circular buffer
@@ -126,6 +157,11 @@ uint32_t circular_buffer_write(
     uint32_t len
 )
 {
+    if (!cb || !data) {
+        THROW(ERROR_INVALID_ARGUMENT);
+        return 0;
+    }
+
     uint32_t bytes_written = 0;
 
     while (bytes_written < len && !circular_buffer_is_full(cb)) {
@@ -149,6 +185,11 @@ uint32_t circular_buffer_write(
  */
 uint32_t circular_buffer_read(CircularBuffer *cb, uint8_t *data, uint32_t len)
 {
+    if (!cb || !data) {
+        THROW(ERROR_INVALID_ARGUMENT);
+        return 0;
+    }
+
     uint32_t bytes_read = 0;
 
     while (bytes_read < len && !circular_buffer_is_empty(cb)) {
@@ -170,5 +211,9 @@ uint32_t circular_buffer_read(CircularBuffer *cb, uint8_t *data, uint32_t len)
  */
 uint32_t circular_buffer_free_space(CircularBuffer *cb)
 {
+    if (!cb) {
+        THROW(ERROR_INVALID_ARGUMENT);
+        return 0;
+    }
     return (cb->size - 1) - ((cb->head - cb->tail) & cb->mask);
 }

--- a/src/util/error.h
+++ b/src/util/error.h
@@ -1,0 +1,133 @@
+/**
+ * @file error.h
+ * @brief Error handling utilities for PSLab firmware
+ *
+ * This header defines error codes and utility functions for error handling
+ * in the PSLab firmware. It wraps the CException library for structured
+ * exception handling and provides integration with standard errno codes.
+ */
+
+#ifndef PSLAB_ERROR_H
+#define PSLAB_ERROR_H
+
+#include "CException.h"
+#include <errno.h>
+#include <stdint.h>
+
+#define TRY Try
+#define CATCH Catch
+#define THROW Throw
+
+/**
+ * @brief PSLab-specific error codes
+ *
+ * These codes are used for domain-specific PSLab functionality.
+ * For system-level operations, prefer using standard errno codes.
+ */
+typedef enum {
+    ERROR_NONE,
+    ERROR_INVALID_ARGUMENT,
+    ERROR_OUT_OF_MEMORY,
+    ERROR_TIMEOUT,
+    ERROR_RESOURCE_BUSY,
+    ERROR_RESOURCE_UNAVAILABLE,
+    ERROR_HARDWARE_FAULT,
+    ERROR_CALIBRATION_FAILED,
+    ERROR_DEVICE_NOT_READY,
+    ERROR_UNKNOWN
+} Error;
+
+static inline char const *error_to_string(Error error)
+{
+    switch (error) {
+    case ERROR_NONE:
+        return "No error";
+    case ERROR_INVALID_ARGUMENT:
+        return "Invalid argument";
+    case ERROR_OUT_OF_MEMORY:
+        return "Out of memory";
+    case ERROR_TIMEOUT:
+        return "Operation timed out";
+    case ERROR_RESOURCE_BUSY:
+        return "Resource busy";
+    case ERROR_RESOURCE_UNAVAILABLE:
+        return "Resource unavailable";
+    case ERROR_HARDWARE_FAULT:
+        return "Hardware fault";
+    case ERROR_CALIBRATION_FAILED:
+        return "Calibration failed";
+    case ERROR_DEVICE_NOT_READY:
+        return "Device not ready";
+    case ERROR_UNKNOWN:
+    default:
+        return "Unknown error";
+    }
+}
+
+/**
+ * @brief Convert PSLab error to appropriate errno code
+ *
+ * @param error PSLab error code
+ * @return Corresponding errno value, or 0 for ERROR_NONE
+ */
+static inline int error_to_errno(Error error)
+{
+    switch (error) {
+    case ERROR_NONE:
+        return 0;
+    case ERROR_INVALID_ARGUMENT:
+        return EINVAL;
+    case ERROR_OUT_OF_MEMORY:
+        return ENOMEM;
+    case ERROR_TIMEOUT:
+        return ETIMEDOUT;
+    case ERROR_RESOURCE_BUSY:
+        return EBUSY;
+    case ERROR_RESOURCE_UNAVAILABLE:
+    case ERROR_HARDWARE_FAULT:
+    case ERROR_CALIBRATION_FAILED:
+        return EIO;
+    case ERROR_DEVICE_NOT_READY:
+        return EAGAIN;
+    case ERROR_UNKNOWN:
+    default:
+        return EIO;
+    }
+}
+
+/**
+ * @brief Convert errno to PSLab error code (best effort)
+ *
+ * @param errno_val errno value
+ * @return Corresponding PSLab error code
+ */
+static inline Error errno_to_error(int errno_val)
+{
+    switch (errno_val) {
+    case 0:
+        return ERROR_NONE;
+    case EINVAL:
+    case EDOM:
+    case ERANGE:
+        return ERROR_INVALID_ARGUMENT;
+    case ENOMEM:
+        return ERROR_OUT_OF_MEMORY;
+    case ETIMEDOUT:
+        return ERROR_TIMEOUT;
+    case EIO:
+    case ENODEV:
+    case ENXIO:
+        return ERROR_HARDWARE_FAULT;
+    case EAGAIN:
+#if EAGAIN != EWOULDBLOCK
+    case EWOULDBLOCK:
+#endif
+        return ERROR_DEVICE_NOT_READY;
+    case EBUSY:
+        return ERROR_RESOURCE_BUSY;
+    default:
+        return ERROR_UNKNOWN;
+    }
+}
+
+#endif // PSLAB_ERROR_H

--- a/tests/test_circular_buffer.c
+++ b/tests/test_circular_buffer.c
@@ -6,6 +6,7 @@
  * implementation used throughout the PSLab firmware.
  */
 
+#include "error.h"
 #include "unity.h"
 #include "util.h"
 #include <stdlib.h>
@@ -54,15 +55,20 @@ void test_circular_buffer_is_empty_when_initialized(void)
 // Test that non-power-of-two size results in unusable buffer
 void test_circular_buffer_init_non_power_of_two_size(void)
 {
+    Error exc;
     CircularBuffer cb;
     uint8_t buffer[30]; // Not a power of two
 
-    circular_buffer_init(&cb, buffer, sizeof(buffer));
-
-    TEST_ASSERT_NULL(cb.buffer); // Should not initialize properly
-    TEST_ASSERT_EQUAL_UINT32(0, cb.head);
-    TEST_ASSERT_EQUAL_UINT32(0, cb.tail);
-    TEST_ASSERT_EQUAL_UINT32(0, cb.size);
+    TRY
+    {
+        circular_buffer_init(&cb, buffer, sizeof(buffer));
+    }
+    CATCH(exc)
+    {
+        // Expected error for non-power-of-two size
+        TEST_ASSERT_EQUAL(ERROR_INVALID_ARGUMENT, exc);
+        return;
+    }
 }
 
 // Test single byte operations


### PR DESCRIPTION
This pull request adds exception handling via CException.

## Summary by Sourcery

Introduce structured exception handling using CException across the firmware and unify error propagation through TRY/CATCH/THROW macros.

New Features:
- Integrate the CException library and provide PSLab wrappers in error.h with TRY/CATCH/THROW macros and a domain-specific Error enum
- Add newlib reentrant syscall stubs (_getpid_r and _kill_r) to support CException in bare-metal environment

Enhancements:
- Refactor UART, ADC, USB, circular buffer, platform init, LED, and system bus modules to use THROW for error conditions instead of silent failures or infinite loops
- Provide utility functions to convert between PSLab Error codes and standard errno values
- Raise default log level from INFO to DEBUG for increased verbosity

Build:
- Add CException as a static library target and link it into pslab-util
- Update CMakeLists to include conditional test and target directories and link against cexception

Documentation:
- Add error_handling.md outlining the new error handling system
- Update LICENSE.md to include CException licensing entry

Tests:
- Modify circular buffer unit tests to use TRY/CATCH for invalid-size initialization scenarios