### PR TITLE
Rename tim_ll timers to match underlying hardware

### DIFF
--- a/src/platform/h563xx/tim_ll.c
+++ b/src/platform/h563xx/tim_ll.c
@@ -36,11 +36,11 @@ static TIM_HandleTypeDef g_htim7 = { nullptr };
 
 /*Array of Timer Instances*/
 static TimerInstance g_timer_instances[TIM_NUM_COUNT] = {
-    [TIM_NUM_0] = {
+    [TIM_NUM_6] = {
         .htim = &g_htim6,
         .initialized = false,
     },
-    [TIM_NUM_1] = {
+    [TIM_NUM_7] = {
         .htim = &g_htim7,
         .initialized = false,
     },
@@ -168,10 +168,10 @@ void TIM_LL_init(TIM_Num tim, uint32_t freq)
 
     instance->frequency = freq;
 
-    if (tim == TIM_NUM_0) {
+    if (tim == TIM_NUM_6) {
         instance->htim->Instance = TIM6;
         instance->htim->Channel = TIM_CHANNEL_1;
-    } else if (tim == TIM_NUM_1) {
+    } else if (tim == TIM_NUM_7) {
         instance->htim->Instance = TIM7;
         instance->htim->Channel = TIM_CHANNEL_1;
     }

--- a/src/platform/tim_ll.h
+++ b/src/platform/tim_ll.h
@@ -19,7 +19,7 @@
 /*
  * @brief TIM instance enumeration
  */
-typedef enum { TIM_NUM_0 = 0, TIM_NUM_1 = 1, TIM_NUM_COUNT = 2 } TIM_Num;
+typedef enum { TIM_NUM_6 = 0, TIM_NUM_7 = 1, TIM_NUM_COUNT = 2 } TIM_Num;
 
 /**
  * @brief Initialize the Timer Module

--- a/src/system/instrument/dmm.c
+++ b/src/system/instrument/dmm.c
@@ -190,7 +190,7 @@ static void dmm_init_timer(DMM_Handle *handle)
     LOG_FUNCTION_ENTRY();
 
     Error error = ERROR_NONE;
-    TRY { TIM_LL_init(TIM_NUM_0, ADC_LL_get_sample_rate()); }
+    TRY { TIM_LL_init(TIM_NUM_6, ADC_LL_get_sample_rate()); }
     CATCH(error)
     {
         LOG_ERROR("DMM: Timer init failed, error %d", error);
@@ -211,15 +211,15 @@ static void dmm_start_conversion(DMM_Handle *handle)
     Error error = ERROR_NONE;
     TRY
     {
-        TIM_LL_start(TIM_NUM_0); // Start timer for ADC triggering
+        TIM_LL_start(TIM_NUM_6); // Start timer for ADC triggering
         ADC_LL_start();
     }
     CATCH(error)
     {
         LOG_ERROR("DMM: Failed to start conversion, error %d", error);
-        TIM_LL_stop(TIM_NUM_0);
+        TIM_LL_stop(TIM_NUM_6);
         ADC_LL_deinit();
-        TIM_LL_deinit(TIM_NUM_0);
+        TIM_LL_deinit(TIM_NUM_6);
         g_dmm_handle = nullptr;
         free(handle);
         THROW(error);
@@ -290,11 +290,11 @@ void DMM_deinit(DMM_Handle *handle)
 
     // Stop ADC and timer
     ADC_LL_stop();
-    TIM_LL_stop(TIM_NUM_0);
+    TIM_LL_stop(TIM_NUM_6);
 
     // Deinitialize peripherals
     ADC_LL_deinit();
-    TIM_LL_deinit(TIM_NUM_0);
+    TIM_LL_deinit(TIM_NUM_6);
 
     // Clear global handle
     g_dmm_handle = nullptr;

--- a/tests/test_dmm.c
+++ b/tests/test_dmm.c
@@ -116,8 +116,8 @@ void test_DMM_init_success_default_config(void)
     ADC_LL_init_Stub(adc_init_success_stub);
     ADC_LL_get_sample_rate_ExpectAndReturn(1000); // 1 kHz sample rate for timer init
     ADC_LL_get_sample_rate_ExpectAndReturn(1000); // 1 kHz sample rate for logging
-    TIM_LL_init_Expect(TIM_NUM_0, 1000);
-    TIM_LL_start_Expect(TIM_NUM_0); // Expect timer start for initial conversion
+    TIM_LL_init_Expect(TIM_NUM_6, 1000);
+    TIM_LL_start_Expect(TIM_NUM_6); // Expect timer start for initial conversion
     ADC_LL_start_Expect(); // Expect ADC start for initial conversion
 
     // Act
@@ -141,8 +141,8 @@ void test_DMM_init_success_custom_config(void)
     ADC_LL_init_Ignore();
     ADC_LL_get_sample_rate_ExpectAndReturn(2000); // 2 kHz sample rate for timer init
     ADC_LL_get_sample_rate_ExpectAndReturn(2000); // 2 kHz sample rate for logging
-    TIM_LL_init_Expect(TIM_NUM_0, 2000);
-    TIM_LL_start_Expect(TIM_NUM_0); // Expect timer start for initial conversion
+    TIM_LL_init_Expect(TIM_NUM_6, 2000);
+    TIM_LL_start_Expect(TIM_NUM_6); // Expect timer start for initial conversion
     ADC_LL_start_Expect(); // Expect ADC start for initial conversion
 
     // Act
@@ -219,8 +219,8 @@ void test_DMM_init_already_initialized(void)
     ADC_LL_init_Ignore();
     ADC_LL_get_sample_rate_ExpectAndReturn(1000);
     ADC_LL_get_sample_rate_ExpectAndReturn(1000);
-    TIM_LL_init_Expect(TIM_NUM_0, 1000);
-    TIM_LL_start_Expect(TIM_NUM_0);
+    TIM_LL_init_Expect(TIM_NUM_6, 1000);
+    TIM_LL_start_Expect(TIM_NUM_6);
     ADC_LL_start_Expect();
 
     g_test_handle = DMM_init(&config);
@@ -270,7 +270,7 @@ void test_DMM_init_timer_failure(void)
     ADC_LL_set_complete_callback_Expect(dmm_adc_complete_callback);
     ADC_LL_init_Ignore(); // ADC init succeeds
     ADC_LL_get_sample_rate_ExpectAndReturn(1000); // For timer init
-    TIM_LL_init_ExpectAndThrow(TIM_NUM_0, 1000, ERROR_HARDWARE_FAULT);
+    TIM_LL_init_ExpectAndThrow(TIM_NUM_6, 1000, ERROR_HARDWARE_FAULT);
     ADC_LL_deinit_Expect(); // Cleanup after timer failure
 
     // Act & Assert
@@ -294,8 +294,8 @@ void test_DMM_deinit_valid_handle(void)
     ADC_LL_init_Ignore();
     ADC_LL_get_sample_rate_ExpectAndReturn(1000);
     ADC_LL_get_sample_rate_ExpectAndReturn(1000);
-    TIM_LL_init_Expect(TIM_NUM_0, 1000);
-    TIM_LL_start_Expect(TIM_NUM_0);
+    TIM_LL_init_Expect(TIM_NUM_6, 1000);
+    TIM_LL_start_Expect(TIM_NUM_6);
     ADC_LL_start_Expect();
 
     g_test_handle = DMM_init(&config);
@@ -303,9 +303,9 @@ void test_DMM_deinit_valid_handle(void)
 
     // Set expectations for deinit
     ADC_LL_stop_Expect();
-    TIM_LL_stop_Expect(TIM_NUM_0);
+    TIM_LL_stop_Expect(TIM_NUM_6);
     ADC_LL_deinit_Expect();
-    TIM_LL_deinit_Expect(TIM_NUM_0);
+    TIM_LL_deinit_Expect(TIM_NUM_6);
 
     // Act
     DMM_deinit(g_test_handle);
@@ -337,8 +337,8 @@ void test_DMM_read_voltage_success_conversion_ready(void)
     ADC_LL_init_Ignore();
     ADC_LL_get_sample_rate_ExpectAndReturn(1000);
     ADC_LL_get_sample_rate_ExpectAndReturn(1000);
-    TIM_LL_init_Expect(TIM_NUM_0, 1000);
-    TIM_LL_start_Expect(TIM_NUM_0);
+    TIM_LL_init_Expect(TIM_NUM_6, 1000);
+    TIM_LL_start_Expect(TIM_NUM_6);
     ADC_LL_start_Expect();
 
     g_test_handle = DMM_init(&config);
@@ -371,8 +371,8 @@ void test_DMM_read_voltage_no_conversion_ready(void)
     ADC_LL_init_Ignore();
     ADC_LL_get_sample_rate_ExpectAndReturn(1000);
     ADC_LL_get_sample_rate_ExpectAndReturn(1000);
-    TIM_LL_init_Expect(TIM_NUM_0, 1000);
-    TIM_LL_start_Expect(TIM_NUM_0);
+    TIM_LL_init_Expect(TIM_NUM_6, 1000);
+    TIM_LL_start_Expect(TIM_NUM_6);
     ADC_LL_start_Expect();
 
     g_test_handle = DMM_init(&config);
@@ -417,8 +417,8 @@ void test_DMM_read_voltage_null_output(void)
     ADC_LL_init_Ignore();
     ADC_LL_get_sample_rate_ExpectAndReturn(1000);
     ADC_LL_get_sample_rate_ExpectAndReturn(1000);
-    TIM_LL_init_Expect(TIM_NUM_0, 1000);
-    TIM_LL_start_Expect(TIM_NUM_0);
+    TIM_LL_init_Expect(TIM_NUM_6, 1000);
+    TIM_LL_start_Expect(TIM_NUM_6);
     ADC_LL_start_Expect();
 
     g_test_handle = DMM_init(&config);
@@ -447,8 +447,8 @@ void test_DMM_read_voltage_adc_start_failure(void)
     ADC_LL_init_Ignore();
     ADC_LL_get_sample_rate_ExpectAndReturn(1000);
     ADC_LL_get_sample_rate_ExpectAndReturn(1000);
-    TIM_LL_init_Expect(TIM_NUM_0, 1000);
-    TIM_LL_start_Expect(TIM_NUM_0);
+    TIM_LL_init_Expect(TIM_NUM_6, 1000);
+    TIM_LL_start_Expect(TIM_NUM_6);
     ADC_LL_start_Expect(); // Initial start succeeds
 
     g_test_handle = DMM_init(&config);
@@ -481,12 +481,12 @@ void test_DMM_read_voltage_timer_start_failure(void)
     ADC_LL_init_Ignore(); // ADC init succeeds
     ADC_LL_get_sample_rate_ExpectAndReturn(1000); // For timer init
     ADC_LL_get_sample_rate_ExpectAndReturn(1000); // For logging
-    TIM_LL_init_Expect(TIM_NUM_0, 1000); // Timer init succeeds
-    TIM_LL_start_Expect(TIM_NUM_0); // Timer start succeeds
+    TIM_LL_init_Expect(TIM_NUM_6, 1000); // Timer init succeeds
+    TIM_LL_start_Expect(TIM_NUM_6); // Timer start succeeds
     ADC_LL_start_ExpectAndThrow(ERROR_HARDWARE_FAULT); // ADC start fails
-    TIM_LL_stop_Expect(TIM_NUM_0); // Cleanup after start failure
+    TIM_LL_stop_Expect(TIM_NUM_6); // Cleanup after start failure
     ADC_LL_deinit_Expect(); // Cleanup after start failure
-    TIM_LL_deinit_Expect(TIM_NUM_0); // Cleanup after start failure
+    TIM_LL_deinit_Expect(TIM_NUM_6); // Cleanup after start failure
 
     // Act & Assert
     TRY {
@@ -513,8 +513,8 @@ void test_DMM_voltage_calculation_zero_adc(void)
     ADC_LL_init_Stub(adc_init_success_stub);
     ADC_LL_get_sample_rate_ExpectAndReturn(1000);
     ADC_LL_get_sample_rate_ExpectAndReturn(1000);
-    TIM_LL_init_Expect(TIM_NUM_0, 1000);
-    TIM_LL_start_Expect(TIM_NUM_0);
+    TIM_LL_init_Expect(TIM_NUM_6, 1000);
+    TIM_LL_start_Expect(TIM_NUM_6);
     ADC_LL_start_Expect();
 
     g_test_handle = DMM_init(&config);
@@ -548,8 +548,8 @@ void test_DMM_voltage_calculation_half_scale_adc(void)
     ADC_LL_init_Stub(adc_init_success_stub);
     ADC_LL_get_sample_rate_ExpectAndReturn(1000);
     ADC_LL_get_sample_rate_ExpectAndReturn(1000);
-    TIM_LL_init_Expect(TIM_NUM_0, 1000);
-    TIM_LL_start_Expect(TIM_NUM_0);
+    TIM_LL_init_Expect(TIM_NUM_6, 1000);
+    TIM_LL_start_Expect(TIM_NUM_6);
     ADC_LL_start_Expect();
 
     g_test_handle = DMM_init(&config);
@@ -590,8 +590,8 @@ void test_DMM_voltage_calculation_full_scale_adc(void)
     ADC_LL_init_Stub(adc_init_success_stub);
     ADC_LL_get_sample_rate_ExpectAndReturn(1000);
     ADC_LL_get_sample_rate_ExpectAndReturn(1000);
-    TIM_LL_init_Expect(TIM_NUM_0, 1000);
-    TIM_LL_start_Expect(TIM_NUM_0);
+    TIM_LL_init_Expect(TIM_NUM_6, 1000);
+    TIM_LL_start_Expect(TIM_NUM_6);
     ADC_LL_start_Expect();
 
     g_test_handle = DMM_init(&config);
@@ -629,8 +629,8 @@ void test_DMM_voltage_calculation_with_oversampling(void)
     ADC_LL_init_Stub(adc_init_success_stub);
     ADC_LL_get_sample_rate_ExpectAndReturn(1000);
     ADC_LL_get_sample_rate_ExpectAndReturn(1000);
-    TIM_LL_init_Expect(TIM_NUM_0, 1000);
-    TIM_LL_start_Expect(TIM_NUM_0);
+    TIM_LL_init_Expect(TIM_NUM_6, 1000);
+    TIM_LL_start_Expect(TIM_NUM_6);
     ADC_LL_start_Expect();
 
     g_test_handle = DMM_init(&config);
@@ -669,17 +669,17 @@ void test_DMM_config_validation_edge_cases(void)
         ADC_LL_init_Ignore();
         ADC_LL_get_sample_rate_ExpectAndReturn(1000);
         ADC_LL_get_sample_rate_ExpectAndReturn(1000);
-        TIM_LL_init_Expect(TIM_NUM_0, 1000);
-        TIM_LL_start_Expect(TIM_NUM_0);
+        TIM_LL_init_Expect(TIM_NUM_6, 1000);
+        TIM_LL_start_Expect(TIM_NUM_6);
         ADC_LL_start_Expect();
 
         g_test_handle = DMM_init(&config);
         TEST_ASSERT_NOT_NULL(g_test_handle);
 
         ADC_LL_stop_Expect();
-        TIM_LL_stop_Expect(TIM_NUM_0);
+        TIM_LL_stop_Expect(TIM_NUM_6);
         ADC_LL_deinit_Expect();
-        TIM_LL_deinit_Expect(TIM_NUM_0);
+        TIM_LL_deinit_Expect(TIM_NUM_6);
         DMM_deinit(g_test_handle);
         g_test_handle = NULL;
     }
@@ -711,17 +711,17 @@ void test_DMM_channel_mapping(void)
         ADC_LL_init_Ignore();
         ADC_LL_get_sample_rate_ExpectAndReturn(1000);
         ADC_LL_get_sample_rate_ExpectAndReturn(1000);
-        TIM_LL_init_Expect(TIM_NUM_0, 1000);
-        TIM_LL_start_Expect(TIM_NUM_0);
+        TIM_LL_init_Expect(TIM_NUM_6, 1000);
+        TIM_LL_start_Expect(TIM_NUM_6);
         ADC_LL_start_Expect();
 
         g_test_handle = DMM_init(&config);
         TEST_ASSERT_NOT_NULL(g_test_handle);
 
         ADC_LL_stop_Expect();
-        TIM_LL_stop_Expect(TIM_NUM_0);
+        TIM_LL_stop_Expect(TIM_NUM_6);
         ADC_LL_deinit_Expect();
-        TIM_LL_deinit_Expect(TIM_NUM_0);
+        TIM_LL_deinit_Expect(TIM_NUM_6);
         DMM_deinit(g_test_handle);
         g_test_handle = NULL;
     }


### PR DESCRIPTION
Mapping 0->6 and 1->7 was confusing. Renaming to match the underlying hardware timers makes it clearer which timer is which. At some point the names may be changed to reflect their actual function (e.g. TIM_TRIGGER, TIM_SAMPLE).

## Summary by Sourcery

Replace generic timer identifiers with hardware-specific constants by remapping TIM_NUM_0 to TIM_NUM_6 and TIM_NUM_1 to TIM_NUM_7 throughout the codebase

Enhancements:
- Update timer enumeration to TIM_NUM_6 and TIM_NUM_7 to reflect actual hardware timers
- Adjust tim_ll implementation to initialize and control TIM6 and TIM7 based on the new identifiers

Tests:
- Update all test suites to expect TIM_NUM_6 in place of TIM_NUM_0 for timer initialization, start, stop, and deinitialization