### PR TITLE
Disable magic number linting for PLL values

### DIFF
--- a/src/platform/h563xx/platform.c
+++ b/src/platform/h563xx/platform.c
@@ -102,11 +102,13 @@ static void system_clock_config(void)
     osc_init.HSI48State = RCC_HSI48_ON;
     osc_init.PLL.PLLState = RCC_PLL_ON;
     osc_init.PLL.PLLSource = RCC_PLL1_SOURCE_HSE;
+    // NOLINTBEGIN: readability-magic-numbers
     osc_init.PLL.PLLM = 5; // 25 MHz / 5 = 5 MHz input
     osc_init.PLL.PLLN = 100; // 5 MHz * 100 = 500 MHz VCO
     osc_init.PLL.PLLP = 2; // 500 MHz / 2 = 250 MHz system clock
     osc_init.PLL.PLLQ = 2; // 500 MHz / 2 = 250 MHz peripheral clock
     osc_init.PLL.PLLR = 2; // 500 MHz / 2 = 250 MHz peripheral clock
+    // NOLINTEND: readability-magic-numbers
     osc_init.PLL.PLLRGE = RCC_PLL1_VCIRANGE_2;
     osc_init.PLL.PLLVCOSEL = RCC_PLL1_VCORANGE_WIDE;
     osc_init.PLL.PLLFRACN = 0;
@@ -143,12 +145,13 @@ static void system_clock_config(void)
     // This is required because HAL_RCCEx_PeriphCLKConfig calls
     // RCCEx_PLL2_Config internally
     periph_clk_init.PLL2.PLL2Source = RCC_PLL2_SOURCE_HSE;
+    // NOLINTBEGIN: readability-magic-numbers
     periph_clk_init.PLL2.PLL2M = 5; // 25 MHz / 5 = 5 MHz
-    // NOLINTNEXTLINE: readability-magic-numbers
     periph_clk_init.PLL2.PLL2N = 60; // 5 MHz * 60 = 300 MHz VCO
     periph_clk_init.PLL2.PLL2P = 2; // 300 MHz / 2 = 150 MHz
     periph_clk_init.PLL2.PLL2Q = 2; // 300 MHz / 2 = 150 MHz
     periph_clk_init.PLL2.PLL2R = 4; // 300 MHz / 4 = 75 MHz (for ADC)
+    // NOLINTEND: readability-magic-numbers
     periph_clk_init.PLL2.PLL2RGE = RCC_PLL2_VCIRANGE_2;
     periph_clk_init.PLL2.PLL2VCOSEL =
         RCC_PLL2_VCORANGE_MEDIUM; // 150-420 MHz VCO


### PR DESCRIPTION
## Summary by Sourcery

Suppress lint warnings for magic numbers in PLL configuration by adding block-level NOLINT directives around constant assignments.

Enhancements:
- Wrap main PLL value assignments in system_clock_config with NOLINTBEGIN/NOLINTEND to disable magic-number linting
- Wrap peripheral PLL2 value assignments in system_clock_config with NOLINTBEGIN/NOLINTEND instead of using single-line NOLINTNEXTLINE