### PR TITLE
Build pslab-system as static library

### DIFF
--- a/src/CMakeLists.target.txt
+++ b/src/CMakeLists.target.txt
@@ -1,28 +1,7 @@
 # Source directory configuration for target builds
 
-add_executable(pslab-mini-firmware)
-
-target_include_directories(pslab-mini-firmware
-    PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}
-)
-
 # Add subdirectories
 add_subdirectory(application)
 add_subdirectory(system)
 add_subdirectory(platform)
 add_subdirectory(util)
-
-# Link the platform library
-target_link_libraries(pslab-mini-firmware
-    PRIVATE
-        pslab-platform
-        pslab-util
-)
-
-# Add platform-specific linker script
-if(PLATFORM STREQUAL "h563xx")
-    stm32_add_linker_script(pslab-mini-firmware PRIVATE platform/h563xx/STM32H563ZITX_FLASH.ld)
-    stm32_print_size_of_target(pslab-mini-firmware)
-    stm32_generate_srec_file(pslab-mini-firmware)
-endif()

--- a/src/application/CMakeLists.txt
+++ b/src/application/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Application layer - only built for target
+add_executable(pslab-mini-firmware)
 
 target_sources(pslab-mini-firmware
     PRIVATE
@@ -9,3 +10,16 @@ target_include_directories(pslab-mini-firmware
     PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}
 )
+
+target_link_libraries(pslab-mini-firmware
+    PRIVATE
+        pslab-util
+        pslab-system
+)
+
+# Add platform-specific linker script
+if(PLATFORM STREQUAL "h563xx")
+    stm32_add_linker_script(pslab-mini-firmware PRIVATE ../platform/h563xx/STM32H563ZITX_FLASH.ld)
+    stm32_print_size_of_target(pslab-mini-firmware)
+    stm32_generate_srec_file(pslab-mini-firmware)
+endif()

--- a/src/system/CMakeLists.target.txt
+++ b/src/system/CMakeLists.target.txt
@@ -1,18 +1,33 @@
 # System layer - target build configuration
+add_library(pslab-system STATIC)
 
 add_subdirectory(bus)
 add_subdirectory(adc)
 add_subdirectory(timer)
 
-target_sources(pslab-mini-firmware
+target_sources(pslab-system
     PRIVATE
         led.c
         system.c
+    # Needed by newlib when linking application
+    PUBLIC
         stubs.c
         syscalls.c
 )
 
-target_include_directories(pslab-mini-firmware
+target_include_directories(pslab-system
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+target_link_libraries(pslab-system
     PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}
+        pslab-util
+        pslab-platform
+)
+
+# Propagate TinyUSB desciptor callbacks to application
+target_link_options(pslab-system
+    INTERFACE
+        $<TARGET_PROPERTY:pslab-platform,INTERFACE_LINK_OPTIONS>
 )

--- a/src/system/adc/CMakeLists.target.txt
+++ b/src/system/adc/CMakeLists.target.txt
@@ -1,11 +1,11 @@
 # ADC subsystem - target build configuration
 
-target_sources(pslab-mini-firmware
+target_sources(pslab-system
     PRIVATE
         adc.c
 )
 
-target_include_directories(pslab-mini-firmware
-    PRIVATE
+target_include_directories(pslab-system
+    PUBLIC
         ${CMAKE_CURRENT_SOURCE_DIR}
 )

--- a/src/system/adc/adc.h
+++ b/src/system/adc/adc.h
@@ -17,8 +17,6 @@
 
 #include <stdint.h>
 
-#include "adc_ll.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/system/bus/CMakeLists.target.txt
+++ b/src/system/bus/CMakeLists.target.txt
@@ -1,12 +1,12 @@
 # Bus subsystem - target build configuration
 
-target_sources(pslab-mini-firmware
+target_sources(pslab-system
     PRIVATE
         uart.c
         usb.c
 )
 
-target_include_directories(pslab-mini-firmware
-    PRIVATE
+target_include_directories(pslab-system
+    PUBLIC
         ${CMAKE_CURRENT_SOURCE_DIR}
 )

--- a/src/system/timer/CMakeLists.target.txt
+++ b/src/system/timer/CMakeLists.target.txt
@@ -1,11 +1,11 @@
 # TIM subsystem - target build configuration
 
-target_sources(pslab-mini-firmware
+target_sources(pslab-system
     PRIVATE
         tim.c
 )
 
-target_include_directories(pslab-mini-firmware
-    PRIVATE
+target_include_directories(pslab-system
+    PUBLIC
         ${CMAKE_CURRENT_SOURCE_DIR}
 )


### PR DESCRIPTION
This PR refactors the build system to build the system layer as a static library, pslab-system.

This requires propagating TinyUSB's descriptor callbacks from pslab-platform through pslab-system up to the application, where they are needed at link time.

syscalls.c and stubs.c are made public, as newlib needs them at link time.

## Summary by Sourcery

Refactor the build to compile the system layer as a static library and update the application build accordingly

Enhancements:
- Propagate TinyUSB descriptor callbacks through pslab-system to the application
- Expose syscalls.c and stubs.c publicly for newlib linking
- Remove redundant header include (adc_ll.h) from adc.h

Build:
- Build the system layer as a static library (pslab-system)
- Update application CMakeLists to link against pslab-system and add platform-specific linker script handling