### PR TITLE
Remove backdoor entry to the bootloader using user button

### DIFF
--- a/boot/hooks.c
+++ b/boot/hooks.c
@@ -79,17 +79,6 @@ blt_bool BackDoorEntryHook(void)
 ****************************************************************************************/
 blt_bool CpuUserProgramStartHook(void)
 {
-  /* additional and optional backdoor entry through the pushbutton on the board. to
-   * force the bootloader to stay active after reset, keep it pressed during reset.
-   */
-  if (LL_GPIO_IsInputPinSet(GPIOC, LL_GPIO_PIN_13) != 0)
-  {
-    /* pushbutton pressed, so do not start the user program and keep the
-     * bootloader active instead.
-     */
-    return BLT_FALSE;
-  }
-
   /* clean up the LED driver */
   LedBlinkExit();
 

--- a/boot/main.c
+++ b/boot/main.c
@@ -258,11 +258,6 @@ void HAL_MspInit(void)
   LL_GPIO_Init(GPIOB, &GPIO_InitStruct);
   LL_GPIO_ResetOutputPin(GPIOB, LL_GPIO_PIN_12);
 
-  /* Configure GPIO pin for (optional) backdoor entry input. */
-  GPIO_InitStruct.Pin = LL_GPIO_PIN_13;
-  GPIO_InitStruct.Mode = LL_GPIO_MODE_INPUT;
-  GPIO_InitStruct.Pull = LL_GPIO_PULL_NO;
-  LL_GPIO_Init(GPIOC, &GPIO_InitStruct);
 #if (BOOT_COM_RS232_ENABLE > 0)
   /* UART TX and RX GPIO pin configuration. */
   GPIO_InitStruct.Pin = LL_GPIO_PIN_8 | LL_GPIO_PIN_9;


### PR DESCRIPTION
- fixes: #154 

This PR removes the backdoor entry in the bootloader using the USER BUTTON PC13, which keeps the firmware stuck in the bootloader instead of entering the main application.

Since the prototype does not have this button, removing its implementation from the bootloader.