### PR TITLE
Enable workflows for prototype_1 branch

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -4,9 +4,11 @@ on:
   pull_request:
     branches:
       - main
+      - prototype_1
   push:
     branches:
       - main
+      - prototype_1
 
 jobs:
   code-checks:

--- a/.github/workflows/main-builder.yml
+++ b/.github/workflows/main-builder.yml
@@ -4,9 +4,11 @@ on:
   pull_request:
     branches:
       - main
+      - prototype_1
   push:
     branches:
       - main
+      - prototype_1
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -4,9 +4,11 @@ on:
   pull_request:
     branches:
       - main
+      - prototype_1
   push:
     branches:
       - main
+      - prototype_1
 
 jobs:
   unit-tests:
@@ -15,7 +17,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      
+
       - name: Init submodules
         run: |
           git submodule update --init --recursive


### PR DESCRIPTION
Until the main branch is retargeted to the prototype PCB, we want workflows to run on both main and prototype_1 branches.

## Summary by Sourcery

CI:
- Include prototype_1 branch in pull_request and push triggers for unit-tests, code-checks, and main-builder workflows