### PR TITLE
Remove ADCInstance.channel_count member

### DIFF
--- a/src/platform/adc_ll.h
+++ b/src/platform/adc_ll.h
@@ -56,8 +56,6 @@ typedef enum {
  */
 typedef struct {
     ADC_LL_Channel channels[MAX_SIMULTANEOUS_CHANNELS]; // ADC channels to use
-    uint8_t channel_count; // Number of channels (1 for single/interleaved,
-                           // 2 for simultaneous)
     ADC_LL_Mode mode; // ADC operation mode
     ADC_LL_TriggerSource trigger_source; // Timer trigger source
     uint16_t *output_buffer; // Output buffer for DMA transfer

--- a/src/system/instrument/dmm.c
+++ b/src/system/instrument/dmm.c
@@ -140,7 +140,6 @@ static ADC_LL_Config dmm_create_adc_config(DMM_Handle *handle)
 {
     ADC_LL_Config adc_config = {
         .channels = { dmm_channel_to_adc_ll(handle->config.channel) },
-        .channel_count = 1,
         .mode = ADC_LL_MODE_SINGLE,
         .trigger_source = ADC_TRIGGER_TIMER6,
         .output_buffer = &handle->adc_value,

--- a/tests/test_dmm.c
+++ b/tests/test_dmm.c
@@ -95,7 +95,6 @@ void adc_init_success_stub(ADC_LL_Config const *config, int cmock_num_calls)
     (void)cmock_num_calls;
     // Verify config is reasonable
     TEST_ASSERT_NOT_NULL(config);
-    TEST_ASSERT_EQUAL(1, config->channel_count);
     TEST_ASSERT_EQUAL(ADC_LL_MODE_SINGLE, config->mode);
     TEST_ASSERT_EQUAL(ADC_TRIGGER_TIMER6, config->trigger_source);
     TEST_ASSERT_NOT_NULL(config->output_buffer);


### PR DESCRIPTION
channel_count is redundant since the channel count can be derived from ADCInstance.mode.

## Summary by Sourcery

Eliminate the channel_count member in ADC configuration and instance, derive channel counts from the mode, and streamline related ADC initialization, calibration, and runtime logic accordingly

Enhancements:
- Remove the redundant channel_count field from ADCInstance and ADC_LL_Config
- Derive the number of active ADC channels from the ADC_LL_Mode instead of storing channel_count
- Simplify init, deinit, start, and calibration logic to use mode-based channel counts and remove obsolete validation
- Consolidate DMA clock enablement and dual-mode configuration under mode checks

Tests:
- Update test suite to remove channel_count assertions from ADC config validation