### PR TITLE
Add CException to clang-tidy system headers

### DIFF
--- a/cmake/pslab-common.cmake
+++ b/cmake/pslab-common.cmake
@@ -88,6 +88,7 @@ function(setup_code_quality_targets)
                 --extra-arg=-isystem${CMAKE_SOURCE_DIR}/lib/STM32H5_CMSIS_HAL-1.5.0/Drivers/STM32H5xx_HAL_Driver/Inc
                 --extra-arg=-isystem${CMAKE_SOURCE_DIR}/lib/STM32H5_CMSIS_HAL-1.5.0/Drivers/STM32H5xx_HAL_Driver/Inc/Legacy
                 --extra-arg=-isystem${CMAKE_SOURCE_DIR}/lib/tinyusb-0.18.0/src
+                --extra-arg=-isystem${CMAKE_SOURCE_DIR}/lib/CException-1.3.4
                 --extra-arg-before=-Qunused-arguments
                 --warnings-as-errors=*
                 ${ALL_C_SOURCE_FILES}


### PR DESCRIPTION
This PR adds CException to clang-tidy's system headers, which facilitates these headers being visible to the linter and not treated as part of the codebase.

This was missed when CException was added in #87. Linting apparently works without this, but adding them to system headers is correct nonetheless.