### PR TITLE
Add uncaught exception handling

### DIFF
--- a/src/platform/h563xx/tim_ll.c
+++ b/src/platform/h563xx/tim_ll.c
@@ -113,7 +113,6 @@ static void calculate_timer_values(TIM_Num tim)
     if (instance->frequency == 0) {
         // frequency should not be zero
         THROW(ERROR_INVALID_ARGUMENT);
-        return;
     }
 
     uint32_t tim_clock = get_timer_clock_frequency(tim);
@@ -121,7 +120,6 @@ static void calculate_timer_values(TIM_Num tim)
     if (tim_clock == 0) {
         // Invalid timer clock frequency
         THROW(ERROR_INVALID_ARGUMENT);
-        return;
     }
 
     instance->period = (tim_clock / instance->frequency) - 1;
@@ -160,12 +158,10 @@ void TIM_LL_init(TIM_Num tim, uint32_t freq)
 {
     if (tim >= TIM_NUM_COUNT) {
         THROW(ERROR_INVALID_ARGUMENT);
-        return;
     }
 
     if (g_timer_instances[tim].initialized) {
         THROW(ERROR_RESOURCE_BUSY);
-        return;
     }
 
     TimerInstance *instance = &g_timer_instances[tim];
@@ -190,7 +186,6 @@ void TIM_LL_init(TIM_Num tim, uint32_t freq)
 
     if (HAL_TIM_Base_Init(instance->htim) != HAL_OK) {
         THROW(ERROR_HARDWARE_FAULT);
-        return;
     }
 
     TIM_MasterConfigTypeDef s_master_config = { 0 };
@@ -202,7 +197,6 @@ void TIM_LL_init(TIM_Num tim, uint32_t freq)
             instance->htim, &s_master_config
         ) != HAL_OK) {
         THROW(ERROR_HARDWARE_FAULT);
-        return;
     }
 
     instance->initialized = true;
@@ -217,7 +211,6 @@ void TIM_LL_deinit(TIM_Num tim)
 {
     if (tim >= TIM_NUM_COUNT) {
         THROW(ERROR_INVALID_ARGUMENT);
-        return;
     }
 
     if (!g_timer_instances[tim].initialized) {
@@ -244,11 +237,9 @@ void TIM_LL_start(TIM_Num tim)
     TimerInstance *instance = &g_timer_instances[tim];
     if (HAL_TIM_Base_Start(instance->htim) != HAL_OK) {
         THROW(ERROR_HARDWARE_FAULT);
-        return;
     }
     if (HAL_TIM_PWM_Start(instance->htim, TIM_CHANNEL_1) != HAL_OK) {
         THROW(ERROR_HARDWARE_FAULT);
-        return;
     }
 }
 
@@ -262,6 +253,5 @@ void TIM_LL_stop(TIM_Num tim)
     TimerInstance *instance = &g_timer_instances[tim];
     if (HAL_TIM_Base_Stop(instance->htim) != HAL_OK) {
         THROW(ERROR_HARDWARE_FAULT);
-        return;
     }
 }

--- a/src/platform/h563xx/uart_ll.c
+++ b/src/platform/h563xx/uart_ll.c
@@ -302,17 +302,14 @@ void UART_LL_init(UART_Bus bus, uint8_t *rx_buf, uint32_t sz)
 {
     if (bus >= UART_BUS_COUNT) {
         THROW(ERROR_INVALID_ARGUMENT);
-        return;
     }
 
     if (!rx_buf || sz == 0) {
         THROW(ERROR_INVALID_ARGUMENT);
-        return;
     }
 
     if (g_uart_instances[bus].initialized) {
         THROW(ERROR_RESOURCE_BUSY);
-        return;
     }
 
     UARTInstance *instance = &g_uart_instances[bus];
@@ -336,7 +333,6 @@ void UART_LL_init(UART_Bus bus, uint8_t *rx_buf, uint32_t sz)
 
     if (HAL_UART_Init(instance->huart) != HAL_OK) {
         THROW(ERROR_HARDWARE_FAULT);
-        return;
     }
 
     instance->rx_buffer_data = rx_buf;
@@ -350,7 +346,6 @@ void UART_LL_init(UART_Bus bus, uint8_t *rx_buf, uint32_t sz)
             instance->huart, instance->rx_buffer_data, instance->rx_buffer_size
         ) != HAL_OK) {
         THROW(ERROR_HARDWARE_FAULT);
-        return;
     }
 
     /* Enable UART idle line interrupt for packet detection */
@@ -370,7 +365,6 @@ void UART_LL_deinit(UART_Bus bus)
 {
     if (bus >= UART_BUS_COUNT) {
         THROW(ERROR_INVALID_ARGUMENT);
-        return;
     }
 
     if (!g_uart_instances[bus].initialized) {
@@ -415,17 +409,14 @@ void UART_LL_start_dma_tx(UART_Bus bus, uint8_t *buffer, uint32_t size)
 {
     if (bus >= UART_BUS_COUNT) {
         THROW(ERROR_INVALID_ARGUMENT);
-        return;
     }
 
     if (!buffer || size == 0) {
         THROW(ERROR_INVALID_ARGUMENT);
-        return;
     }
 
     if (!g_uart_instances[bus].initialized) {
         THROW(ERROR_DEVICE_NOT_READY);
-        return;
     }
 
     UARTInstance *instance = &g_uart_instances[bus];

--- a/src/platform/h563xx/usb_ll.c
+++ b/src/platform/h563xx/usb_ll.c
@@ -69,12 +69,10 @@ void USB_LL_init(USB_Bus bus)
 {
     if (bus >= USB_BUS_COUNT) {
         THROW(ERROR_INVALID_ARGUMENT);
-        return;
     }
 
     if (g_usb_instances[bus].initialized) {
         THROW(ERROR_RESOURCE_BUSY);
-        return;
     }
 
     HAL_PWREx_EnableVddUSB();
@@ -85,7 +83,6 @@ void USB_LL_init(USB_Bus bus)
     periph_init.UsbClockSelection = RCC_USBCLKSOURCE_HSI48;
     if (HAL_RCCEx_PeriphCLKConfig(&periph_init) != HAL_OK) {
         THROW(ERROR_HARDWARE_FAULT);
-        return;
     }
 
     // Enable USB-related clocks.
@@ -112,7 +109,6 @@ void USB_LL_init(USB_Bus bus)
     // incorrect) to call HAL_NVIC_EnableIRQ(USB_DRD_FS_IRQn) here.
     if (!tusb_init()) {
         THROW(ERROR_HARDWARE_FAULT);
-        return;
     }
 
     if (__HAL_RCC_GET_USB_SOURCE() == RCC_USBCLKSOURCE_HSI48) {

--- a/src/platform/platform.h
+++ b/src/platform/platform.h
@@ -68,4 +68,20 @@ typedef enum {
  */
 uint32_t PLATFORM_get_peripheral_clock_speed(PLATFORM_PeripheralClock clock);
 
+/**
+ * @brief Reset the platform/system
+ *
+ * This function performs a software reset of the entire system. It triggers
+ * a system-wide reset that will restart the microcontroller, equivalent to
+ * a hardware reset or power cycle.
+ *
+ * @note This function does not return - the system will be reset immediately
+ * @note All system state will be lost and the system will restart from the
+ *       reset vector
+ * @note This is a non-recoverable operation
+ *
+ * @return None (function does not return)
+ */
+[[noreturn]] void PLATFORM_reset(void);
+
 #endif // PSLAB_LL_PLATFORM_H

--- a/src/platform/platform.h
+++ b/src/platform/platform.h
@@ -82,6 +82,6 @@ uint32_t PLATFORM_get_peripheral_clock_speed(PLATFORM_PeripheralClock clock);
  *
  * @return None (function does not return)
  */
-[[noreturn]] void PLATFORM_reset(void);
+__attribute__((noreturn)) void PLATFORM_reset(void);
 
 #endif // PSLAB_LL_PLATFORM_H

--- a/src/system/bus/uart.c
+++ b/src/system/bus/uart.c
@@ -68,7 +68,6 @@ size_t UART_get_bus_count(void) { return UART_BUS_COUNT; }
 static UART_Handle *get_handle_from_bus(UART_Bus bus)
 {
     if (bus >= UART_BUS_COUNT) {
-        THROW(ERROR_INVALID_ARGUMENT);
         return nullptr;
     }
     return g_active_handles[bus];
@@ -244,7 +243,6 @@ UART_Handle *UART_init(
 {
     if (!rx_buffer || !tx_buffer || bus >= UART_BUS_COUNT) {
         THROW(ERROR_INVALID_ARGUMENT);
-        return nullptr;
     }
 
 /* Check if syscalls is claiming the UART */
@@ -252,7 +250,6 @@ UART_Handle *UART_init(
     if (bus == SYSCALLS_UART_BUS && !g_SYSCALLS_uart_claim) {
         /* Only syscalls can claim this bus */
         THROW(ERROR_RESOURCE_UNAVAILABLE);
-        return nullptr;
     }
 #endif
 
@@ -261,14 +258,12 @@ UART_Handle *UART_init(
     /* Check if bus is already initialized */
     if (g_active_handles[bus_id] != nullptr) {
         THROW(ERROR_RESOURCE_BUSY);
-        return nullptr;
     }
 
     /* Allocate handle */
     UART_Handle *handle = malloc(sizeof(UART_Handle));
     if (!handle) {
         THROW(ERROR_OUT_OF_MEMORY);
-        return nullptr;
     }
 
     /* Initialize handle */

--- a/src/system/bus/usb.c
+++ b/src/system/bus/usb.c
@@ -169,7 +169,6 @@ USB_Handle *USB_init(size_t interface, CircularBuffer *rx_buffer)
 {
     if (!rx_buffer || interface >= USB_INTERFACE_COUNT) {
         THROW(ERROR_INVALID_ARGUMENT);
-        return nullptr;
     }
 
     uint8_t interface_id = (uint8_t)interface;
@@ -177,14 +176,12 @@ USB_Handle *USB_init(size_t interface, CircularBuffer *rx_buffer)
     /* Check if interface is already initialized */
     if (g_active_handles[interface_id] != nullptr) {
         THROW(ERROR_RESOURCE_BUSY);
-        return nullptr;
     }
 
     /* Allocate handle */
     USB_Handle *handle = malloc(sizeof(USB_Handle));
     if (!handle) {
         THROW(ERROR_OUT_OF_MEMORY);
-        return nullptr;
     }
 
     /* Initialize handle */

--- a/src/system/system.c
+++ b/src/system/system.c
@@ -36,8 +36,6 @@ void SYSTEM_init(void)
  */
 __attribute__((noreturn)) void EXCEPTION_halt(uint32_t exception_id)
 {
-    // Attempt to log the uncaught exception
-    // Use LOG_ERROR since this is a critical system error
     LOG_ERROR(
         "FATAL: Uncaught exception 0x%08X - system will reset",
         (unsigned int)exception_id

--- a/src/system/system.c
+++ b/src/system/system.c
@@ -46,6 +46,7 @@ __attribute__((noreturn)) void EXCEPTION_halt(uint32_t exception_id)
     // Force a small delay to allow log message to be transmitted
     // This is a simple busy wait since we're about to reset anyway
     // TODO: Replace with proper delay function
+    // This is about 2 ms on STM32H563xx
     uint32_t volatile delay = 100000; // NOLINT[readability-magic-numbers]
     while (delay--);
 

--- a/src/system/system.c
+++ b/src/system/system.c
@@ -22,3 +22,32 @@ void SYSTEM_init(void)
     LOG_task(max_log_entries);
     LED_init();
 }
+
+/**
+ * @brief Handler for uncaught CException throws
+ *
+ * This function is called when a THROW occurs outside of any TRY context.
+ * It provides a last-resort error handler that logs the exception and
+ * resets the system to prevent undefined behavior.
+ *
+ * @param exception_id The exception ID that was thrown but not caught
+ *
+ * @note This function does not return; it resets the system
+ */
+__attribute__((noreturn)) void EXCEPTION_halt(uint32_t exception_id)
+{
+    // Attempt to log the uncaught exception
+    // Use LOG_ERROR since this is a critical system error
+    LOG_ERROR(
+        "FATAL: Uncaught exception 0x%08X - system will reset",
+        (unsigned int)exception_id
+    );
+
+    // Force a small delay to allow log message to be transmitted
+    // This is a simple busy wait since we're about to reset anyway
+    uint32_t volatile delay = 100000; // NOLINT[readability-magic-numbers]
+    while (delay--);
+
+    // Reset the system - this function does not return
+    PLATFORM_reset();
+}

--- a/src/system/system.c
+++ b/src/system/system.c
@@ -45,6 +45,7 @@ __attribute__((noreturn)) void EXCEPTION_halt(uint32_t exception_id)
 
     // Force a small delay to allow log message to be transmitted
     // This is a simple busy wait since we're about to reset anyway
+    // TODO: Replace with proper delay function
     uint32_t volatile delay = 100000; // NOLINT[readability-magic-numbers]
     while (delay--);
 

--- a/src/system/system.c
+++ b/src/system/system.c
@@ -43,7 +43,7 @@ __attribute__((noreturn)) void EXCEPTION_halt(uint32_t exception_id)
 
     // Force a small delay to allow log message to be transmitted
     // This is a simple busy wait since we're about to reset anyway
-    // TODO: Replace with proper delay function
+    // TODO(bessman): Replace with proper delay function
     // This is about 2 ms on STM32H563xx
     uint32_t volatile delay = 100000; // NOLINT[readability-magic-numbers]
     while (delay--);

--- a/src/system/timer/tim.c
+++ b/src/system/timer/tim.c
@@ -44,17 +44,15 @@ TIM_Handle *TIM_init(size_t tim, uint32_t freq)
 {
     if (tim >= TIM_NUM_COUNT) {
         THROW(ERROR_INVALID_ARGUMENT);
-        return nullptr; // Invalid timer
     }
 
     if (g_active_timers[tim] != nullptr) {
         THROW(ERROR_RESOURCE_BUSY);
-        return nullptr; // timer already started
     }
 
     TIM_Handle *handle = malloc(sizeof(TIM_Handle));
     if (handle == nullptr) {
-        return nullptr; // Memory allocation failed
+        THROW(ERROR_OUT_OF_MEMORY);
     }
 
     handle->tim_id = tim;
@@ -79,12 +77,10 @@ void TIM_start(size_t tim)
 {
     if (tim >= TIM_NUM_COUNT) {
         THROW(ERROR_INVALID_ARGUMENT);
-        return;
     }
 
     if (g_active_timers[tim] == nullptr) {
         THROW(ERROR_INVALID_ARGUMENT);
-        return;
     }
 
     TIM_LL_start((TIM_Num)tim);
@@ -102,7 +98,6 @@ void TIM_stop(size_t tim)
 {
     if (tim >= TIM_NUM_COUNT) {
         THROW(ERROR_INVALID_ARGUMENT);
-        return;
     }
 
     if (g_active_timers[tim] == nullptr) {

--- a/src/util/CExceptionConfig.h
+++ b/src/util/CExceptionConfig.h
@@ -1,0 +1,39 @@
+/**
+ * @file CExceptionConfig.h
+ * @brief CException library configuration for PSLab firmware
+ *
+ * This file configures the CException library for use in PSLab firmware.
+ * It provides a configurable uncaught exception handler mechanism that
+ * allows the hardware-agnostic util library to delegate error handling
+ * to platform-specific code.
+ */
+
+#ifndef CEXCEPTION_CONFIG_H
+#define CEXCEPTION_CONFIG_H
+
+#include "exception.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief CException configuration macro for uncaught exception handling
+ *
+ * This macro is called by the CException library when an exception is
+ * thrown but not caught. It delegates to the registered handler if one
+ * is set, otherwise it does nothing (which may result in undefined behavior).
+ *
+ * @param id The exception ID that was not caught
+ */
+#define CEXCEPTION_NO_CATCH_HANDLER(id)                                        \
+    do {                                                                       \
+        EXCEPTION_halt(id);                                                    \
+        __builtin_unreachable();                                               \
+    } while (0)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // CEXCEPTION_CONFIG_H

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -2,11 +2,16 @@ add_library(pslab-util STATIC)
 
 target_sources(pslab-util PRIVATE
     circular_buffer.c
+    exception.c
     logging.c
 )
 
 target_include_directories(pslab-util PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+target_compile_definitions(pslab-util PUBLIC
+    CEXCEPTION_USE_CONFIG_FILE
 )
 
 target_link_libraries(pslab-util PUBLIC

--- a/src/util/circular_buffer.c
+++ b/src/util/circular_buffer.c
@@ -23,13 +23,11 @@ void circular_buffer_init(CircularBuffer *cb, uint8_t *buffer, uint32_t size)
 {
     if (!cb || !buffer) {
         THROW(ERROR_INVALID_ARGUMENT);
-        return;
     }
 
     // Require power of two size
     if ((size == 0) || (size & (size - 1)) != 0) {
         THROW(ERROR_INVALID_ARGUMENT);
-        return;
     }
     cb->buffer = buffer;
     cb->head = 0;
@@ -48,7 +46,6 @@ bool circular_buffer_is_empty(CircularBuffer *cb)
 {
     if (!cb) {
         THROW(ERROR_INVALID_ARGUMENT);
-        return true;
     }
     return cb->head == cb->tail;
 }
@@ -63,7 +60,6 @@ bool circular_buffer_is_full(CircularBuffer *cb)
 {
     if (!cb) {
         THROW(ERROR_INVALID_ARGUMENT);
-        return true;
     }
     return ((cb->head + 1) & cb->mask) == cb->tail;
 }
@@ -78,7 +74,6 @@ uint32_t circular_buffer_available(CircularBuffer *cb)
 {
     if (!cb) {
         THROW(ERROR_INVALID_ARGUMENT);
-        return 0;
     }
     return (cb->head - cb->tail) & cb->mask;
 }
@@ -94,7 +89,6 @@ bool circular_buffer_put(CircularBuffer *cb, uint8_t data)
 {
     if (!cb) {
         THROW(ERROR_INVALID_ARGUMENT);
-        return false;
     }
 
     if (circular_buffer_is_full(cb)) {
@@ -117,7 +111,6 @@ bool circular_buffer_get(CircularBuffer *cb, uint8_t *data)
 {
     if (!cb || !data) {
         THROW(ERROR_INVALID_ARGUMENT);
-        return false;
     }
 
     if (circular_buffer_is_empty(cb)) {
@@ -138,7 +131,6 @@ void circular_buffer_reset(CircularBuffer *cb)
 {
     if (!cb) {
         THROW(ERROR_INVALID_ARGUMENT);
-        return;
     }
     cb->head = cb->tail = 0;
 }
@@ -159,7 +151,6 @@ uint32_t circular_buffer_write(
 {
     if (!cb || !data) {
         THROW(ERROR_INVALID_ARGUMENT);
-        return 0;
     }
 
     uint32_t bytes_written = 0;
@@ -187,7 +178,6 @@ uint32_t circular_buffer_read(CircularBuffer *cb, uint8_t *data, uint32_t len)
 {
     if (!cb || !data) {
         THROW(ERROR_INVALID_ARGUMENT);
-        return 0;
     }
 
     uint32_t bytes_read = 0;
@@ -213,7 +203,6 @@ uint32_t circular_buffer_free_space(CircularBuffer *cb)
 {
     if (!cb) {
         THROW(ERROR_INVALID_ARGUMENT);
-        return 0;
     }
     return (cb->size - 1) - ((cb->head - cb->tail) & cb->mask);
 }

--- a/src/util/error.h
+++ b/src/util/error.h
@@ -11,6 +11,7 @@
 #define PSLAB_ERROR_H
 
 #include "CException.h"
+#include "exception.h"
 #include <errno.h>
 #include <stdint.h>
 
@@ -27,7 +28,16 @@
 #define TRY Try
 // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
 #define CATCH Catch
-#define THROW Throw
+#define THROW(error)                                                           \
+    do {                                                                       \
+        Throw(error);                                                          \
+        /* At this point, control flow has passed to either:                   \
+           1. Catch block                                                      \
+           2. Last resort noreturn exception handler (EXCEPTION_halt)          \
+           This means that control never reaches this point.                   \
+         */                                                                    \
+        __builtin_unreachable();                                               \
+    } while (0)
 
 /**
  * @brief PSLab-specific error codes

--- a/src/util/exception.c
+++ b/src/util/exception.c
@@ -1,0 +1,19 @@
+/**
+ * @file exception.c
+ * @brief CException configuration implementation
+ *
+ * This file implements the configurable exception handler mechanism
+ * for the CException library integration.
+ */
+
+#include "exception.h"
+#include "logging.h"
+#include <stdint.h>
+
+__attribute__((weak, noreturn)) void EXCEPTION_halt(uint32_t exception_id)
+{
+    (void)exception_id;
+    // Default implementation does nothing and hangs indefinitely
+    while (1) {
+    }
+}

--- a/src/util/exception.h
+++ b/src/util/exception.h
@@ -1,0 +1,38 @@
+/**
+ * @file exception.h
+ * @brief Exception handler type definitions and declarations
+ *
+ * This header provides the exception handler types and function declarations
+ * needed by both the CException configuration and the main error handling
+ * system. It exists as a separate header to avoid circular dependencies.
+ */
+
+#ifndef PSLAB_EXCEPTION_H
+#define PSLAB_EXCEPTION_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Last resort uncaught exception handler
+ *
+ * This function is called when an exception is thrown but not caught.
+ * The default implementation does nothing and hangs indefinitely.
+ *
+ * It is recommended to provide platform-specific behavior to reset or
+ * otherwise recover the system by overriding this function.
+ *
+ * @param exception_id The ID (error code) of the uncaught exception
+ *
+ * @note Overriding functions must not return.
+ */
+__attribute__((weak, noreturn)) void EXCEPTION_halt(uint32_t exception_id);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // PSLAB_EXCEPTION_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,7 +7,7 @@ target_include_directories(unity PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/unity/src/)
 # CMock mocking framework
 add_library(cmock ${CMAKE_CURRENT_SOURCE_DIR}/cmock/src/cmock.c)
 target_include_directories(cmock PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/cmock/src/)
-target_link_libraries(cmock unity)
+target_link_libraries(cmock cexception unity)
 
 # Generate mocks for UART dependencies
 cmock_generate_mock(mock_uart_ll ${CMAKE_CURRENT_SOURCE_DIR}/../src/platform/uart_ll.h)


### PR DESCRIPTION
This PR adds handling of uncaught CException throws to the error system.

If a THROW is hit outside of a TRY context, the EXCEPTION_halt function is called via CEXCEPTION_NO_CATCH_HANDLER macro. EXCEPTION_halt is weakly defined in pslab-util, where it simply hangs the system, and non-weakly defined in pslab-system, where it logs the error and resets the hardware.

PLATFORM_reset has been added, which resets the STM32H563xx MCU.

Previously, THROW was commonly followed by return in case of non-TRY contexts. There returns are have been removed.

The UART tests erroneously depended on execution continuing after THROW outside of TRY context. This has been fixed.

## Summary by Sourcery

Add robust uncaught exception support by using CException’s no-catch handler to call a platform-weak EXCEPTION_halt, implement EXCEPTION_halt in system to log and reset via a new PLATFORM_reset, update THROW macro to be noreturn and remove unreachable returns after THROW, adjust UART tests to use TRY/CATCH and assert thrown errors, and include new exception configuration files in the build.

New Features:
- Configure CException to invoke EXCEPTION_halt on uncaught throws
- Implement EXCEPTION_halt in system to log a fatal error and trigger PLATFORM_reset
- Add PLATFORM_reset for software-triggered MCU reset

Bug Fixes:
- Update UART tests to stop assuming execution continues after THROW and assert on caught errors

Enhancements:
- Redefine THROW macro to call Throw and mark it noreturn
- Remove redundant return statements following THROW
- Include exception.c and CExceptionConfig.h in util and enable CEXCEPTION_USE_CONFIG_FILE

Build:
- Link cmock against cexception for proper exception handling in tests
- Update util CMakeLists to add exception.c and define CEXCEPTION_USE_CONFIG_FILE