### PR TITLE
[DO NOT MERGE ] UART passthrough test

### DIFF
--- a/src/application/main.c
+++ b/src/application/main.c
@@ -1,6 +1,7 @@
 
 #include "protocol.h"
 #include "system/bus/uart.h"
+#include "system/esp.h"
 #include "system/led.h"
 #include "system/system.h"
 #include "util/error.h"
@@ -12,6 +13,9 @@ int main(void)
     SYSTEM_init();
     LOG_INIT("Main application");
 
+    ESP_init();
+    ESP_enter_bootloader();
+    
     // Enable UART passthrough
     uint8_t rx1_buffer[512];
     CircularBuffer rx1_cb;

--- a/src/application/main.c
+++ b/src/application/main.c
@@ -1,14 +1,33 @@
 
 #include "protocol.h"
+#include "system/bus/uart.h"
 #include "system/led.h"
 #include "system/system.h"
 #include "util/error.h"
 #include "util/logging.h"
+#include "util/util.h"
 
 int main(void)
 {
     SYSTEM_init();
     LOG_INIT("Main application");
+
+    // Enable UART passthrough
+    uint8_t rx1_buffer[512];
+    CircularBuffer rx1_cb;
+    circular_buffer_init(&rx1_cb, rx1_buffer, sizeof(rx1_buffer));
+    uint8_t tx1_buffer[512];
+    CircularBuffer tx1_cb;
+    circular_buffer_init(&tx1_cb, tx1_buffer, sizeof(tx1_buffer));
+    uint8_t rx2_buffer[512];
+    CircularBuffer rx2_cb;
+    circular_buffer_init(&rx2_cb, rx2_buffer, sizeof(rx2_buffer));
+    uint8_t tx2_buffer[512];
+    CircularBuffer tx2_cb;
+    circular_buffer_init(&tx2_cb, tx2_buffer, sizeof(tx2_buffer));
+    UART_Handle *uart_handle1 = UART_init(0, &rx1_cb, &tx1_cb);
+    UART_Handle *uart_handle2 = UART_init(1, &rx2_cb, &tx2_cb);
+    UART_enable_passthrough(uart_handle1, uart_handle2);
 
     // Initialize the protocol
     if (!protocol_init()) {

--- a/src/application/main.c
+++ b/src/application/main.c
@@ -15,7 +15,7 @@ int main(void)
 
     ESP_init();
     ESP_enter_bootloader();
-    
+
     // Enable UART passthrough
     uint8_t rx1_buffer[512];
     CircularBuffer rx1_cb;

--- a/src/system/system.c
+++ b/src/system/system.c
@@ -37,8 +37,8 @@ void SYSTEM_init(void)
     // Set up log output
     circular_buffer_init(&g_log_cb, g_log_buf, sizeof(g_log_buf));
     circular_buffer_init(&g_log_rx_cb, g_log_rx_buf, sizeof(g_log_rx_buf));
-    uint8_t log_bus = 2;
-    g_logging_uart_handle = UART_init(log_bus, &g_log_rx_cb, &g_log_cb);
+    // uint8_t log_bus = 2;
+    // g_logging_uart_handle = UART_init(log_bus, &g_log_rx_cb, &g_log_cb);
     extern void syscalls_init(UART_Handle * handle);
     syscalls_init(g_logging_uart_handle);
     // Buffered log messages can now be output with LOG_task


### PR DESCRIPTION
This PR enables UART passthrough between the UART header pins and the ESP UART bus on the prototype PCB. Since these are the only two UART buses available, logging is disabled.

This PR is for testing purposes only. Do not merge.