### PR TITLE
Add SYSTEM_get_tick

### DIFF
--- a/src/system/system.c
+++ b/src/system/system.c
@@ -26,6 +26,8 @@ void SYSTEM_init(void)
     LED_init();
 }
 
+uint32_t SYSTEM_get_tick(void) { return PLATFORM_get_tick(); }
+
 __attribute__((noreturn)) void SYSTEM_reset(void)
 {
     LOG_INFO("Resetting...");

--- a/src/system/system.h
+++ b/src/system/system.h
@@ -24,6 +24,13 @@
 void SYSTEM_init(void);
 
 /**
+ * @brief Get the current system tick count
+ *
+ * @return The current tick count.
+ */
+uint32_t SYSTEM_get_tick(void);
+
+/**
  * @brief Reset system
  *
  * This function resets the system after flushing any pending log messages.


### PR DESCRIPTION
## Summary by Sourcery

Add a new API function to retrieve the current system tick count

New Features:
- Add SYSTEM_get_tick function declaration in system.h

Enhancements:
- Implement SYSTEM_get_tick by forwarding to PLATFORM_get_tick in system.c