### PR TITLE
feat: Added ADC Multimode driver

### DIFF
--- a/src/application/main.c
+++ b/src/application/main.c
@@ -127,34 +127,31 @@ int main(void) // NOLINT
         if (g_adc_ready) {
             g_adc_ready = false;
             LED_toggle();
-            uint32_t buf[ADC_BUFFER_SIZE] = { 0 };
-            uint32_t samples_read = ADC_read(hadc, buf, ADC_BUFFER_SIZE);
-
-            if (samples_read > 0) {
-
+            uint32_t num_samples = sizeof(g_adc_buffer_data);
+            if (num_samples >
+                1) // As the g_adc_buffer_data is initialised with a single
+                   // element so it needs to be greater than that
+            {
                 if (CONVERSION_ADC == 2) {
-                    uint32_t num_samples = samples_read;
-                    uint16_t adc1_buf[num_samples];
-                    uint16_t adc2_buf[num_samples];
                     for (uint32_t i = 0; i < num_samples; i++) {
-                        adc2_buf[i] =
-                            (buf[i] >> 16) & 0xFFF; // Extract ADC2 data
-                        adc1_buf[i] = buf[i] & 0xFFF; // Extract ADC1 data
+                        uint16_t adc2_value = (g_adc_buffer_data[i] >> 16) &
+                                              0xFFF; // Extract ADC2 data
+                        uint16_t adc1_value =
+                            g_adc_buffer_data[i] & 0xFFF; // Extract ADC1 data
                         LOG_INFO(
                             "Sample %u: ADC1: %u, ADC2: %u",
                             i + 1,
-                            adc1_buf[i],
-                            adc2_buf[i]
+                            adc1_value,
+                            adc2_value
                         );
                     }
                 } else {
-                    uint32_t num_samples = samples_read;
                     for (uint32_t i = 0; i < num_samples; i++) {
-                        LOG_INFO("Sample %u: %u", i + 1, buf[i]);
+                        LOG_INFO("Sample %u: %u", i + 1, g_adc_buffer_data[i]);
                     }
                 }
             } else {
-                LOG_ERROR("ADC read failed or no data available");
+                LOG_ERROR("No data available");
             }
             ADC_restart(hadc); // Restart ADC for next conversion
         }

--- a/src/application/main.c
+++ b/src/application/main.c
@@ -127,9 +127,8 @@ int main(void) // NOLINT
         if (g_adc_ready) {
             g_adc_ready = false;
             LED_toggle();
-            uint32_t buf_size = sizeof(g_adc_buffer_data);
             if (CONVERSION_ADC == 2) {
-                for (uint32_t i = 0; i < buf_size; i++) {
+                for (uint32_t i = 0; i < ADC_BUFFER_SIZE; i++) {
                     uint16_t adc2_value = (g_adc_buffer_data[i] >> 16) &
                                           0xFFF; // Extract ADC2 data
                     uint16_t adc1_value =
@@ -142,7 +141,7 @@ int main(void) // NOLINT
                     );
                 }
             } else {
-                for (uint32_t i = 0; i < buf_size; i++) {
+                for (uint32_t i = 0; i < ADC_BUFFER_SIZE; i++) {
                     LOG_INFO("Sample %u: %u", i + 1, g_adc_buffer_data[i]);
                 }
             }

--- a/src/application/main.c
+++ b/src/application/main.c
@@ -127,31 +127,24 @@ int main(void) // NOLINT
         if (g_adc_ready) {
             g_adc_ready = false;
             LED_toggle();
-            uint32_t num_samples = sizeof(g_adc_buffer_data);
-            if (num_samples >
-                1) // As the g_adc_buffer_data is initialised with a single
-                   // element so it needs to be greater than that
-            {
-                if (CONVERSION_ADC == 2) {
-                    for (uint32_t i = 0; i < num_samples; i++) {
-                        uint16_t adc2_value = (g_adc_buffer_data[i] >> 16) &
-                                              0xFFF; // Extract ADC2 data
-                        uint16_t adc1_value =
-                            g_adc_buffer_data[i] & 0xFFF; // Extract ADC1 data
-                        LOG_INFO(
-                            "Sample %u: ADC1: %u, ADC2: %u",
-                            i + 1,
-                            adc1_value,
-                            adc2_value
-                        );
-                    }
-                } else {
-                    for (uint32_t i = 0; i < num_samples; i++) {
-                        LOG_INFO("Sample %u: %u", i + 1, g_adc_buffer_data[i]);
-                    }
+            uint32_t buf_size = sizeof(g_adc_buffer_data);
+            if (CONVERSION_ADC == 2) {
+                for (uint32_t i = 0; i < buf_size; i++) {
+                    uint16_t adc2_value = (g_adc_buffer_data[i] >> 16) &
+                                          0xFFF; // Extract ADC2 data
+                    uint16_t adc1_value =
+                        g_adc_buffer_data[i] & 0xFFF; // Extract ADC1 data
+                    LOG_INFO(
+                        "Sample %u: ADC1: %u, ADC2: %u",
+                        i + 1,
+                        adc1_value,
+                        adc2_value
+                    );
                 }
             } else {
-                LOG_ERROR("No data available");
+                for (uint32_t i = 0; i < buf_size; i++) {
+                    LOG_INFO("Sample %u: %u", i + 1, g_adc_buffer_data[i]);
+                }
             }
             ADC_restart(hadc); // Restart ADC for next conversion
         }

--- a/src/platform/adc_ll.h
+++ b/src/platform/adc_ll.h
@@ -40,7 +40,7 @@ typedef void (*ADC_LL_CompleteCallback)(ADC_Num adc_num);
  */
 void ADC_LL_init(
     ADC_Num adc_num,
-    uint16_t *adc_buf,
+    uint32_t *adc_buf,
     uint32_t sz,
     ADC_LL_TriggerSource adc_trigger_timer
 );

--- a/src/platform/adc_ll.h
+++ b/src/platform/adc_ll.h
@@ -17,6 +17,8 @@ typedef enum {
     ADC_TRIGGER_TIMER7 = 7
 } ADC_LL_TriggerSource;
 
+typedef enum { ADC_1 = 0, ADC_2 = 1, ADC_1_2 = 2, ADC_COUNT = 3 } ADC_Num;
+
 /**
  * @brief Callback function type for ADC complete events.
  *
@@ -24,7 +26,7 @@ typedef enum {
  * It receives the DMA position as an argument.
  * @param dma_pos Current DMA position.
  */
-typedef void (*ADC_LL_CompleteCallback)(void);
+typedef void (*ADC_LL_CompleteCallback)(ADC_Num adc_num);
 
 /**
  * @brief Initializes the ADC1 peripheral.
@@ -37,6 +39,7 @@ typedef void (*ADC_LL_CompleteCallback)(void);
  * @param adc_trigger_timer Trigger source for the ADC (e.g., timer).
  */
 void ADC_LL_init(
+    ADC_Num adc_num,
     uint16_t *adc_buf,
     uint32_t sz,
     ADC_LL_TriggerSource adc_trigger_timer
@@ -48,7 +51,7 @@ void ADC_LL_init(
  * This function deinitializes the ADC peripheral and releases any resources
  * used.
  */
-void ADC_LL_deinit(void);
+void ADC_LL_deinit(ADC_Num adc_num);
 
 /**
  * @brief Starts the ADC conversion.
@@ -56,7 +59,7 @@ void ADC_LL_deinit(void);
  * This function starts the ADC conversion process. It must be called after
  * the ADC has been initialized and configured.
  */
-void ADC_LL_start(void);
+void ADC_LL_start(ADC_Num adc_num);
 
 /**
  * @brief Stops the ADC conversion.
@@ -64,7 +67,7 @@ void ADC_LL_start(void);
  * This function stops the ongoing ADC conversion process. It can be called
  * to halt conversions before deinitializing the ADC or when no longer needed.
  */
-void ADC_LL_stop(void);
+void ADC_LL_stop(ADC_Num adc_num);
 
 /**
  * @brief Sets the callback for ADC completion events.
@@ -74,6 +77,9 @@ void ADC_LL_stop(void);
  *
  * @param callback Pointer to the callback function to be set.
  */
-void ADC_LL_set_complete_callback(ADC_LL_CompleteCallback callback);
+void ADC_LL_set_complete_callback(
+    ADC_Num adc_num,
+    ADC_LL_CompleteCallback callback
+);
 
 #endif // ADC_LL_H

--- a/src/platform/h563xx/adc_ll.c
+++ b/src/platform/h563xx/adc_ll.c
@@ -22,6 +22,11 @@
 
 enum { ADC_IRQ_PRIORITY = 1 }; // ADC interrupt priority
 
+bool g_adc1_initialized = false; // Flag to indicate if ADC1 is initialized
+bool g_adc2_initialized = false; // Flag to indicate if ADC2 is initialized
+bool g_adc_multimode =
+    true; // Flag to indicate if ADC1 and ADC2 are in multimode
+
 typedef struct {
     ADC_HandleTypeDef *adc_handle; // Pointer to the ADC handle
     ADC_ChannelConfTypeDef adc_config; // ADC channel configuration
@@ -30,19 +35,45 @@ typedef struct {
     uint32_t adc_buffer_size; // Size of the ADC data buffer
     ADC_LL_CompleteCallback
         adc_complete_callback; // Callback for ADC completion
-    bool initialized; // Flag to indicate if the ADC is initialized
 } ADCInstance;
 
-static ADC_HandleTypeDef g_hadc = { nullptr };
+static ADC_HandleTypeDef g_hadc1 = { nullptr };
+static ADC_HandleTypeDef g_hadc2 = { nullptr };
 
-static ADC_ChannelConfTypeDef g_config = { 0 };
+static ADC_ChannelConfTypeDef g_config1 = { 0 };
+static ADC_ChannelConfTypeDef g_config2 = { 0 };
 
-static DMA_HandleTypeDef g_hdma_adc = { nullptr };
+static DMA_HandleTypeDef g_hdma_adc1 = { nullptr };
+static DMA_HandleTypeDef g_hdma_adc2 = { nullptr };
 
-static ADCInstance g_adc_instance = {
-    .adc_handle = &g_hadc,
-    .dma_handle = &g_hdma_adc,
+static ADCInstance g_adc_instances[ADC_COUNT] = {
+    [ADC_1] = {
+        .adc_handle = &g_hadc1,
+        .dma_handle = &g_hdma_adc1,
+    },
+    [ADC_2] = {
+        .adc_handle = &g_hadc2,
+        .dma_handle = &g_hdma_adc2,
+    },
+    [ADC_1_2] = {
+        .adc_handle = &g_hadc1, // Use ADC1 for dual mode
+        .dma_handle = &g_hdma_adc1,
+    }
 };
+
+static ADC_Num get_adc_num_from_handle(ADC_HandleTypeDef *hadc)
+{
+    if (hadc->Instance == ADC1 || !g_adc_multimode) {
+        return ADC_1;
+    }
+    if (hadc->Instance == ADC2 || !g_adc_multimode) {
+        return ADC_2;
+    }
+    if (hadc->Instance == ADC1 || g_adc_multimode) {
+        return ADC_1_2;
+    }
+    return ADC_COUNT; // Invalid ADC instance
+}
 
 /**
  * @brief Initializes the ADC MSP (MCU Support Package).
@@ -56,47 +87,105 @@ void HAL_ADC_MspInit(ADC_HandleTypeDef *hadc)
 {
     (void)hadc; // Suppress unused parameter warning
     GPIO_InitTypeDef gpio_init = { 0 };
+    if (hadc->Instance == ADC1) {
+        // Enable ADC1 clock
+        __HAL_RCC_ADC_CLK_ENABLE();
+        // Enable GPIOA clock
+        __HAL_RCC_GPIOA_CLK_ENABLE();
+        // Enable DMA1 clock
+        __HAL_RCC_GPDMA1_CLK_ENABLE();
+        if (g_adc_multimode) {
+            // Configure GPIO pin for ADC1_IN14 (PA14)
+            gpio_init.Pin = GPIO_PIN_14; // PA14
+        } else {
+            // Configure GPIO pin for ADC1_IN0 (PA0)
+            gpio_init.Pin = GPIO_PIN_0; // PA0
+        }
+        gpio_init.Mode = GPIO_MODE_ANALOG;
+        gpio_init.Pull = GPIO_NOPULL;
+        HAL_GPIO_Init(GPIOA, &gpio_init);
 
-    // Enable ADC1 clock
-    __HAL_RCC_ADC_CLK_ENABLE();
-    // Enable GPIOA clock
-    __HAL_RCC_GPIOA_CLK_ENABLE();
-    // Enable DMA1 clock
-    __HAL_RCC_GPDMA1_CLK_ENABLE();
+        /*DMA for the ADC*/
+        g_hdma_adc1.Instance = GPDMA1_Channel6; // DMA channel for ADC1
+        g_hdma_adc1.Init.Request = GPDMA1_REQUEST_ADC1;
+        g_hdma_adc1.Init.BlkHWRequest = DMA_BREQ_SINGLE_BURST;
+        g_hdma_adc1.Init.Direction = DMA_PERIPH_TO_MEMORY;
+        g_hdma_adc1.Init.SrcInc = DMA_SINC_FIXED;
+        g_hdma_adc1.Init.DestInc = DMA_DINC_INCREMENTED;
+        g_hdma_adc1.Init.SrcDataWidth = DMA_SRC_DATAWIDTH_HALFWORD;
+        g_hdma_adc1.Init.DestDataWidth = DMA_DEST_DATAWIDTH_HALFWORD;
+        g_hdma_adc1.Init.Priority = DMA_LOW_PRIORITY_LOW_WEIGHT;
+        g_hdma_adc1.Init.SrcBurstLength = 1;
+        g_hdma_adc1.Init.DestBurstLength = 1;
+        g_hdma_adc1.Init.TransferAllocatedPort =
+            (DMA_SRC_ALLOCATED_PORT0 | DMA_DEST_ALLOCATED_PORT0);
+        g_hdma_adc1.Init.TransferEventMode = DMA_TCEM_BLOCK_TRANSFER;
+        g_hdma_adc1.Init.Mode = DMA_NORMAL;
+        if (HAL_DMA_Init(&g_hdma_adc1) != HAL_OK) {
+            THROW(ERROR_HARDWARE_FAULT);
+        }
+        __HAL_LINKDMA(&g_hadc1, DMA_Handle, g_hdma_adc1);
 
-    // Configure GPIO pin for ADC1_IN0 (PA0)
-    gpio_init.Pin = GPIO_PIN_0; // PA0
-    gpio_init.Mode = GPIO_MODE_ANALOG;
-    gpio_init.Pull = GPIO_NOPULL;
-    HAL_GPIO_Init(GPIOA, &gpio_init);
+        // Enable ADC1 interrupt
+        HAL_NVIC_SetPriority(ADC1_IRQn, ADC_IRQ_PRIORITY, 0);
+        HAL_NVIC_EnableIRQ(ADC1_IRQn);
 
-    /*DMA for the ADC*/
-    g_hdma_adc.Instance = GPDMA1_Channel6; // DMA channel for ADC1
-    g_hdma_adc.Init.Request = GPDMA1_REQUEST_ADC1;
-    g_hdma_adc.Init.BlkHWRequest = DMA_BREQ_SINGLE_BURST;
-    g_hdma_adc.Init.Direction = DMA_PERIPH_TO_MEMORY;
-    g_hdma_adc.Init.SrcInc = DMA_SINC_FIXED;
-    g_hdma_adc.Init.DestInc = DMA_DINC_INCREMENTED;
-    g_hdma_adc.Init.SrcDataWidth = DMA_SRC_DATAWIDTH_HALFWORD;
-    g_hdma_adc.Init.DestDataWidth = DMA_DEST_DATAWIDTH_HALFWORD;
-    g_hdma_adc.Init.Priority = DMA_LOW_PRIORITY_LOW_WEIGHT;
-    g_hdma_adc.Init.SrcBurstLength = 1;
-    g_hdma_adc.Init.DestBurstLength = 1;
-    g_hdma_adc.Init.TransferAllocatedPort =
-        (DMA_SRC_ALLOCATED_PORT0 | DMA_DEST_ALLOCATED_PORT0);
-    g_hdma_adc.Init.TransferEventMode = DMA_TCEM_BLOCK_TRANSFER;
-    g_hdma_adc.Init.Mode = DMA_NORMAL;
-    if (HAL_DMA_Init(&g_hdma_adc) != HAL_OK) {
-        THROW(ERROR_HARDWARE_FAULT);
+        HAL_NVIC_SetPriority(GPDMA1_Channel6_IRQn, ADC_IRQ_PRIORITY, 1);
+        HAL_NVIC_EnableIRQ(GPDMA1_Channel6_IRQn);
+    } else if (hadc->Instance == ADC2 || !g_adc_multimode) {
+        // Enable ADC2 clock
+        __HAL_RCC_ADC_CLK_ENABLE();
+        // Enable GPIOA clock
+        __HAL_RCC_GPIOA_CLK_ENABLE();
+        // Enable DMA1 clock
+        __HAL_RCC_GPDMA1_CLK_ENABLE();
+        // Configure GPIO pin for ADC2_IN1 (PA1)
+        GPIO_InitTypeDef gpio_init = { 0 };
+        gpio_init.Pin = GPIO_PIN_1; // PA1
+        gpio_init.Mode = GPIO_MODE_ANALOG;
+        gpio_init.Pull = GPIO_NOPULL;
+        HAL_GPIO_Init(GPIOA, &gpio_init);
+        /*DMA for the ADC*/
+        g_hdma_adc2.Instance = GPDMA1_Channel7; // DMA channel for ADC2
+        g_hdma_adc2.Init.Request = GPDMA1_REQUEST_ADC2;
+        g_hdma_adc2.Init.BlkHWRequest = DMA_BREQ_SINGLE_BURST;
+        g_hdma_adc2.Init.Direction = DMA_PERIPH_TO_MEMORY;
+        g_hdma_adc2.Init.SrcInc = DMA_SINC_FIXED;
+        g_hdma_adc2.Init.DestInc = DMA_DINC_INCREMENTED;
+        g_hdma_adc2.Init.SrcDataWidth = DMA_SRC_DATAWIDTH_HALFWORD;
+        g_hdma_adc2.Init.DestDataWidth = DMA_DEST_DATAWIDTH_HALFWORD;
+        g_hdma_adc2.Init.Priority = DMA_LOW_PRIORITY_LOW_WEIGHT;
+        g_hdma_adc2.Init.SrcBurstLength = 1;
+        g_hdma_adc2.Init.DestBurstLength = 1;
+        g_hdma_adc2.Init.TransferAllocatedPort =
+            (DMA_SRC_ALLOCATED_PORT0 | DMA_DEST_ALLOCATED_PORT0);
+        g_hdma_adc2.Init.TransferEventMode = DMA_TCEM_BLOCK_TRANSFER;
+        g_hdma_adc2.Init.Mode = DMA_NORMAL;
+        if (HAL_DMA_Init(&g_hdma_adc2) != HAL_OK) {
+            THROW(ERROR_HARDWARE_FAULT);
+        }
+
+        __HAL_LINKDMA(&g_hadc2, DMA_Handle, g_hdma_adc2);
+
+        // Enable ADC2 interrupt
+        HAL_NVIC_SetPriority(ADC2_IRQn, ADC_IRQ_PRIORITY, 0);
+        HAL_NVIC_EnableIRQ(ADC2_IRQn);
+
+        HAL_NVIC_SetPriority(GPDMA1_Channel7_IRQn, ADC_IRQ_PRIORITY, 1);
+        HAL_NVIC_EnableIRQ(GPDMA1_Channel7_IRQn);
     }
-    __HAL_LINKDMA(&g_hadc, DMA_Handle, g_hdma_adc);
 
-    // Enable ADC1 interrupt
-    HAL_NVIC_SetPriority(ADC1_IRQn, ADC_IRQ_PRIORITY, 0);
-    HAL_NVIC_EnableIRQ(ADC1_IRQn);
-
-    HAL_NVIC_SetPriority(GPDMA1_Channel6_IRQn, ADC_IRQ_PRIORITY, 1);
-    HAL_NVIC_EnableIRQ(GPDMA1_Channel6_IRQn);
+    else if (hadc->Instance == ADC2 || g_adc_multimode) {
+        // Configure GPIO pin for ADC2_IN7 (PA7)
+        GPIO_InitTypeDef gpio_init = { 0 };
+        gpio_init.Pin = GPIO_PIN_7; // PA7
+        gpio_init.Mode = GPIO_MODE_ANALOG;
+        gpio_init.Pull = GPIO_NOPULL;
+        HAL_GPIO_Init(GPIOA, &gpio_init);
+        // Enable ADC2 interrupt
+        HAL_NVIC_SetPriority(ADC2_IRQn, ADC_IRQ_PRIORITY, 0);
+        HAL_NVIC_EnableIRQ(ADC2_IRQn);
+    }
 }
 
 /**
@@ -108,6 +197,7 @@ void HAL_ADC_MspInit(ADC_HandleTypeDef *hadc)
  *
  */
 void ADC_LL_init(
+    ADC_Num adc_num,
     uint16_t *adc_buf,
     uint32_t sz,
     ADC_LL_TriggerSource adc_trigger_timer
@@ -118,80 +208,243 @@ void ADC_LL_init(
         return;
     }
 
-    if (g_adc_instance.initialized) {
-        THROW(ERROR_RESOURCE_BUSY);
-        return;
+    // Initialize the ADC handle
+    ADCInstance *instance = &g_adc_instances[adc_num];
+
+    if (adc_num == ADC_1) {
+        if (g_adc1_initialized) {
+            THROW(ERROR_RESOURCE_BUSY);
+            return;
+        }
+
+        instance->adc_handle->Instance = ADC1;
+        // Initialize the ADC peripheral
+        instance->adc_handle->Init.ClockPrescaler =
+            ADC_CLOCK_SYNC_PCLK_DIV1; // ADC clock and prescaler
+        instance->adc_handle->Init.Resolution = ADC_RESOLUTION_12B;
+        instance->adc_handle->Init.DataAlign = ADC_DATAALIGN_RIGHT;
+        instance->adc_handle->Init.ScanConvMode = DISABLE;
+        instance->adc_handle->Init.EOCSelection = ADC_EOC_SINGLE_CONV;
+        instance->adc_handle->Init.LowPowerAutoWait = DISABLE;
+        instance->adc_handle->Init.ContinuousConvMode = DISABLE;
+        instance->adc_handle->Init.NbrOfConversion = 1;
+        instance->adc_handle->Init.DiscontinuousConvMode = DISABLE;
+        if (adc_trigger_timer == ADC_TRIGGER_TIMER6) {
+            instance->adc_handle->Init.ExternalTrigConv =
+                ADC_EXTERNALTRIG_T6_TRGO;
+        } else {
+            THROW(ERROR_INVALID_ARGUMENT);
+            return;
+        }
+        instance->adc_handle->Init.ExternalTrigConvEdge =
+            ADC_EXTERNALTRIGCONVEDGE_RISING;
+        instance->adc_handle->Init.SamplingMode = ADC_SAMPLING_MODE_NORMAL;
+        instance->adc_handle->Init.DMAContinuousRequests = DISABLE;
+        instance->adc_handle->Init.Overrun = ADC_OVR_DATA_OVERWRITTEN;
+        instance->adc_handle->Init.OversamplingMode = DISABLE;
+
+        if (HAL_ADC_Init(instance->adc_handle) != HAL_OK) {
+            THROW(ERROR_HARDWARE_FAULT);
+        }
+
+        // Configure the ADC channel
+        instance->adc_config = g_config1;
+        if (!g_adc_multimode) {
+            g_config1.Channel = ADC_CHANNEL_0; // ADC1_IN0
+        } else if (g_adc_multimode) {
+            g_config1.Channel = ADC_CHANNEL_3; // ADC1_INP3
+        }
+        g_config1.Rank = ADC_REGULAR_RANK_1;
+        g_config1.SamplingTime = ADC_SAMPLETIME_12CYCLES_5;
+        g_config1.SingleDiff = ADC_SINGLE_ENDED; // Single-ended input
+        g_config1.OffsetNumber = ADC_OFFSET_NONE;
+        g_config1.Offset = 0;
+        if (HAL_ADC_ConfigChannel(instance->adc_handle, &g_config1) != HAL_OK) {
+            THROW(ERROR_HARDWARE_FAULT);
+        }
+
+        // Calibration with error handling
+        if (HAL_ADCEx_Calibration_Start(
+                instance->adc_handle, ADC_SINGLE_ENDED
+            ) != HAL_OK) {
+            THROW(ERROR_HARDWARE_FAULT);
+        } // Calibration
+        if (!g_adc_multimode) {
+            instance->adc_buffer_data = adc_buf;
+            instance->adc_buffer_size = sz;
+            g_adc1_initialized = true; // Set the ADC1 initialized flag
+        }
     }
 
-    // Initialize the ADC handle
-    ADCInstance *instance = &g_adc_instance;
+    else if (adc_num == ADC_2) {
+        if (g_adc2_initialized) {
+            THROW(ERROR_RESOURCE_BUSY);
+            return;
+        }
+        instance->adc_handle->Instance = ADC2;
+        // Initialize the ADC peripheral
+        instance->adc_handle->Init.ClockPrescaler =
+            ADC_CLOCK_SYNC_PCLK_DIV1; // ADC clock and prescaler
+        instance->adc_handle->Init.Resolution = ADC_RESOLUTION_12B;
+        instance->adc_handle->Init.DataAlign = ADC_DATAALIGN_RIGHT;
+        instance->adc_handle->Init.ScanConvMode = DISABLE;
+        instance->adc_handle->Init.EOCSelection = ADC_EOC_SINGLE_CONV;
+        instance->adc_handle->Init.LowPowerAutoWait = DISABLE;
+        instance->adc_handle->Init.ContinuousConvMode = DISABLE;
+        instance->adc_handle->Init.NbrOfConversion = 1;
+        instance->adc_handle->Init.DiscontinuousConvMode = DISABLE;
+        if (adc_trigger_timer == ADC_TRIGGER_TIMER6) {
+            instance->adc_handle->Init.ExternalTrigConv =
+                ADC_EXTERNALTRIG_T6_TRGO;
+        } else {
+            THROW(ERROR_INVALID_ARGUMENT);
+            return;
+        }
+        instance->adc_handle->Init.ExternalTrigConvEdge =
+            ADC_EXTERNALTRIGCONVEDGE_RISING;
+        instance->adc_handle->Init.SamplingMode = ADC_SAMPLING_MODE_NORMAL;
+        instance->adc_handle->Init.DMAContinuousRequests = DISABLE;
+        instance->adc_handle->Init.Overrun = ADC_OVR_DATA_OVERWRITTEN;
+        instance->adc_handle->Init.OversamplingMode = DISABLE;
 
-    // Initialize the ADC peripheral
-    instance->adc_handle->Instance = ADC1;
-    instance->adc_handle->Init.ClockPrescaler =
-        ADC_CLOCK_SYNC_PCLK_DIV1; // ADC clock and prescaler
-    instance->adc_handle->Init.Resolution = ADC_RESOLUTION_12B;
-    instance->adc_handle->Init.DataAlign = ADC_DATAALIGN_RIGHT;
-    instance->adc_handle->Init.ScanConvMode = DISABLE;
-    instance->adc_handle->Init.EOCSelection = ADC_EOC_SINGLE_CONV;
-    instance->adc_handle->Init.LowPowerAutoWait = DISABLE;
-    instance->adc_handle->Init.ContinuousConvMode = DISABLE;
-    instance->adc_handle->Init.NbrOfConversion = 1;
-    instance->adc_handle->Init.DiscontinuousConvMode = DISABLE;
-    if (adc_trigger_timer == ADC_TRIGGER_TIMER6) {
-        instance->adc_handle->Init.ExternalTrigConv = ADC_EXTERNALTRIG_T6_TRGO;
-    } else {
+        if (HAL_ADC_Init(instance->adc_handle) != HAL_OK) {
+            THROW(ERROR_HARDWARE_FAULT);
+        }
+
+        // Configure the ADC channel
+        instance->adc_config = g_config2;
+        g_config2.Channel = ADC_CHANNEL_1; // ADC2_IN1
+        g_config2.Rank = ADC_REGULAR_RANK_1;
+        g_config2.SamplingTime = ADC_SAMPLETIME_12CYCLES_5;
+        g_config2.SingleDiff = ADC_SINGLE_ENDED; // Single-ended input
+        g_config2.OffsetNumber = ADC_OFFSET_NONE;
+        g_config2.Offset = 0;
+        if (HAL_ADC_ConfigChannel(instance->adc_handle, &g_config2) != HAL_OK) {
+            THROW(ERROR_HARDWARE_FAULT);
+        }
+
+        // Calibration with error handling
+        if (HAL_ADCEx_Calibration_Start(
+                instance->adc_handle, ADC_SINGLE_ENDED
+            ) != HAL_OK) {
+            THROW(ERROR_HARDWARE_FAULT);
+        } // Calibration
+        if (!g_adc_multimode) {
+            instance->adc_buffer_data = adc_buf;
+            instance->adc_buffer_size = sz;
+            g_adc2_initialized = true; // Set the ADC1 initialized flag
+        }
+    }
+
+    else if (adc_num == ADC_1_2) {
+        if (g_adc1_initialized || g_adc2_initialized) {
+            THROW(ERROR_RESOURCE_BUSY);
+            return;
+        }
+
+        g_adc_multimode = true; // Set multimode flag
+
+        ADC_LL_init(ADC_1, adc_buf, sz, adc_trigger_timer);
+
+        instance->adc_handle->Instance = ADC2;
+        // Initialize the ADC peripheral
+        instance->adc_handle->Init.ClockPrescaler =
+            ADC_CLOCK_SYNC_PCLK_DIV1; // ADC clock and prescaler
+        instance->adc_handle->Init.Resolution = ADC_RESOLUTION_12B;
+        instance->adc_handle->Init.DataAlign = ADC_DATAALIGN_RIGHT;
+        instance->adc_handle->Init.ScanConvMode = DISABLE;
+        instance->adc_handle->Init.EOCSelection = ADC_EOC_SINGLE_CONV;
+        instance->adc_handle->Init.LowPowerAutoWait = DISABLE;
+        instance->adc_handle->Init.ContinuousConvMode = DISABLE;
+        instance->adc_handle->Init.NbrOfConversion = 1;
+        instance->adc_handle->Init.DiscontinuousConvMode = DISABLE;
+        if (adc_trigger_timer == ADC_TRIGGER_TIMER6) {
+            instance->adc_handle->Init.ExternalTrigConv =
+                ADC_EXTERNALTRIG_T6_TRGO;
+        } else {
+            THROW(ERROR_INVALID_ARGUMENT);
+            return;
+        }
+        instance->adc_handle->Init.ExternalTrigConvEdge =
+            ADC_EXTERNALTRIGCONVEDGE_RISING;
+        instance->adc_handle->Init.SamplingMode = ADC_SAMPLING_MODE_NORMAL;
+        instance->adc_handle->Init.DMAContinuousRequests = DISABLE;
+        instance->adc_handle->Init.Overrun = ADC_OVR_DATA_OVERWRITTEN;
+        instance->adc_handle->Init.OversamplingMode = DISABLE;
+
+        if (HAL_ADC_Init(instance->adc_handle) != HAL_OK) {
+            THROW(ERROR_HARDWARE_FAULT);
+        }
+
+        // Configure the ADC channel
+        instance->adc_config = g_config2;
+        g_config2.Channel = ADC_CHANNEL_7; // ADC2_IN7
+        g_config2.Rank = ADC_REGULAR_RANK_1;
+        g_config2.SamplingTime = ADC_SAMPLETIME_12CYCLES_5;
+        g_config2.SingleDiff = ADC_SINGLE_ENDED; // Single-ended input
+        g_config2.OffsetNumber = ADC_OFFSET_NONE;
+        g_config2.Offset = 0;
+        if (HAL_ADC_ConfigChannel(instance->adc_handle, &g_config2) != HAL_OK) {
+            THROW(ERROR_HARDWARE_FAULT);
+        }
+
+        // Calibration with error handling
+        if (HAL_ADCEx_Calibration_Start(
+                instance->adc_handle, ADC_SINGLE_ENDED
+            ) != HAL_OK) {
+            THROW(ERROR_HARDWARE_FAULT);
+        } // Calibration
+
+        ADC_MultiModeTypeDef multimode_config = { 0 };
+        multimode_config.Mode = ADC_DUALMODE_INTERL;
+        multimode_config.DMAAccessMode = ADC_DMAACCESSMODE_12_10_BITS;
+        multimode_config.TwoSamplingDelay = ADC_TWOSAMPLINGDELAY_12CYCLES;
+
+        if (HAL_ADCEx_MultiModeConfigChannel(&g_hadc1, &multimode_config) !=
+            HAL_OK) {
+            THROW(ERROR_HARDWARE_FAULT);
+        } // Configure multimode
+        instance->adc_handle =
+            &g_hadc1; // Use ADC1 handle for multimode(adding this again here to
+                      // ensure that when this pointer is called later for
+                      // example in ADC_LL_start, it points to ADC1 handle)
+        instance->adc_buffer_data = adc_buf;
+        instance->adc_buffer_size = sz;
+        g_adc1_initialized = true; // Set the ADC1 initialized flag
+        g_adc2_initialized = true; // Set the ADC2 initialized flag
+    }
+
+    else {
         THROW(ERROR_INVALID_ARGUMENT);
         return;
     }
-    instance->adc_handle->Init.ExternalTrigConvEdge =
-        ADC_EXTERNALTRIGCONVEDGE_RISING;
-    instance->adc_handle->Init.SamplingMode = ADC_SAMPLING_MODE_NORMAL;
-    instance->adc_handle->Init.DMAContinuousRequests = DISABLE;
-    instance->adc_handle->Init.Overrun = ADC_OVR_DATA_OVERWRITTEN;
-    instance->adc_handle->Init.OversamplingMode = DISABLE;
-
-    if (HAL_ADC_Init(&g_hadc) != HAL_OK) {
-        THROW(ERROR_HARDWARE_FAULT);
-    }
-
-    // Configure the ADC channel
-    instance->adc_config = g_config;
-    g_config.Channel = ADC_CHANNEL_0; // ADC1_IN0
-    g_config.Rank = ADC_REGULAR_RANK_1;
-    g_config.SamplingTime = ADC_SAMPLETIME_12CYCLES_5;
-    g_config.SingleDiff = ADC_SINGLE_ENDED; // Single-ended input
-    g_config.OffsetNumber = ADC_OFFSET_NONE;
-    g_config.Offset = 0;
-    if (HAL_ADC_ConfigChannel(instance->adc_handle, &g_config) != HAL_OK) {
-        THROW(ERROR_HARDWARE_FAULT);
-    }
-
-    // Calibration with error handling
-    if (HAL_ADCEx_Calibration_Start(&g_hadc, ADC_SINGLE_ENDED) != HAL_OK) {
-        THROW(ERROR_HARDWARE_FAULT);
-    } // Calibration
-
-    // Set the ADC buffer and size
-    instance->adc_buffer_data = adc_buf;
-    instance->adc_buffer_size = sz;
-    instance->initialized = true;
 }
 
 /**
  * @brief Deinitializes the ADC
  *
  */
-void ADC_LL_deinit(void)
+void ADC_LL_deinit(ADC_Num adc_num)
 {
-    if (!g_adc_instance.initialized) {
-        THROW(ERROR_RESOURCE_UNAVAILABLE);
+    if (adc_num >= ADC_COUNT) {
+        THROW(ERROR_INVALID_ARGUMENT);
         return;
     }
 
-    ADCInstance *instance = &g_adc_instance;
+    ADCInstance *instance = &g_adc_instances[adc_num];
     // Stop the ADC conversion;
-    HAL_NVIC_DisableIRQ(ADC1_IRQn); // Disable ADC1 interrupt
+    if (adc_num == ADC_1) {
+        HAL_NVIC_DisableIRQ(ADC1_IRQn); // Disable ADC1 interrupt
+        g_adc1_initialized = false; // Clear the ADC1 initialized flag
+    } else if (adc_num == ADC_2) {
+        HAL_NVIC_DisableIRQ(ADC2_IRQn); // Disable ADC2 interrupt
+        g_adc2_initialized = false; // Clear the ADC2 initialized flag
+    } else if (adc_num == ADC_1_2) {
+        HAL_NVIC_DisableIRQ(ADC1_IRQn); // Disable ADC1 interrupt
+        HAL_NVIC_DisableIRQ(ADC2_IRQn); // Disable ADC2 interrupt
+        g_adc1_initialized = false; // Clear the ADC1 initialized flag
+        g_adc2_initialized = false; // Clear the ADC2 initialized flag
+    }
 
     // Deinitialize the ADC peripheral
     if (HAL_ADC_DeInit(instance->adc_handle) != HAL_OK) {
@@ -201,7 +454,6 @@ void ADC_LL_deinit(void)
     instance->adc_buffer_data = nullptr;
     instance->adc_buffer_size = 0;
     instance->adc_complete_callback = nullptr; // Clear the callback
-    instance->initialized = false;
 }
 
 /**
@@ -211,14 +463,17 @@ void ADC_LL_deinit(void)
  * the ADC has been initialized and configured.
  *
  */
-void ADC_LL_start(void)
+void ADC_LL_start(ADC_Num adc_num)
 {
-    __HAL_ADC_CLEAR_FLAG(&g_hadc, ADC_FLAG_OVR); // Clear any previous flags
+    ADCInstance *instance = &g_adc_instances[adc_num];
+    __HAL_ADC_CLEAR_FLAG(
+        instance->adc_handle, ADC_FLAG_OVR
+    ); // Clear any previous flags
 
     if (HAL_ADC_Start_DMA(
-            &g_hadc,
-            (uint32_t *)g_adc_instance.adc_buffer_data,
-            g_adc_instance.adc_buffer_size
+            instance->adc_handle,
+            (uint32_t *)instance->adc_buffer_data,
+            instance->adc_buffer_size
         ) != HAL_OK) {
         THROW(ERROR_HARDWARE_FAULT);
     } // Start ADC in DMA mode
@@ -231,14 +486,28 @@ void ADC_LL_start(void)
  * to halt conversions before deinitializing the ADC or when no longer needed.
  *
  */
-void ADC_LL_stop(void)
+void ADC_LL_stop(ADC_Num adc_num)
 {
-    // Stop the ADC conversion
-    if (HAL_ADC_Stop_DMA(&g_hadc) != HAL_OK) {
-        THROW(ERROR_HARDWARE_FAULT);
+    if (adc_num >= ADC_COUNT) {
+        THROW(ERROR_INVALID_ARGUMENT);
+        return;
     }
-}
 
+    ADCInstance *instance = &g_adc_instances[adc_num];
+    if (instance->adc_handle == nullptr) {
+        THROW(ERROR_DEVICE_NOT_READY);
+        return;
+    }
+
+    // Stop the ADC conversion
+    if (HAL_ADC_Stop_DMA(instance->adc_handle) != HAL_OK) {
+        THROW(ERROR_HARDWARE_FAULT);
+    } // Stop ADC in DMA mode
+
+    // Clear any pending flags
+    __HAL_ADC_CLEAR_FLAG(instance->adc_handle, ADC_FLAG_EOC);
+    __HAL_ADC_CLEAR_FLAG(instance->adc_handle, ADC_FLAG_OVR);
+}
 /**
  * @brief Sets the ADC complete callback.
  *
@@ -247,25 +516,34 @@ void ADC_LL_stop(void)
  *
  * @param callback Pointer to the callback function.
  */
-void ADC_LL_set_complete_callback(ADC_LL_CompleteCallback callback)
+void ADC_LL_set_complete_callback(
+    ADC_Num adc_num,
+    ADC_LL_CompleteCallback callback
+)
 {
-    g_adc_instance.adc_complete_callback =
+    g_adc_instances[adc_num].adc_complete_callback =
         callback; // Set the user-defined callback
 }
 
 void HAL_ADC_ConvCpltCallback(ADC_HandleTypeDef *hadc)
 {
-    (void)hadc; // Suppress unused parameter warning
-
-    if (g_adc_instance.adc_complete_callback != nullptr) {
-        g_adc_instance.adc_complete_callback(
+    ADC_Num adc_num = get_adc_num_from_handle(hadc);
+    if (g_adc_instances[adc_num].adc_complete_callback != nullptr) {
+        g_adc_instances[adc_num].adc_complete_callback(adc_num
         ); // Call the user-defined callback with the ADC value
     }
 }
 
-void ADC1_IRQHandler(void) { HAL_ADC_IRQHandler(&g_hadc); }
+void ADC1_IRQHandler(void) { HAL_ADC_IRQHandler(&g_hadc1); }
+
+void ADC2_IRQHandler(void) { HAL_ADC_IRQHandler(&g_hadc2); }
 
 void GPDMA1_Channel6_IRQHandler(void)
 {
-    HAL_DMA_IRQHandler(&g_hdma_adc); // Handle DMA interrupts
+    HAL_DMA_IRQHandler(&g_hdma_adc1); // Handle DMA interrupts
+}
+
+void GPDMA1_Channel7_IRQHandler(void)
+{
+    HAL_DMA_IRQHandler(&g_hdma_adc2); // Handle DMA interrupts
 }

--- a/src/platform/h563xx/adc_ll.c
+++ b/src/platform/h563xx/adc_ll.c
@@ -61,6 +61,15 @@ static ADCInstance g_adc_instances[ADC_COUNT] = {
     }
 };
 
+/**
+ * @brief Get the ADC instance number from the ADC handle
+ *
+ * This function retrieves the ADC instance number based on the provided ADC
+ * handle. It is used to determine which ADC instance is being referenced.
+ *
+ * @param hadc Pointer to the ADC handle
+ * @return The ADC instance number (ADC_1, ADC_2, or ADC_1_2)
+ */
 static ADC_Num get_adc_num_from_handle(ADC_HandleTypeDef *hadc)
 {
     if (hadc->Instance == ADC1 || !g_adc_multimode) {
@@ -76,35 +85,54 @@ static ADC_Num get_adc_num_from_handle(ADC_HandleTypeDef *hadc)
 }
 
 /**
- * @brief Initializes the ADC MSP (MCU Support Package).
+ * @brief Configures the GPIO pins for ADC input
  *
- * This function configures the ADC GPIO pins, DMA, and clock settings.
- * It is called by the HAL_ADC_Init function to set up the ADC hardware.
+ * This function configures the GPIO pins used by the ADC. It sets the mode to
+ * analog and disables pull-up/pull-down resistors.
  *
- * @param hadc Pointer to the ADC handle structure.
+ * @param hadc Pointer to the ADC handle
  */
-void HAL_ADC_MspInit(ADC_HandleTypeDef *hadc)
+void gpio_config(ADC_HandleTypeDef *hadc)
 {
-    (void)hadc; // Suppress unused parameter warning
     GPIO_InitTypeDef gpio_init = { 0 };
+    // Enable GPIOA clock
+    __HAL_RCC_GPIOA_CLK_ENABLE();
     if (hadc->Instance == ADC1) {
-        // Enable ADC1 clock
-        __HAL_RCC_ADC_CLK_ENABLE();
-        // Enable GPIOA clock
-        __HAL_RCC_GPIOA_CLK_ENABLE();
-        // Enable DMA1 clock
-        __HAL_RCC_GPDMA1_CLK_ENABLE();
         if (g_adc_multimode) {
-            // Configure GPIO pin for ADC1_IN14 (PA14)
-            gpio_init.Pin = GPIO_PIN_14; // PA14
+            // Configure GPIO pin for ADC1_IN6 (PA6)
+            gpio_init.Pin = GPIO_PIN_6; // PA6
         } else {
             // Configure GPIO pin for ADC1_IN0 (PA0)
             gpio_init.Pin = GPIO_PIN_0; // PA0
         }
-        gpio_init.Mode = GPIO_MODE_ANALOG;
-        gpio_init.Pull = GPIO_NOPULL;
-        HAL_GPIO_Init(GPIOA, &gpio_init);
+    } else if (hadc->Instance == ADC2) {
+        if (g_adc_multimode) {
+            // Configure GPIO pin for ADC2_IN7 (PA7)
+            gpio_init.Pin = GPIO_PIN_7; // PA7
+        } else {
+            // Configure GPIO pin for ADC2_IN1 (PA1)
+            gpio_init.Pin = GPIO_PIN_1; // PA1
+        }
+    }
+    gpio_init.Mode = GPIO_MODE_ANALOG;
+    gpio_init.Pull = GPIO_NOPULL;
+    HAL_GPIO_Init(GPIOA, &gpio_init);
+}
 
+/**
+ * @brief Configures the DMA for ADC operations
+ *
+ * This function initializes the DMA for ADC operations. It sets up the DMA
+ * channel, request, direction, data width, and other parameters.
+ *
+ * @param hadc Pointer to the ADC handle
+ */
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+void dma_config(ADC_HandleTypeDef *hadc)
+{
+    // Enable DMA1 clock
+    __HAL_RCC_GPDMA1_CLK_ENABLE();
+    if (hadc->Instance == ADC1) {
         /*DMA for the ADC*/
         g_hdma_adc1.Instance = GPDMA1_Channel6; // DMA channel for ADC1
         g_hdma_adc1.Init.Request = GPDMA1_REQUEST_ADC1;
@@ -132,90 +160,60 @@ void HAL_ADC_MspInit(ADC_HandleTypeDef *hadc)
 
         HAL_NVIC_SetPriority(GPDMA1_Channel6_IRQn, ADC_IRQ_PRIORITY, 1);
         HAL_NVIC_EnableIRQ(GPDMA1_Channel6_IRQn);
-    } else if (hadc->Instance == ADC2 || !g_adc_multimode) {
-        // Enable ADC2 clock
-        __HAL_RCC_ADC_CLK_ENABLE();
-        // Enable GPIOA clock
-        __HAL_RCC_GPIOA_CLK_ENABLE();
-        // Enable DMA1 clock
-        __HAL_RCC_GPDMA1_CLK_ENABLE();
-        // Configure GPIO pin for ADC2_IN1 (PA1)
-        GPIO_InitTypeDef gpio_init = { 0 };
-        gpio_init.Pin = GPIO_PIN_1; // PA1
-        gpio_init.Mode = GPIO_MODE_ANALOG;
-        gpio_init.Pull = GPIO_NOPULL;
-        HAL_GPIO_Init(GPIOA, &gpio_init);
-        /*DMA for the ADC*/
-        g_hdma_adc2.Instance = GPDMA1_Channel7; // DMA channel for ADC2
-        g_hdma_adc2.Init.Request = GPDMA1_REQUEST_ADC2;
-        g_hdma_adc2.Init.BlkHWRequest = DMA_BREQ_SINGLE_BURST;
-        g_hdma_adc2.Init.Direction = DMA_PERIPH_TO_MEMORY;
-        g_hdma_adc2.Init.SrcInc = DMA_SINC_FIXED;
-        g_hdma_adc2.Init.DestInc = DMA_DINC_INCREMENTED;
-        g_hdma_adc2.Init.SrcDataWidth = DMA_SRC_DATAWIDTH_HALFWORD;
-        g_hdma_adc2.Init.DestDataWidth = DMA_DEST_DATAWIDTH_HALFWORD;
-        g_hdma_adc2.Init.Priority = DMA_LOW_PRIORITY_LOW_WEIGHT;
-        g_hdma_adc2.Init.SrcBurstLength = 1;
-        g_hdma_adc2.Init.DestBurstLength = 1;
-        g_hdma_adc2.Init.TransferAllocatedPort =
-            (DMA_SRC_ALLOCATED_PORT0 | DMA_DEST_ALLOCATED_PORT0);
-        g_hdma_adc2.Init.TransferEventMode = DMA_TCEM_BLOCK_TRANSFER;
-        g_hdma_adc2.Init.Mode = DMA_NORMAL;
-        if (HAL_DMA_Init(&g_hdma_adc2) != HAL_OK) {
-            THROW(ERROR_HARDWARE_FAULT);
+    } else if (hadc->Instance == ADC2) {
+        if (!g_adc_multimode) {
+            /*DMA for the ADC*/
+            g_hdma_adc2.Instance = GPDMA1_Channel7; // DMA channel for ADC2
+            g_hdma_adc2.Init.Request = GPDMA1_REQUEST_ADC2;
+            g_hdma_adc2.Init.BlkHWRequest = DMA_BREQ_SINGLE_BURST;
+            g_hdma_adc2.Init.Direction = DMA_PERIPH_TO_MEMORY;
+            g_hdma_adc2.Init.SrcInc = DMA_SINC_FIXED;
+            g_hdma_adc2.Init.DestInc = DMA_DINC_INCREMENTED;
+            g_hdma_adc2.Init.SrcDataWidth = DMA_SRC_DATAWIDTH_HALFWORD;
+            g_hdma_adc2.Init.DestDataWidth = DMA_DEST_DATAWIDTH_HALFWORD;
+            g_hdma_adc2.Init.Priority = DMA_LOW_PRIORITY_LOW_WEIGHT;
+            g_hdma_adc2.Init.SrcBurstLength = 1;
+            g_hdma_adc2.Init.DestBurstLength = 1;
+            g_hdma_adc2.Init.TransferAllocatedPort =
+                (DMA_SRC_ALLOCATED_PORT0 | DMA_DEST_ALLOCATED_PORT0);
+            g_hdma_adc2.Init.TransferEventMode = DMA_TCEM_BLOCK_TRANSFER;
+            g_hdma_adc2.Init.Mode = DMA_NORMAL;
+            if (HAL_DMA_Init(&g_hdma_adc2) != HAL_OK) {
+                THROW(ERROR_HARDWARE_FAULT);
+            }
+
+            __HAL_LINKDMA(&g_hadc2, DMA_Handle, g_hdma_adc2);
+
+            // Enable ADC2 interrupt
+            HAL_NVIC_SetPriority(ADC2_IRQn, ADC_IRQ_PRIORITY, 0);
+            HAL_NVIC_EnableIRQ(ADC2_IRQn);
+
+            HAL_NVIC_SetPriority(GPDMA1_Channel7_IRQn, ADC_IRQ_PRIORITY, 1);
+            HAL_NVIC_EnableIRQ(GPDMA1_Channel7_IRQn);
         }
-
-        __HAL_LINKDMA(&g_hadc2, DMA_Handle, g_hdma_adc2);
-
-        // Enable ADC2 interrupt
-        HAL_NVIC_SetPriority(ADC2_IRQn, ADC_IRQ_PRIORITY, 0);
-        HAL_NVIC_EnableIRQ(ADC2_IRQn);
-
-        HAL_NVIC_SetPriority(GPDMA1_Channel7_IRQn, ADC_IRQ_PRIORITY, 1);
-        HAL_NVIC_EnableIRQ(GPDMA1_Channel7_IRQn);
-    }
-
-    else if (hadc->Instance == ADC2 || g_adc_multimode) {
-        // Configure GPIO pin for ADC2_IN7 (PA7)
-        GPIO_InitTypeDef gpio_init = { 0 };
-        gpio_init.Pin = GPIO_PIN_7; // PA7
-        gpio_init.Mode = GPIO_MODE_ANALOG;
-        gpio_init.Pull = GPIO_NOPULL;
-        HAL_GPIO_Init(GPIOA, &gpio_init);
-        // Enable ADC2 interrupt
-        HAL_NVIC_SetPriority(ADC2_IRQn, ADC_IRQ_PRIORITY, 0);
-        HAL_NVIC_EnableIRQ(ADC2_IRQn);
+        if (g_adc_multimode) {
+            HAL_NVIC_SetPriority(ADC2_IRQn, ADC_IRQ_PRIORITY, 0);
+            HAL_NVIC_EnableIRQ(ADC2_IRQn);
+        }
     }
 }
 
 /**
- * @brief Initializes the ADC1 peripheral.
+ * @brief Initializes the ADC hardware
  *
- * This function configures the ADC1 peripheral with the specified settings.
- * It sets the clock prescaler, resolution, data alignment, and other
- * parameters.
+ * This function sets up the ADC parameters and prepares it for use.
  *
+ * @param adc_num The ADC instance number (ADC_1, or ADC_2)
+ * @param adc_trigger_timer The trigger source for the ADC (e.g., TIMER6)
  */
-void ADC_LL_init(
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+void adc_handle_initialization(
     ADC_Num adc_num,
-    uint16_t *adc_buf,
-    uint32_t sz,
     ADC_LL_TriggerSource adc_trigger_timer
 )
 {
-    if (adc_buf == nullptr || sz == 0) {
-        THROW(ERROR_INVALID_ARGUMENT);
-        return;
-    }
-
-    // Initialize the ADC handle
     ADCInstance *instance = &g_adc_instances[adc_num];
-
     if (adc_num == ADC_1) {
-        if (g_adc1_initialized) {
-            THROW(ERROR_RESOURCE_BUSY);
-            return;
-        }
 
         instance->adc_handle->Instance = ADC1;
         // Initialize the ADC peripheral
@@ -247,36 +245,7 @@ void ADC_LL_init(
             THROW(ERROR_HARDWARE_FAULT);
         }
 
-        // Configure the ADC channel
-        instance->adc_config = g_config1;
-        if (!g_adc_multimode) {
-            g_config1.Channel = ADC_CHANNEL_0; // ADC1_IN0
-        } else if (g_adc_multimode) {
-            g_config1.Channel = ADC_CHANNEL_3; // ADC1_INP3
-        }
-        g_config1.Rank = ADC_REGULAR_RANK_1;
-        g_config1.SamplingTime = ADC_SAMPLETIME_12CYCLES_5;
-        g_config1.SingleDiff = ADC_SINGLE_ENDED; // Single-ended input
-        g_config1.OffsetNumber = ADC_OFFSET_NONE;
-        g_config1.Offset = 0;
-        if (HAL_ADC_ConfigChannel(instance->adc_handle, &g_config1) != HAL_OK) {
-            THROW(ERROR_HARDWARE_FAULT);
-        }
-
-        // Calibration with error handling
-        if (HAL_ADCEx_Calibration_Start(
-                instance->adc_handle, ADC_SINGLE_ENDED
-            ) != HAL_OK) {
-            THROW(ERROR_HARDWARE_FAULT);
-        } // Calibration
-        if (!g_adc_multimode) {
-            instance->adc_buffer_data = adc_buf;
-            instance->adc_buffer_size = sz;
-            g_adc1_initialized = true; // Set the ADC1 initialized flag
-        }
-    }
-
-    else if (adc_num == ADC_2) {
+    } else if (adc_num == ADC_2) {
         if (g_adc2_initialized) {
             THROW(ERROR_RESOURCE_BUSY);
             return;
@@ -310,10 +279,65 @@ void ADC_LL_init(
         if (HAL_ADC_Init(instance->adc_handle) != HAL_OK) {
             THROW(ERROR_HARDWARE_FAULT);
         }
+    }
+}
+
+/**
+ * @brief Configures the ADC channel for the specified ADC instance
+ *
+ * This function sets up the ADC channel configuration, including the channel,
+ * rank, sampling time, and other parameters.
+ *
+ * @param adc_num The ADC instance number (ADC_1 or ADC_2)
+ * @param adc_buf Pointer to the buffer where ADC data will be stored
+ * @param sz Size of the ADC buffer
+ */
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+void adc_channel_configuration(ADC_Num adc_num, uint16_t *adc_buf, uint32_t sz)
+{
+    ADCInstance *instance = &g_adc_instances[adc_num];
+    if (adc_num == ADC_1) {
 
         // Configure the ADC channel
+        instance->adc_config = g_config1;
+        if (!g_adc_multimode) {
+            g_config1.Channel = ADC_CHANNEL_0; // ADC1_IN0
+        }
+        if (g_adc_multimode) {
+            g_config1.Channel = ADC_CHANNEL_3; // ADC1_INP3
+        }
+        g_config1.Rank = ADC_REGULAR_RANK_1;
+        g_config1.SamplingTime = ADC_SAMPLETIME_12CYCLES_5;
+        g_config1.SingleDiff = ADC_SINGLE_ENDED; // Single-ended input
+        g_config1.OffsetNumber = ADC_OFFSET_NONE;
+        g_config1.Offset = 0;
+
+        if (HAL_ADC_ConfigChannel(instance->adc_handle, &g_config1) != HAL_OK) {
+            THROW(ERROR_HARDWARE_FAULT);
+        }
+
+        // Calibration with error handling
+        if (HAL_ADCEx_Calibration_Start(
+                instance->adc_handle, ADC_SINGLE_ENDED
+            ) != HAL_OK) {
+            THROW(ERROR_HARDWARE_FAULT);
+        } // Calibration
+        if (!g_adc_multimode) {
+            instance->adc_buffer_data = adc_buf;
+            instance->adc_buffer_size = sz;
+        }
+        g_adc1_initialized = true; // Set the ADC1 initialized flag
+
+    } else if (adc_num == ADC_2) {
+        // Configure the ADC channel
         instance->adc_config = g_config2;
-        g_config2.Channel = ADC_CHANNEL_1; // ADC2_IN1
+        if (!g_adc_multimode) {
+            g_config2.Channel = ADC_CHANNEL_1; // ADC2_IN1
+        }
+        if (g_adc_multimode) {
+            g_config2.Channel = ADC_CHANNEL_7; // ADC2_INP7
+        }
+        // Configure the ADC channel
         g_config2.Rank = ADC_REGULAR_RANK_1;
         g_config2.SamplingTime = ADC_SAMPLETIME_12CYCLES_5;
         g_config2.SingleDiff = ADC_SINGLE_ENDED; // Single-ended input
@@ -332,71 +356,78 @@ void ADC_LL_init(
         if (!g_adc_multimode) {
             instance->adc_buffer_data = adc_buf;
             instance->adc_buffer_size = sz;
-            g_adc2_initialized = true; // Set the ADC1 initialized flag
         }
+        g_adc2_initialized = true; // Set the ADC2 initialized flag
     }
+}
+/**
+ * @brief Initializes the ADC MSP (MCU Support Package).
+ *
+ * This function configures the ADC GPIO pins, DMA, and clock settings.
+ * It is called by the HAL_ADC_Init function to set up the ADC hardware.
+ *
+ * @param hadc Pointer to the ADC handle structure.
+ * @return None
+ */
+void HAL_ADC_MspInit(ADC_HandleTypeDef *hadc)
+{
+    // Enable ADC clock
+    __HAL_RCC_ADC_CLK_ENABLE();
+    gpio_config(hadc);
+    dma_config(hadc);
+}
 
-    else if (adc_num == ADC_1_2) {
+/**
+ * @brief Initializes the ADC1 peripheral.
+ *
+ * This function configures the ADC1 peripheral with the specified settings.
+ * It sets the clock prescaler, resolution, data alignment, and other
+ * parameters.
+ *
+ */
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+void ADC_LL_init(
+    ADC_Num adc_num,
+    uint16_t *adc_buf,
+    uint32_t sz,
+    ADC_LL_TriggerSource adc_trigger_timer
+)
+{
+    if (adc_buf == nullptr || sz == 0) {
+        THROW(ERROR_INVALID_ARGUMENT);
+        return;
+    }
+    if (adc_num == ADC_1) {
+        if (g_adc1_initialized) {
+            THROW(ERROR_RESOURCE_BUSY);
+            return;
+        }
+        adc_handle_initialization(ADC_1, adc_trigger_timer);
+        adc_channel_configuration(ADC_1, adc_buf, sz);
+    } else if (adc_num == ADC_2) {
+        if (g_adc2_initialized) {
+            THROW(ERROR_RESOURCE_BUSY);
+            return;
+        }
+        adc_handle_initialization(ADC_2, adc_trigger_timer);
+        adc_channel_configuration(ADC_2, adc_buf, sz);
+    } else if (adc_num == ADC_1_2) {
         if (g_adc1_initialized || g_adc2_initialized) {
             THROW(ERROR_RESOURCE_BUSY);
             return;
         }
+        g_adc_multimode = true; // Enable multimode for ADC1 and ADC2
+        // Initialize both ADC1 and ADC2
+        adc_handle_initialization(ADC_1, adc_trigger_timer);
+        adc_channel_configuration(ADC_1, adc_buf, sz);
 
-        g_adc_multimode = true; // Set multimode flag
+        adc_handle_initialization(ADC_2, adc_trigger_timer);
+        adc_channel_configuration(ADC_2, adc_buf, sz);
 
-        ADC_LL_init(ADC_1, adc_buf, sz, adc_trigger_timer);
-
-        instance->adc_handle->Instance = ADC2;
-        // Initialize the ADC peripheral
-        instance->adc_handle->Init.ClockPrescaler =
-            ADC_CLOCK_SYNC_PCLK_DIV1; // ADC clock and prescaler
-        instance->adc_handle->Init.Resolution = ADC_RESOLUTION_12B;
-        instance->adc_handle->Init.DataAlign = ADC_DATAALIGN_RIGHT;
-        instance->adc_handle->Init.ScanConvMode = DISABLE;
-        instance->adc_handle->Init.EOCSelection = ADC_EOC_SINGLE_CONV;
-        instance->adc_handle->Init.LowPowerAutoWait = DISABLE;
-        instance->adc_handle->Init.ContinuousConvMode = DISABLE;
-        instance->adc_handle->Init.NbrOfConversion = 1;
-        instance->adc_handle->Init.DiscontinuousConvMode = DISABLE;
-        if (adc_trigger_timer == ADC_TRIGGER_TIMER6) {
-            instance->adc_handle->Init.ExternalTrigConv =
-                ADC_EXTERNALTRIG_T6_TRGO;
-        } else {
-            THROW(ERROR_INVALID_ARGUMENT);
-            return;
-        }
-        instance->adc_handle->Init.ExternalTrigConvEdge =
-            ADC_EXTERNALTRIGCONVEDGE_RISING;
-        instance->adc_handle->Init.SamplingMode = ADC_SAMPLING_MODE_NORMAL;
-        instance->adc_handle->Init.DMAContinuousRequests = DISABLE;
-        instance->adc_handle->Init.Overrun = ADC_OVR_DATA_OVERWRITTEN;
-        instance->adc_handle->Init.OversamplingMode = DISABLE;
-
-        if (HAL_ADC_Init(instance->adc_handle) != HAL_OK) {
-            THROW(ERROR_HARDWARE_FAULT);
-        }
-
-        // Configure the ADC channel
-        instance->adc_config = g_config2;
-        g_config2.Channel = ADC_CHANNEL_7; // ADC2_IN7
-        g_config2.Rank = ADC_REGULAR_RANK_1;
-        g_config2.SamplingTime = ADC_SAMPLETIME_12CYCLES_5;
-        g_config2.SingleDiff = ADC_SINGLE_ENDED; // Single-ended input
-        g_config2.OffsetNumber = ADC_OFFSET_NONE;
-        g_config2.Offset = 0;
-        if (HAL_ADC_ConfigChannel(instance->adc_handle, &g_config2) != HAL_OK) {
-            THROW(ERROR_HARDWARE_FAULT);
-        }
-
-        // Calibration with error handling
-        if (HAL_ADCEx_Calibration_Start(
-                instance->adc_handle, ADC_SINGLE_ENDED
-            ) != HAL_OK) {
-            THROW(ERROR_HARDWARE_FAULT);
-        } // Calibration
+        ADCInstance *instance = &g_adc_instances[adc_num];
 
         ADC_MultiModeTypeDef multimode_config = { 0 };
-        multimode_config.Mode = ADC_DUALMODE_INTERL;
+        multimode_config.Mode = ADC_DUALMODE_INTERL; // Set to interleaved mode
         multimode_config.DMAAccessMode = ADC_DMAACCESSMODE_12_10_BITS;
         multimode_config.TwoSamplingDelay = ADC_TWOSAMPLINGDELAY_12CYCLES;
 
@@ -404,17 +435,13 @@ void ADC_LL_init(
             HAL_OK) {
             THROW(ERROR_HARDWARE_FAULT);
         } // Configure multimode
-        instance->adc_handle =
-            &g_hadc1; // Use ADC1 handle for multimode(adding this again here to
-                      // ensure that when this pointer is called later for
-                      // example in ADC_LL_start, it points to ADC1 handle)
+        instance->adc_handle = &g_hadc1;
+        // Use ADC1 handle for multimode(adding this again here to
+        // ensure that when this pointer is called later for
+        // example in ADC_LL_start, it points to ADC1 handle)
         instance->adc_buffer_data = adc_buf;
         instance->adc_buffer_size = sz;
-        g_adc1_initialized = true; // Set the ADC1 initialized flag
-        g_adc2_initialized = true; // Set the ADC2 initialized flag
-    }
-
-    else {
+    } else {
         THROW(ERROR_INVALID_ARGUMENT);
         return;
     }

--- a/src/system/adc/adc.c
+++ b/src/system/adc/adc.c
@@ -11,7 +11,6 @@
  * @date 2025-07-02
  */
 
-#include <stddef.h>
 #include <stdint.h>
 #include <stdlib.h>
 

--- a/src/system/adc/adc.c
+++ b/src/system/adc/adc.c
@@ -148,6 +148,7 @@ void ADC_deinit(ADC_Handle *handle)
 
         handle->initialized = false;
 
+        g_active_adc_handles[handle->adc_id] = nullptr;
         free(handle); // Free the ADC handle memory
     }
 
@@ -208,27 +209,6 @@ void ADC_stop(ADC_Handle *handle)
     TIM_stop(ADC_TIM_NUM); // Stop the timer used for ADC conversions
     // Stop the ADC conversion
     ADC_LL_stop(handle->adc_id);
-}
-
-uint32_t ADC_read(ADC_Handle *handle, uint32_t *const adc_buf, uint32_t sz)
-{
-    if (!handle || !handle->initialized) {
-        THROW(ERROR_DEVICE_NOT_READY);
-        return 0;
-    }
-
-    if (!adc_buf || sz == 0) {
-        THROW(ERROR_INVALID_ARGUMENT);
-        return 0;
-    }
-
-    uint32_t samples_read = 0;
-    while (samples_read < sz) {
-        adc_buf[samples_read] = handle->adc_buffer[samples_read];
-        samples_read++;
-    }
-
-    return samples_read; // Return the number of samples read
 }
 
 void ADC_set_callback(ADC_Handle *handle, ADC_Callback callback)

--- a/src/system/adc/adc.c
+++ b/src/system/adc/adc.c
@@ -30,7 +30,7 @@ enum { ADC_TRIGGER_TIMER = 6 };
 
 struct ADC_Handle {
     ADC_Num adc_id; // ADC instance ID
-    uint16_t *adc_buffer; // Buffer for ADC data
+    uint32_t *adc_buffer; // Buffer for ADC data
     uint32_t adc_buffer_size; // Size of the ADC buffer
     ADC_Callback g_adc_callback; // Callback for ADC completion
     bool initialized; // Flag to indicate if ADC is initialized
@@ -62,7 +62,7 @@ static void adc_complete_callback(ADC_Num adc_num)
  * It must be called before any ADC operations can be performed.
  *
  */
-void *ADC_init(size_t adc, uint16_t *adc_buffer, uint32_t adc_buffer_size)
+void *ADC_init(size_t adc, uint32_t *adc_buffer, uint32_t adc_buffer_size)
 {
     if (adc >= ADC_COUNT) {
         THROW(ERROR_INVALID_ARGUMENT);
@@ -210,7 +210,7 @@ void ADC_stop(ADC_Handle *handle)
     ADC_LL_stop(handle->adc_id);
 }
 
-uint32_t ADC_read(ADC_Handle *handle, uint16_t *const adc_buf, uint32_t sz)
+uint32_t ADC_read(ADC_Handle *handle, uint32_t *const adc_buf, uint32_t sz)
 {
     if (!handle || !handle->initialized) {
         THROW(ERROR_DEVICE_NOT_READY);
@@ -223,7 +223,7 @@ uint32_t ADC_read(ADC_Handle *handle, uint16_t *const adc_buf, uint32_t sz)
     }
 
     uint32_t samples_read = 0;
-    while (samples_read <= sz) {
+    while (samples_read < sz) {
         adc_buf[samples_read] = handle->adc_buffer[samples_read];
         samples_read++;
     }

--- a/src/system/adc/adc.c
+++ b/src/system/adc/adc.c
@@ -11,6 +11,7 @@
  * @date 2025-07-02
  */
 
+#include <stddef.h>
 #include <stdint.h>
 #include <stdlib.h>
 
@@ -24,30 +25,34 @@
  * Macros
  **********************************************************************/
 
-enum { ADC1_TIM_NUM = 0 }; // Timer used for ADC1 conversions
-enum { ADC1_TIM_Frequency = 25000 }; // ADC1 timer frequency in Hz
-enum { ADC1_TRIGGER_TIMER = 6 };
+enum { ADC_TIM_NUM = 0 }; // Timer used for ADC conversions
+enum { ADC_TIM_Frequency = 25000 }; // ADC timer frequency in Hz
+enum { ADC_TRIGGER_TIMER = 6 };
 
 struct ADC_Handle {
+    ADC_Num adc_id; // ADC instance ID
     uint16_t *adc_buffer; // Buffer for ADC data
     uint32_t adc_buffer_size; // Size of the ADC buffer
     ADC_Callback g_adc_callback; // Callback for ADC completion
     bool initialized; // Flag to indicate if ADC is initialized
 };
 
-static ADC_Handle *g_active_adc_handle = nullptr; // Global ADC handle
+static ADC_Handle *g_active_adc_handles[ADC_COUNT] = {
+    nullptr
+}; // Global ADC handles
 
 /**
  * @brief Callback invoked by hardware layer when ADC conversion is complete
  */
-static void adc_complete_callback(void)
+static void adc_complete_callback(ADC_Num adc_num)
 {
-    if (!g_active_adc_handle || !g_active_adc_handle->initialized) {
+    if (!g_active_adc_handles[adc_num] ||
+        !g_active_adc_handles[adc_num]->initialized) {
         return;
     }
 
     // Check if we should run the ADC callback now
-    g_active_adc_handle->g_adc_callback(g_active_adc_handle
+    g_active_adc_handles[adc_num]->g_adc_callback(g_active_adc_handles[adc_num]
     ); // Call the user-defined callback with the ADC value
 }
 
@@ -58,8 +63,12 @@ static void adc_complete_callback(void)
  * It must be called before any ADC operations can be performed.
  *
  */
-void *ADC_init(uint16_t *adc_buffer, uint32_t adc_buffer_size)
+void *ADC_init(size_t adc, uint16_t *adc_buffer, uint32_t adc_buffer_size)
 {
+    if (adc >= ADC_COUNT) {
+        THROW(ERROR_INVALID_ARGUMENT);
+        return nullptr;
+    }
     if (!adc_buffer || adc_buffer_size == 0) {
         THROW(ERROR_INVALID_ARGUMENT);
         return nullptr;
@@ -67,7 +76,7 @@ void *ADC_init(uint16_t *adc_buffer, uint32_t adc_buffer_size)
 
     // Initialize the timer used for ADC conversions
     TIM_init(
-        ADC1_TIM_NUM, ADC1_TIM_Frequency
+        ADC_TIM_NUM, ADC_TIM_Frequency
     ); // Set the timer frequency to 25000 Hz to enable sampling at 1KSPS
     /*
     Explanation for 25khz to achieve 1KSPS:
@@ -89,7 +98,7 @@ void *ADC_init(uint16_t *adc_buffer, uint32_t adc_buffer_size)
     conversions.
     */
 
-    if (g_active_adc_handle) {
+    if (g_active_adc_handles[adc] && g_active_adc_handles[adc]->initialized) {
         THROW(ERROR_RESOURCE_BUSY);
         return nullptr;
     }
@@ -100,18 +109,22 @@ void *ADC_init(uint16_t *adc_buffer, uint32_t adc_buffer_size)
         return nullptr;
     }
     // Initialize the ADC handle
+    handle->adc_id = (ADC_Num)adc; // Set the ADC instance ID
     handle->adc_buffer = adc_buffer;
     handle->adc_buffer_size = adc_buffer_size;
     handle->g_adc_callback = nullptr;
     handle->initialized = false;
     // Initialize the ADC peripheral
     ADC_LL_init(
-        handle->adc_buffer, handle->adc_buffer_size, ADC1_TRIGGER_TIMER
+        handle->adc_id,
+        handle->adc_buffer,
+        handle->adc_buffer_size,
+        ADC_TRIGGER_TIMER
     );
     // Set the ADC complete callback
-    ADC_LL_set_complete_callback(adc_complete_callback);
+    ADC_LL_set_complete_callback(handle->adc_id, adc_complete_callback);
     handle->initialized = true;
-    g_active_adc_handle = handle;
+    g_active_adc_handles[adc] = handle;
 
     return handle; // Return the ADC handle
 }
@@ -122,21 +135,21 @@ void *ADC_init(uint16_t *adc_buffer, uint32_t adc_buffer_size)
  * This function deinitializes the ADC peripheral and releases any resources
  * used. It should be called when the ADC is no longer needed.
  */
-void ADC_deinit(void)
+void ADC_deinit(ADC_Handle *handle)
 {
-    TIM_stop(ADC1_TIM_NUM); // Stop the timer used for ADC conversions
-    if (g_active_adc_handle && g_active_adc_handle->initialized) {
+    TIM_stop(ADC_TIM_NUM); // Stop the timer used for ADC conversions
+
+    if (handle && handle->initialized) {
         // Deinitialize the ADC peripheral
-        ADC_LL_deinit();
+        ADC_LL_deinit(handle->adc_id);
 
-        ADC_LL_set_complete_callback(nullptr);
+        ADC_LL_set_complete_callback(
+            handle->adc_id, nullptr
+        ); // Clear the callback
 
-        g_active_adc_handle->initialized = false;
+        handle->initialized = false;
 
-        free(g_active_adc_handle); // Free the ADC handle memory
-
-        // Clear the global ADC handle
-        g_active_adc_handle = nullptr;
+        free(handle); // Free the ADC handle memory
     }
 
     else {
@@ -152,28 +165,28 @@ void ADC_deinit(void)
  * the ADC has been initialized and configured.
  *
  */
-void ADC_start(void)
+void ADC_start(ADC_Handle *handle)
 {
-    if (!g_active_adc_handle || !g_active_adc_handle->initialized) {
+    if (!handle || !handle->initialized) {
         THROW(ERROR_DEVICE_NOT_READY);
         return;
     }
 
-    TIM_start(ADC1_TIM_NUM); // Start the timer for ADC conversions
+    TIM_start(ADC_TIM_NUM); // Start the timer for ADC conversions
 
     // Start the ADC conversion
-    ADC_LL_start();
-    LOG_INFO("ADC_started_successfully");
+    ADC_LL_start(handle->adc_id);
+    LOG_INFO("ADC started successfully");
 }
 
-void ADC_restart(void)
+void ADC_restart(ADC_Handle *handle)
 {
-    if (!g_active_adc_handle || !g_active_adc_handle->initialized) {
+    if (!handle || !handle->initialized) {
         THROW(ERROR_DEVICE_NOT_READY);
         return;
     }
-    // Restart the ADC conversion
-    ADC_LL_start();
+
+    ADC_LL_start(handle->adc_id); // Start a new conversion
 }
 
 /**
@@ -183,16 +196,24 @@ void ADC_restart(void)
  * to halt conversions before deinitializing the ADC or when no longer needed.
  *
  */
-void ADC_stop(void)
+void ADC_stop(ADC_Handle *handle)
 {
-    TIM_stop(ADC1_TIM_NUM); // Stop the timer used for ADC conversions
+    if (!handle || !handle->initialized) {
+        THROW(ERROR_DEVICE_NOT_READY);
+        return;
+    }
+
+    LOG_INFO("Stopping ADC conversion");
+
+    // Stop the timer used for ADC conversions
+    TIM_stop(ADC_TIM_NUM); // Stop the timer used for ADC conversions
     // Stop the ADC conversion
-    ADC_LL_stop();
+    ADC_LL_stop(handle->adc_id);
 }
 
-uint32_t ADC_read(uint16_t *const adc_buf, uint32_t sz)
+uint32_t ADC_read(ADC_Handle *handle, uint16_t *const adc_buf, uint32_t sz)
 {
-    if (!g_active_adc_handle || !g_active_adc_handle->initialized) {
+    if (!handle || !handle->initialized) {
         THROW(ERROR_DEVICE_NOT_READY);
         return 0;
     }
@@ -204,19 +225,19 @@ uint32_t ADC_read(uint16_t *const adc_buf, uint32_t sz)
 
     uint32_t samples_read = 0;
     while (samples_read <= sz) {
-        adc_buf[samples_read] = g_active_adc_handle->adc_buffer[samples_read];
+        adc_buf[samples_read] = handle->adc_buffer[samples_read];
         samples_read++;
     }
 
     return samples_read; // Return the number of samples read
 }
 
-void ADC_set_callback(ADC_Callback callback)
+void ADC_set_callback(ADC_Handle *handle, ADC_Callback callback)
 {
-    if (!g_active_adc_handle || !g_active_adc_handle->initialized) {
+    if (!handle || !handle->initialized) {
         THROW(ERROR_INVALID_ARGUMENT);
         return;
     }
     // Set the ADC callback
-    g_active_adc_handle->g_adc_callback = callback;
+    handle->g_adc_callback = callback;
 }

--- a/src/system/adc/adc.h
+++ b/src/system/adc/adc.h
@@ -43,7 +43,7 @@ typedef void (*ADC_Callback)(ADC_Handle *handle);
  *
  * @param adc_buffer Pointer to the circular buffer for ADC data.
  */
-void *ADC_init(size_t adc, uint16_t *adc_buffer, uint32_t buffer_size);
+void *ADC_init(size_t adc, uint32_t *adc_buffer, uint32_t buffer_size);
 
 /**
  * @brief Deinitializes the ADC peripheral.
@@ -90,7 +90,7 @@ void ADC_stop(ADC_Handle *handle);
  *
  * @return Number of bytes read from the ADC buffer.
  */
-uint32_t ADC_read(ADC_Handle *handle, uint16_t *adc_buf, uint32_t sz);
+uint32_t ADC_read(ADC_Handle *handle, uint32_t *adc_buf, uint32_t sz);
 
 /**
  * @brief Sets the callback function to be called when an ADC conversion is

--- a/src/system/adc/adc.h
+++ b/src/system/adc/adc.h
@@ -42,7 +42,7 @@ typedef void (*ADC_Callback)(ADC_Handle *handle);
  *
  * @param adc_buffer Pointer to the circular buffer for ADC data.
  */
-void *ADC_init(uint16_t *adc_buffer, uint32_t buffer_size);
+void *ADC_init(size_t adc, uint16_t *adc_buffer, uint32_t buffer_size);
 
 /**
  * @brief Deinitializes the ADC peripheral.
@@ -50,7 +50,7 @@ void *ADC_init(uint16_t *adc_buffer, uint32_t buffer_size);
  * This function deinitializes the ADC peripheral and releases any resources
  * used. It should be called when the ADC is no longer needed.
  */
-void ADC_deinit(void);
+void ADC_deinit(ADC_Handle *handle);
 
 /**
  * @brief Starts the ADC conversion.
@@ -58,7 +58,7 @@ void ADC_deinit(void);
  * This function starts the ADC conversion process. It must be called after
  * the ADC has been initialized and configured.
  */
-void ADC_start(void);
+void ADC_start(ADC_Handle *handle);
 
 /**
  * @brief Restarts the ADC conversion.
@@ -67,7 +67,7 @@ void ADC_start(void);
  * restart conversions after dma buffer is completely filled and we need
  * to call the dma to restart the transfer.
  */
-void ADC_restart(void);
+void ADC_restart(ADC_Handle *handle);
 
 /**
  * @brief Stops the ADC conversion.
@@ -76,7 +76,7 @@ void ADC_restart(void);
  * to halt conversions before deinitializing the ADC or when no longer needed.
 
  */
-void ADC_stop(void);
+void ADC_stop(ADC_Handle *handle);
 
 /**
  * @brief Reads data from the ADC buffer.
@@ -89,7 +89,7 @@ void ADC_stop(void);
  *
  * @return Number of bytes read from the ADC buffer.
  */
-uint32_t ADC_read(uint16_t *adc_buf, uint32_t sz);
+uint32_t ADC_read(ADC_Handle *handle, uint16_t *adc_buf, uint32_t sz);
 
 /**
  * @brief Sets the callback function to be called when an ADC conversion is
@@ -101,7 +101,7 @@ uint32_t ADC_read(uint16_t *adc_buf, uint32_t sz);
  *
  * @param callback Pointer to the callback function to be set.
  */
-void ADC_set_callback(ADC_Callback callback);
+void ADC_set_callback(ADC_Handle *handle, ADC_Callback callback);
 
 #ifdef __cplusplus
 }

--- a/src/system/adc/adc.h
+++ b/src/system/adc/adc.h
@@ -15,6 +15,7 @@
 #ifndef ADC_H
 #define ADC_H
 
+#include <stddef.h>
 #include <stdint.h>
 
 #ifdef __cplusplus

--- a/src/system/adc/adc.h
+++ b/src/system/adc/adc.h
@@ -80,19 +80,6 @@ void ADC_restart(ADC_Handle *handle);
 void ADC_stop(ADC_Handle *handle);
 
 /**
- * @brief Reads data from the ADC buffer.
- *
- * This function reads data from the ADC circular buffer into the provided
- * buffer. It checks if the ADC is initialized and if the input buffer is valid.
- *
- * @param adc_buf Pointer to the buffer where ADC data will be stored.
- * @param sz Size of the buffer in bytes.
- *
- * @return Number of bytes read from the ADC buffer.
- */
-uint32_t ADC_read(ADC_Handle *handle, uint32_t *adc_buf, uint32_t sz);
-
-/**
  * @brief Sets the callback function to be called when an ADC conversion is
  * complete.
  *


### PR DESCRIPTION
- fixes: #72 

This is still a work in progress and not operational yet

This sets up the structure for multimode ADC sampling with the following modes of operation:
Mode 1: ADC 1 sampling (Through PA0 pin, ADC 1 channel 0 )
Mode 2: ADC 2 sampling (Through PA1 pin, ADC 2 channel 1 )
Mode 3: ADC 1 and ADC 2 are in multimode with a common DMA (Through pins PA6 and PA7)

In this setup, Mode 1 and Mode 2 can be enabled simultaneously and both the ADCs will operate independently in that case.

## Summary by Sourcery

Add support for ADC multimode operation, enabling single-channel sampling on ADC1 or ADC2 and interleaved dual-channel sampling via shared DMA.

New Features:
- Support ADC multimode interleaved sampling combining ADC1 and ADC2 on a common DMA channel.
- Enable independent simultaneous operation of ADC1 and ADC2 in single-channel modes.
- Extend system ADC API to accept an ADC instance identifier and return per-instance handles for init/start/stop/read operations.

Enhancements:
- Modularize the low-level ADC driver into separate GPIO, DMA, initialization, channel configuration, and start/stop functions, and introduce an ADC_Num enum with instance arrays.
- Switch ADC data buffers from 16-bit to 32-bit to accommodate packed dual-mode samples.
- Update the application main logic to use the new ADC handle API and unpack dual ADC data for logging.