### PR TITLE
Fix incorrect LED warning message

### DIFF
--- a/src/system/led.c
+++ b/src/system/led.c
@@ -26,6 +26,7 @@ void LED_on(LED_ID led_id)
 {
     if (led_id < LED_COUNT) {
         LED_LL_on(g_LED_MAPPING[led_id]);
+        return;
     }
     LOG_WARN(g_LED_INVALID_WARN_MSG, led_id);
 }
@@ -34,6 +35,7 @@ void LED_off(LED_ID led_id)
 {
     if (led_id < LED_COUNT) {
         LED_LL_off(g_LED_MAPPING[led_id]);
+        return;
     }
     LOG_WARN(g_LED_INVALID_WARN_MSG, led_id);
 }
@@ -42,6 +44,7 @@ void LED_toggle(LED_ID led_id)
 {
     if (led_id < LED_COUNT) {
         LED_LL_toggle(g_LED_MAPPING[led_id]);
+        return;
     }
     LOG_WARN(g_LED_INVALID_WARN_MSG, led_id);
 }


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Add return statements in LED_on, LED_off, and LED_toggle to ensure warnings are only emitted for invalid LED IDs.