### PR TITLE
Fix compile-time log level filter

### DIFF
--- a/src/application/main.c
+++ b/src/application/main.c
@@ -87,6 +87,7 @@ int main(void) // NOLINT
             LOG_INFO("System running, USB active");
             FIXED_Q1616 voltage = FIXED_ZERO;
             bool new_reading = DMM_read_voltage(dmmh, &voltage);
+            (void)new_reading;
             LOG_INFO(
                 "DMM Channel 0 Voltage: %d.%04d V (new_reading=%s)",
                 FIXED_get_integer_part(voltage),

--- a/src/system/led.c
+++ b/src/system/led.c
@@ -20,7 +20,12 @@ static LED_LL_ID const g_LED_MAPPING[LED_COUNT] = {
 static char const *const g_LED_INVALID_WARN_MSG =
     "Attempted to access invalid LED ID: %d";
 
-void LED_init(void) { LED_LL_init(); }
+void LED_init(void)
+{
+    // Silence unused variable warning when log level is <= WARN
+    (void)g_LED_INVALID_WARN_MSG;
+    LED_LL_init();
+}
 
 void LED_on(LED_ID led_id)
 {

--- a/src/util/logging.h
+++ b/src/util/logging.h
@@ -130,6 +130,12 @@ bool LOG_read_entry(LOG_Entry *entry);
  */
 int LOG_task(uint32_t max_entries);
 
+// The preprocessor can't see the enum values
+#define LOG_LEVEL_ERROR 0
+#define LOG_LEVEL_WARN 1
+#define LOG_LEVEL_INFO 2
+#define LOG_LEVEL_DEBUG 3
+
 /**
  * @brief Core logging macros with compile-time filtering
  */
@@ -156,6 +162,12 @@ int LOG_task(uint32_t max_entries);
 #else
 #define LOG_DEBUG(fmt, ...) ((void)0)
 #endif
+
+// Restore the enum values
+#undef LOG_LEVEL_ERROR
+#undef LOG_LEVEL_WARN
+#undef LOG_LEVEL_INFO
+#undef LOG_LEVEL_DEBUG
 
 /**
  * @brief Convenience macros for common patterns


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Add and remove preprocessor macros for log levels to allow use of enum values in compile-time filtering