### PR TITLE
Add yellow and red LEDs

### DIFF
--- a/src/application/main.c
+++ b/src/application/main.c
@@ -97,7 +97,7 @@ int main(void) // NOLINT
 
         if (g_usb_service_requested) {
             g_usb_service_requested = false;
-            LED_toggle();
+            LED_toggle(LED_GREEN);
             uint8_t buf[CB_THRESHOLD + 1] = { 0 };
             uint32_t bytes_read = USB_read(husb, buf, CB_THRESHOLD);
             buf[bytes_read] = '\0';

--- a/src/platform/h563xx/led_ll.c
+++ b/src/platform/h563xx/led_ll.c
@@ -7,10 +7,12 @@
  *
  * Hardware Implementation Details:
  * - Uses STM32H5xx HAL library for GPIO operations
- * - LED1 is connected to GPIOB Pin 0 (PB0)
+ * - LED_GREEN (LED1) is connected to GPIOB Pin 0 (PB0)
+ * - LED_YELLOW (LED2) is connected to GPIOF Pin 4 (PF4)
+ * - LED_RED (LED3) is connected to GPIOG Pin 4 (PG4)
  * - Configured as push-pull output with no pull-up/pull-down resistors
  * - Low frequency GPIO speed setting for power efficiency
- * - Requires GPIOB clock to be enabled
+ * - Requires GPIOB, GPIOF, and GPIOG clocks to be enabled
  *
  * @author PSLab Team
  * @date 2025
@@ -20,37 +22,81 @@
 
 #include "led_ll.h"
 
-#define LED1_GPIO_GROUP GPIOB
-#define LED1_GPIO_PIN GPIO_PIN_0
+#define LED_GREEN_GPIO_GROUP GPIOB
+#define LED_GREEN_GPIO_PIN GPIO_PIN_0
+
+#define LED_YELLOW_GPIO_GROUP GPIOF
+#define LED_YELLOW_GPIO_PIN GPIO_PIN_4
+
+#define LED_RED_GPIO_GROUP GPIOG
+#define LED_RED_GPIO_PIN GPIO_PIN_4
+
+typedef struct {
+    GPIO_TypeDef *gpio_group;
+    uint16_t gpio_pin;
+} LEDConfig;
+
+static LEDConfig const g_LED_CONFIGS[LED_LL_COUNT] = {
+    [LED_LL_GREEN] = { LED_GREEN_GPIO_GROUP, LED_GREEN_GPIO_PIN },
+    [LED_LL_YELLOW] = { LED_YELLOW_GPIO_GROUP, LED_YELLOW_GPIO_PIN },
+    [LED_LL_RED] = { LED_RED_GPIO_GROUP, LED_RED_GPIO_PIN },
+};
 
 /**
  * @brief Initialize the LED hardware
  *
- * Configures GPIO Port B Pin 0 (PB0) as an output pin for LED control.
- * Enables the GPIOB clock and sets up the pin as push-pull output with
- * low frequency speed for optimal power consumption.
+ * Configures all LED GPIO pins as outputs and enables the necessary GPIO
+ * clocks. Sets up all pins as push-pull outputs with low frequency speed for
+ * optimal power consumption.
  */
 void LED_LL_init(void)
 {
     GPIO_InitTypeDef gpio_init = { 0 };
 
-    /* GPIO ports clock enable. */
+    /* Enable GPIO port clocks */
     __HAL_RCC_GPIOB_CLK_ENABLE();
+    __HAL_RCC_GPIOF_CLK_ENABLE();
+    __HAL_RCC_GPIOG_CLK_ENABLE();
 
-    /* Configure the LED GPIO pin. */
-    gpio_init.Pin = GPIO_PIN_0;
+    /* Configure common GPIO settings */
     gpio_init.Mode = GPIO_MODE_OUTPUT_PP;
     gpio_init.Pull = GPIO_NOPULL;
     gpio_init.Speed = GPIO_SPEED_FREQ_LOW;
-    HAL_GPIO_Init(GPIOB, &gpio_init);
+
+    /* Configure each LED pin */
+    for (int i = 0; i < LED_LL_COUNT; ++i) {
+        gpio_init.Pin = g_LED_CONFIGS[i].gpio_pin;
+        HAL_GPIO_Init(g_LED_CONFIGS[i].gpio_group, &gpio_init);
+    }
 }
 
-/**
- * @brief Toggle the LED state
- *
- * Uses the STM32H5xx HAL library function to toggle the GPIO pin state.
- * This will turn the LED on if it was off, or off if it was on.
- *
- * @note LED_LL_init() must be called before using this function.
- */
-void LED_LL_toggle(void) { HAL_GPIO_TogglePin(LED1_GPIO_GROUP, LED1_GPIO_PIN); }
+void LED_LL_on(LED_LL_ID led_id)
+{
+    if (led_id < LED_LL_COUNT) {
+        HAL_GPIO_WritePin(
+            g_LED_CONFIGS[led_id].gpio_group,
+            g_LED_CONFIGS[led_id].gpio_pin,
+            GPIO_PIN_SET
+        );
+    }
+}
+
+void LED_LL_off(LED_LL_ID led_id)
+{
+    if (led_id < LED_LL_COUNT) {
+        HAL_GPIO_WritePin(
+            g_LED_CONFIGS[led_id].gpio_group,
+            g_LED_CONFIGS[led_id].gpio_pin,
+            GPIO_PIN_RESET
+        );
+    }
+}
+
+void LED_LL_toggle(LED_LL_ID led_id)
+{
+    if (led_id < LED_LL_COUNT) {
+        HAL_GPIO_TogglePin(
+            g_LED_CONFIGS[led_id].gpio_group, g_LED_CONFIGS[led_id].gpio_pin
+        );
+    }
+}

--- a/src/platform/led_ll.h
+++ b/src/platform/led_ll.h
@@ -14,19 +14,50 @@
 #define PSLAB_LL_LED_H
 
 /**
+ * @brief LED identifiers for the Nucleo-H563ZI board
+ */
+typedef enum {
+    LED_LL_GREEN = 0, /**< Green LED on PB0 */
+    LED_LL_YELLOW, /**< Yellow LED on PF4 */
+    LED_LL_RED, /**< Red LED on PG4 */
+    LED_LL_COUNT /**< Total number of LEDs */
+} LED_LL_ID;
+
+/**
  * @brief Initialize the LED hardware
  *
- * Configures the GPIO pins and enables the necessary clocks for LED control.
- * This function must be called before any other LED operations.
+ * Configures the GPIO pins and enables the necessary clocks for all LED
+ * control. This function must be called before any other LED operations.
  */
 void LED_LL_init(void);
 
 /**
- * @brief Toggle the LED state
+ * @brief Turn on the specified LED
  *
- * Toggles the current state of the onboard LED (on->off, off->on).
- * The LED must be initialized with LED_LL_init() before calling this function.
+ * @pre LED_LL_init() must be called before using this function.
+ *
+ * @param led_id The ID of the LED to turn on (LED_LL_GREEN, LED_LL_YELLOW, or
+ *               LED_LL_RED).
  */
-void LED_LL_toggle(void);
+void LED_LL_on(LED_LL_ID led_id);
+
+/**
+ * @brief Turn off the specified LED
+ *
+ * @pre LED_LL_init() must be called before using this function.
+ *
+ * @param led_id The ID of the LED to turn off (LED_LL_GREEN, LED_LL_YELLOW, or
+ *               LED_LL_RED).
+ */
+void LED_LL_off(LED_LL_ID led_id);
+
+/**
+ * @brief Toggle the specified LED state
+ *
+ * @pre LED_LL_init() must be called before using this function.
+ *
+ * @param led_id The LED to toggle (LED_LL_GREEN, LED_LL_YELLOW, or LED_LL_RED)
+ */
+void LED_LL_toggle(LED_LL_ID led_id);
 
 #endif // PSLAB_LL_LED_H

--- a/src/system/led.c
+++ b/src/system/led.c
@@ -3,16 +3,45 @@
  * @brief LED system implementation - simple wrapper around the led_ll interface
  *
  * This module implements the LED system interface by wrapping calls to the
- * low-level LED hardware abstraction layer (led_ll). It provides a clean
- * separation between the application layer and hardware-specific
- * implementation.
+ * low-level LED hardware abstraction layer (led_ll).
  */
 
 #include "platform/led_ll.h"
-#include "util/error.h"
+#include "util/logging.h"
 
 #include "led.h"
 
+static LED_LL_ID const g_LED_MAPPING[LED_COUNT] = {
+    [LED_GREEN] = LED_LL_GREEN,
+    [LED_YELLOW] = LED_LL_YELLOW,
+    [LED_RED] = LED_LL_RED,
+};
+
+static char const *const g_LED_INVALID_WARN_MSG =
+    "Attempted to access invalid LED ID: %d";
+
 void LED_init(void) { LED_LL_init(); }
 
-void LED_toggle(void) { LED_LL_toggle(); }
+void LED_on(LED_ID led_id)
+{
+    if (led_id < LED_COUNT) {
+        LED_LL_on(g_LED_MAPPING[led_id]);
+    }
+    LOG_WARN(g_LED_INVALID_WARN_MSG, led_id);
+}
+
+void LED_off(LED_ID led_id)
+{
+    if (led_id < LED_COUNT) {
+        LED_LL_off(g_LED_MAPPING[led_id]);
+    }
+    LOG_WARN(g_LED_INVALID_WARN_MSG, led_id);
+}
+
+void LED_toggle(LED_ID led_id)
+{
+    if (led_id < LED_COUNT) {
+        LED_LL_toggle(g_LED_MAPPING[led_id]);
+    }
+    LOG_WARN(g_LED_INVALID_WARN_MSG, led_id);
+}

--- a/src/system/led.h
+++ b/src/system/led.h
@@ -1,14 +1,14 @@
 /**
  * @file led.h
- * @brief LED system interface - simple wrapper around the led_ll interface
+ * @brief LED system interface
  *
- * This module provides a high-level LED interface that wraps the low-level
- * LED hardware abstraction layer (led_ll). It offers a clean,
- * platform-independent API for LED control operations.
+ * This module provides a high-level LED interface.
  */
 
 #ifndef SYSTEM_LED_H
 #define SYSTEM_LED_H
+
+typedef enum { LED_GREEN, LED_YELLOW, LED_RED, LED_COUNT } LED_ID;
 
 /**
  * @brief Initialize the LED system
@@ -19,10 +19,33 @@
 void LED_init(void);
 
 /**
+ * @brief Turn on the specified LED
+ *
+ * Activates the specified LED, turning it on.
+ *
+ * @param led_id The ID of the LED to turn on (LED_GREEN, LED_YELLOW, or
+ *               LED_RED)
+ */
+void LED_on(LED_ID led_id);
+
+/**
+ * @brief Turn off the specified LED
+ *
+ * Deactivates the specified LED, turning it off.
+ *
+ * @param led_id The ID of the LED to turn off (LED_GREEN, LED_YELLOW, or
+ *               LED_RED)
+ */
+void LED_off(LED_ID led_id);
+
+/**
  * @brief Toggle the LED state
  *
  * Switches the LED from its current state (on to off, or off to on).
+ *
+ * @param led_id The ID of the LED to toggle (LED_GREEN, LED_YELLOW, or
+ *               LED_RED)
  */
-void LED_toggle(void);
+void LED_toggle(LED_ID led_id);
 
 #endif // SYSTEM_LED_H


### PR DESCRIPTION
## Summary by Sourcery

Add support for yellow and red LEDs by generalizing the low-level driver with a configuration array, introducing on/off APIs, extending the high-level LED interface with identifiers and logging, and updating documentation accordingly.

New Features:
- Support yellow (PF4) and red (PG4) LEDs in addition to the existing green LED
- Add LED_LL_on and LED_LL_off functions alongside toggle in the low-level driver
- Extend high-level interface with LED_on and LED_off functions and LED_ID enum

Enhancements:
- Refactor low-level driver to use an LEDConfig array and loop-based initialization for all LEDs, and enable GPIOB, GPIOF, and GPIOG clocks
- Map high-level LED_ID to low-level IDs and add warning logs for invalid LED access

Documentation:
- Update low-level and system-level header comments to document new LED identifiers and APIs