### PR TITLE
Configure clock for crystal oscillator

### DIFF
--- a/boot/main.c
+++ b/boot/main.c
@@ -147,9 +147,7 @@ static void SystemClock_Config(void)
     ;
   }
 
-  /* Enable the HSE clock in bypass mode. */
-  LL_RCC_HSE_EnableBypass();
-  LL_RCC_HSE_SetExternalClockType(LL_RCC_HSE_ANALOG_TYPE);
+  /* Enable the HSE clock with crystal oscillator. */
   LL_RCC_HSE_Enable();
   /* Wait till HSE is ready. */
   while(LL_RCC_HSE_IsReady() != 1)
@@ -167,10 +165,10 @@ static void SystemClock_Config(void)
 
   /* Configure and enable the PLL. */
   LL_RCC_PLL1_SetSource(LL_RCC_PLL1SOURCE_HSE);
-  LL_RCC_PLL1_SetVCOInputRange(LL_RCC_PLLINPUTRANGE_2_4);
+  LL_RCC_PLL1_SetVCOInputRange(LL_RCC_PLLINPUTRANGE_4_8);
   LL_RCC_PLL1_SetVCOOutputRange(LL_RCC_PLLVCORANGE_WIDE);
-  LL_RCC_PLL1_SetM(4);
-  LL_RCC_PLL1_SetN(250);
+  LL_RCC_PLL1_SetM(5);
+  LL_RCC_PLL1_SetN(100);
   LL_RCC_PLL1_SetP(2);
   LL_RCC_PLL1_SetQ(25);
   LL_RCC_PLL1_SetR(2);

--- a/boot/stm32h5xx_hal_conf.h
+++ b/boot/stm32h5xx_hal_conf.h
@@ -102,7 +102,7 @@
   *        (when HSE is used as system clock source, directly or through the PLL).
   */
 #if !defined  (HSE_VALUE)
-  #define HSE_VALUE    8000000U /*!< Value of the External oscillator in Hz */
+  #define HSE_VALUE    25000000U /*!< Value of the External oscillator in Hz */
 #endif /* HSE_VALUE */
 
 #if !defined  (HSE_STARTUP_TIMEOUT)

--- a/src/platform/h563xx/platform.c
+++ b/src/platform/h563xx/platform.c
@@ -98,17 +98,16 @@ static void system_clock_config(void)
      * in the RCC_OscInitTypeDef structure.
      */
     osc_init.OscillatorType = RCC_OSCILLATORTYPE_HSE | RCC_OSCILLATORTYPE_HSI48;
-    osc_init.HSEState = RCC_HSE_BYPASS;
+    osc_init.HSEState = RCC_HSE_ON;
     osc_init.HSI48State = RCC_HSI48_ON;
     osc_init.PLL.PLLState = RCC_PLL_ON;
     osc_init.PLL.PLLSource = RCC_PLL1_SOURCE_HSE;
-    osc_init.PLL.PLLM = 4; // 8 MHz / 4 = 2 MHz input
-    osc_init.PLL.PLLN =
-        SYSTEM_CLOCK_FREQ / SI_PREFIX_MEGA; // 2 MHz * 250 = 500 MHz VCO
+    osc_init.PLL.PLLM = 5; // 25 MHz / 5 = 5 MHz input
+    osc_init.PLL.PLLN = 100; // 5 MHz * 100 = 500 MHz VCO
     osc_init.PLL.PLLP = 2; // 500 MHz / 2 = 250 MHz system clock
     osc_init.PLL.PLLQ = 2; // 500 MHz / 2 = 250 MHz peripheral clock
     osc_init.PLL.PLLR = 2; // 500 MHz / 2 = 250 MHz peripheral clock
-    osc_init.PLL.PLLRGE = RCC_PLL1_VCIRANGE_1;
+    osc_init.PLL.PLLRGE = RCC_PLL1_VCIRANGE_2;
     osc_init.PLL.PLLVCOSEL = RCC_PLL1_VCORANGE_WIDE;
     osc_init.PLL.PLLFRACN = 0;
 
@@ -144,13 +143,13 @@ static void system_clock_config(void)
     // This is required because HAL_RCCEx_PeriphCLKConfig calls
     // RCCEx_PLL2_Config internally
     periph_clk_init.PLL2.PLL2Source = RCC_PLL2_SOURCE_HSE;
-    periph_clk_init.PLL2.PLL2M = 2; // 8 MHz / 2 = 4 MHz
+    periph_clk_init.PLL2.PLL2M = 5; // 25 MHz / 5 = 5 MHz
     // NOLINTNEXTLINE: readability-magic-numbers
-    periph_clk_init.PLL2.PLL2N = 75; // 4 MHz * 75 = 300 MHz VCO
+    periph_clk_init.PLL2.PLL2N = 60; // 5 MHz * 60 = 300 MHz VCO
     periph_clk_init.PLL2.PLL2P = 2; // 300 MHz / 2 = 150 MHz
     periph_clk_init.PLL2.PLL2Q = 2; // 300 MHz / 2 = 150 MHz
     periph_clk_init.PLL2.PLL2R = 4; // 300 MHz / 4 = 75 MHz (for ADC)
-    periph_clk_init.PLL2.PLL2RGE = RCC_PLL2_VCIRANGE_1; // 2-4 MHz input range
+    periph_clk_init.PLL2.PLL2RGE = RCC_PLL2_VCIRANGE_2;
     periph_clk_init.PLL2.PLL2VCOSEL =
         RCC_PLL2_VCORANGE_MEDIUM; // 150-420 MHz VCO
     periph_clk_init.PLL2.PLL2FRACN = 0;

--- a/src/platform/h563xx/stm32h5xx_hal_conf.h
+++ b/src/platform/h563xx/stm32h5xx_hal_conf.h
@@ -102,7 +102,7 @@ extern "C" {
  * PLL).
  */
 #if !defined(HSE_VALUE)
-#define HSE_VALUE 8000000UL /*!< Value of the External oscillator in Hz */
+#define HSE_VALUE 25000000UL /*!< Value of the External oscillator in Hz */
 #endif                      /* HSE_VALUE */
 
 #if !defined(HSE_STARTUP_TIMEOUT)


### PR DESCRIPTION
This PR changes the clock config to use the 25 MHz crystal oscillator instead of using the Nucleo's onboard ST-Link as HSE source.

## Summary by Sourcery

Configure the system clock to use a 25 MHz external crystal oscillator instead of the ST-Link bypass and update all related PLL and HSE settings accordingly

Enhancements:
- Enable HSE in crystal oscillator mode and disable bypass
- Recalculate PLL1 and PLL2 prescalers, multipliers, and VCI ranges for a 25 MHz input to maintain existing clock frequencies
- Update HSE_VALUE macros to reflect the 25 MHz external oscillator value