### PR TITLE
Increase cyclomatic complexity limit

### DIFF
--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -48,7 +48,7 @@ CheckOptions:
   - key: bugprone-easily-swappable-parameters.ModelImplicitConversions
     value: false
   - key: readability-function-cognitive-complexity.Threshold
-    value: '10'
+    value: '20'
   - key: readability-function-size.LineThreshold
     value: '80'
 


### PR DESCRIPTION
Since CException uses branching in its Try/Catch macros, they artificially inflate cyclomatic complexity. Even simple functions were hitting the limit, necessitating this increase.

## Summary by Sourcery

Enhancements:
- Raise cyclomatic complexity threshold in clang-tidy configuration to accommodate CException macros