### PR TITLE
feat: add SCPI command interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,14 +13,29 @@ add_executable(pslab_pico)
 
 target_sources(pslab_pico PRIVATE
         src/application/main.c
+        src/application/protocol/common.c
+        src/application/protocol/la.c
+        src/application/logic_analyser_commands.c
         src/platform/usb_cdc.c
         src/platform/usb_descriptors.c
+        src/platform/status_led.c
+        src/platform/test_signal.c
         src/system/logic_analyser.c
+        lib/scpi-parser-2.3/src/error.c
+        lib/scpi-parser-2.3/src/expression.c
+        lib/scpi-parser-2.3/src/fifo.c
+        lib/scpi-parser-2.3/src/ieee488.c
+        lib/scpi-parser-2.3/src/lexer.c
+        lib/scpi-parser-2.3/src/minimal.c
+        lib/scpi-parser-2.3/src/parser.c
+        lib/scpi-parser-2.3/src/units.c
+        lib/scpi-parser-2.3/src/utils.c
         )
 
 target_include_directories(pslab_pico PRIVATE
         ${CMAKE_CURRENT_LIST_DIR}/src
         ${CMAKE_CURRENT_LIST_DIR}/src/platform
+        ${CMAKE_CURRENT_LIST_DIR}/lib/scpi-parser-2.3/inc
         )
 
 target_link_libraries(pslab_pico PRIVATE
@@ -28,6 +43,8 @@ target_link_libraries(pslab_pico PRIVATE
         pico_unique_id
         hardware_pio
         hardware_dma
+        hardware_pwm
+        hardware_clocks
         tinyusb_device
         tinyusb_board
         )

--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@
 This repository is being prepared for the Raspberry Pi Pico based PSLab
 firmware port.
 
-This branch adds the initial Pico SDK based firmware skeleton after the
-STM32-specific cleanup. The skeleton builds a minimal `pslab_pico` firmware
-target for RP2350 boards.
+This branch adds the Pico SCPI command interface on top of the USB CDC and
+PIO/DMA logic analyser driver branches. The firmware now exposes a USB CDC
+serial endpoint that accepts SCPI commands for logic analyser capture and
+test signal control.
 
 ## Kept For Porting
 
@@ -22,14 +23,45 @@ target for RP2350 boards.
 - `pico_sdk_import.cmake` for Pico SDK discovery.
 - Minimal `src/application/main.c` entrypoint.
 
+## USB CDC Platform Driver
+
 - `src/platform/usb_cdc.c`
 - `src/platform/usb_cdc.h`
 - `src/platform/usb_descriptors.c`
 - `src/platform/tusb_config.h`
 
+## Logic Analyser System Driver
+
 - `src/system/logic_analyser.c`
 - `src/system/logic_analyser.h`
 
+## SCPI Command Interface
+
+- `src/application/protocol/common.c`: SCPI context, transport callbacks, and
+  shared protocol state.
+- `src/application/protocol/la.c`: logic analyser SCPI command table.
+- `src/application/logic_analyser_commands.c`: command handlers for logic
+  analyser configuration, capture, data reads, streaming, and test signal
+  control.
+- `lib/scpi-parser-2.3`: embedded SCPI parser used by the application layer.
+
+Common commands include:
+
+- `*IDN?`
+- `SYST:ERR?`
+- `LA:CONF:PINS <first_gpio> <pin_count>`
+- `LA:CONF:DIV <divider>`
+- `LA:CONF:SAMPLES <sample_count>`
+- `LA:TRIG:MODE <AUTO|LEVEL|EDGE>`
+- `LA:TRIG:PIN <gpio>`
+- `LA:TRIG:LEVEL <0|1>`
+- `LA:CAPT`
+- `LA:DATA?`
+- `LA:STREAM:START`
+- `LA:STREAM:STOP`
+- `TEST:SQUARE:CONF <gpio> <frequency_hz>`
+- `TEST:SQUARE:START`
+- `TEST:SQUARE:STOP`
 
 ## Build
 

--- a/src/application/logic_analyser_commands.c
+++ b/src/application/logic_analyser_commands.c
@@ -1,0 +1,356 @@
+#include "application/logic_analyser_commands.h"
+
+#include <string.h>
+
+#include "hardware/pio.h"
+#include "system/logic_analyser.h"
+#include "platform/status_led.h"
+
+enum {
+    LA_DEFAULT_PIN_BASE = 16,
+    LA_DEFAULT_PIN_COUNT = 2,
+    LA_DEFAULT_SAMPLES = 96,
+    LA_DEFAULT_DIVIDER = 1,
+    LA_MAX_PIN_COUNT = 8,
+    LA_MAX_SAMPLES = 4096,
+    LA_MAX_DIVIDER = 16777215,
+};
+
+static LogicAnalyser la;
+static bool la_initialized;
+static uint32_t capture_buffer[LA_MAX_SAMPLES];
+static LogicAnalyserCaptureInfo last_capture;
+static bool capture_valid;
+static bool stream_enabled;
+static bool stream_capturing;
+static uint32_t stream_buffers[2][LA_MAX_SAMPLES];
+static LogicAnalyserCaptureInfo stream_info[2];
+static uint32_t stream_capture_index;
+static uint32_t stream_sequence;
+static uint32_t stream_overruns;
+
+static struct {
+    uint32_t pin_base;
+    uint32_t pin_count;
+    uint32_t samples;
+    uint32_t divider;
+    uint32_t trigger_pin;
+    bool trigger_level;
+    LogicAnalyserTriggerMode trigger_mode;
+} state = {
+    .pin_base = LA_DEFAULT_PIN_BASE,
+    .pin_count = LA_DEFAULT_PIN_COUNT,
+    .samples = LA_DEFAULT_SAMPLES,
+    .divider = LA_DEFAULT_DIVIDER,
+    .trigger_pin = LA_DEFAULT_PIN_BASE,
+    .trigger_level = true,
+    .trigger_mode = LOGIC_ANALYSER_TRIGGER_EDGE,
+};
+
+static bool config_is_valid(void)
+{
+    return state.pin_count >= 1 && state.pin_count <= LA_MAX_PIN_COUNT &&
+           state.pin_base + state.pin_count <= 30 && state.samples >= 1 &&
+           state.samples <= LA_MAX_SAMPLES && state.divider >= 1 &&
+           state.trigger_pin <= 29;
+}
+
+static bool apply_config(void)
+{
+    if (!config_is_valid()) {
+        return false;
+    }
+
+    LogicAnalyserConfig config = {
+        .pio = pio0,
+        .sm = 0,
+        .pin_base = state.pin_base,
+        .pin_count = state.pin_count,
+        .clk_div = (float)state.divider,
+    };
+
+    if (la_initialized) {
+        return logic_analyser_configure(&la, &config);
+    }
+
+    la_initialized = logic_analyser_init(&la, &config);
+    return la_initialized;
+}
+
+static bool set_and_maybe_reconfigure(
+    uint32_t *target,
+    uint32_t value,
+    uint32_t min,
+    uint32_t max,
+    bool reconfigure
+)
+{
+    if (value < min || value > max) {
+        return false;
+    }
+
+    uint32_t old_value = *target;
+    *target = value;
+    capture_valid = false;
+    la_stream_stop();
+
+    if (reconfigure && !apply_config()) {
+        *target = old_value;
+        return false;
+    }
+
+    return true;
+}
+
+void la_reset_state(void)
+{
+    la_stream_stop();
+
+    if (la_initialized) {
+        logic_analyser_deinit(&la);
+    }
+
+    la_initialized = false;
+    capture_valid = false;
+    stream_enabled = false;
+    stream_sequence = 0;
+    stream_overruns = 0;
+    state.pin_base = LA_DEFAULT_PIN_BASE;
+    state.pin_count = LA_DEFAULT_PIN_COUNT;
+    state.samples = LA_DEFAULT_SAMPLES;
+    state.divider = LA_DEFAULT_DIVIDER;
+    state.trigger_pin = LA_DEFAULT_PIN_BASE;
+    state.trigger_level = true;
+    state.trigger_mode = LOGIC_ANALYSER_TRIGGER_EDGE;
+}
+
+bool la_set_pin_base(uint32_t value)
+{
+    bool ok = set_and_maybe_reconfigure(&state.pin_base, value, 0, 29, true);
+    if (ok && state.trigger_pin < state.pin_base) {
+        state.trigger_pin = state.pin_base;
+    }
+    return ok;
+}
+
+bool la_set_pin_count(uint32_t value)
+{
+    return set_and_maybe_reconfigure(
+        &state.pin_count, value, 1, LA_MAX_PIN_COUNT, true
+    );
+}
+
+bool la_set_samples(uint32_t value)
+{
+    return set_and_maybe_reconfigure(
+        &state.samples, value, 1, LA_MAX_SAMPLES, false
+    );
+}
+
+bool la_set_divider(uint32_t value)
+{
+    return set_and_maybe_reconfigure(&state.divider, value, 1, LA_MAX_DIVIDER, true);
+}
+
+bool la_set_trigger_pin(uint32_t value)
+{
+    return set_and_maybe_reconfigure(&state.trigger_pin, value, 0, 29, false);
+}
+
+void la_set_trigger_level(bool value)
+{
+    state.trigger_level = value;
+    capture_valid = false;
+    la_stream_stop();
+}
+
+bool la_set_trigger_mode_edge(bool edge_mode)
+{
+    state.trigger_mode = edge_mode ? LOGIC_ANALYSER_TRIGGER_EDGE
+                                   : LOGIC_ANALYSER_TRIGGER_LEVEL;
+    capture_valid = false;
+    la_stream_stop();
+    return true;
+}
+
+uint32_t la_get_pin_base(void) { return state.pin_base; }
+
+uint32_t la_get_pin_count(void) { return state.pin_count; }
+
+uint32_t la_get_samples(void) { return state.samples; }
+
+uint32_t la_get_divider(void) { return state.divider; }
+
+uint32_t la_get_trigger_pin(void) { return state.trigger_pin; }
+
+bool la_get_trigger_level(void) { return state.trigger_level; }
+
+bool la_get_trigger_mode_edge(void)
+{
+    return state.trigger_mode == LOGIC_ANALYSER_TRIGGER_EDGE;
+}
+
+bool la_initiate(void)
+{
+    la_stream_stop();
+
+    if (!la_initialized && !apply_config()) {
+        return false;
+    }
+
+    uint32_t word_count = logic_analyser_capture_word_count(
+        state.pin_count, state.samples
+    );
+    if (word_count == 0 ||
+        word_count > sizeof(capture_buffer) / sizeof(capture_buffer[0])) {
+        return false;
+    }
+
+    memset(capture_buffer, 0, word_count * sizeof(capture_buffer[0]));
+
+    status_led_capture_started();
+    bool captured = logic_analyser_capture(
+            &la,
+            state.trigger_pin,
+            state.trigger_level,
+            state.trigger_mode,
+            capture_buffer,
+            state.samples,
+            &last_capture
+        );
+    status_led_capture_finished();
+
+    if (!captured) {
+        return false;
+    }
+
+    capture_valid = true;
+    return true;
+}
+
+bool la_fetch(uint8_t const **data, size_t *len)
+{
+    if (!capture_valid || !data || !len) {
+        return false;
+    }
+
+    *data = (uint8_t const *)capture_buffer;
+    *len = last_capture.word_count * sizeof(uint32_t);
+    return true;
+}
+
+uint32_t la_status(void)
+{
+    if (la_initialized && logic_analyser_is_busy(&la)) {
+        return 2;
+    }
+
+    return capture_valid ? 1 : 0;
+}
+
+bool la_stream_start(void)
+{
+    la_stream_stop();
+
+    if (!la_initialized && !apply_config()) {
+        ++stream_overruns;
+        return false;
+    }
+
+    uint32_t word_count = logic_analyser_capture_word_count(
+        state.pin_count, state.samples
+    );
+    if (word_count == 0 ||
+        word_count > sizeof(stream_buffers[0]) / sizeof(stream_buffers[0][0])) {
+        ++stream_overruns;
+        return false;
+    }
+
+    memset(stream_buffers, 0, sizeof(stream_buffers));
+    capture_valid = false;
+    stream_enabled = true;
+    stream_capturing = false;
+    stream_capture_index = 0;
+    stream_sequence = 0;
+    stream_overruns = 0;
+
+    status_led_capture_started();
+    if (!logic_analyser_capture_start(
+            &la,
+            state.trigger_pin,
+            state.trigger_level,
+            state.trigger_mode,
+            stream_buffers[stream_capture_index],
+            state.samples,
+            &stream_info[stream_capture_index],
+            true
+        )) {
+        la_stream_stop();
+        ++stream_overruns;
+        return false;
+    }
+
+    stream_capturing = true;
+    return true;
+}
+
+void la_stream_stop(void)
+{
+    if (stream_capturing && la_initialized) {
+        logic_analyser_capture_abort(&la);
+    }
+
+    if (stream_enabled) {
+        status_led_capture_finished();
+    }
+
+    stream_enabled = false;
+    stream_capturing = false;
+}
+
+bool la_stream_is_enabled(void) { return stream_enabled; }
+
+uint32_t la_stream_get_sequence(void) { return stream_sequence; }
+
+uint32_t la_stream_get_overruns(void) { return stream_overruns; }
+
+bool la_stream_next_frame(uint8_t const **data, size_t *len, uint32_t *sequence)
+{
+    if (!stream_enabled || !data || !len || !sequence) {
+        return false;
+    }
+
+    if (!stream_capturing || logic_analyser_is_busy(&la)) {
+        return false;
+    }
+
+    if (!logic_analyser_capture_complete(&la)) {
+        ++stream_overruns;
+        return false;
+    }
+
+    uint32_t completed_index = stream_capture_index;
+    uint32_t next_index = completed_index ^ 1u;
+    memset(stream_buffers[next_index], 0, stream_info[completed_index].word_count * sizeof(uint32_t));
+
+    stream_capture_index = next_index;
+    stream_capturing = logic_analyser_capture_start(
+        &la,
+        state.trigger_pin,
+        state.trigger_level,
+        state.trigger_mode,
+        stream_buffers[stream_capture_index],
+        state.samples,
+        &stream_info[stream_capture_index],
+        false
+    );
+    if (!stream_capturing) {
+        ++stream_overruns;
+        stream_enabled = false;
+    }
+
+    *data = (uint8_t const *)stream_buffers[completed_index];
+    *len = stream_info[completed_index].word_count * sizeof(uint32_t);
+    *sequence = stream_sequence++;
+    return true;
+}

--- a/src/application/logic_analyser_commands.h
+++ b/src/application/logic_analyser_commands.h
@@ -1,0 +1,45 @@
+#ifndef LOGIC_ANALYSER_COMMANDS_H
+#define LOGIC_ANALYSER_COMMANDS_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void la_reset_state(void);
+
+bool la_set_pin_base(uint32_t value);
+bool la_set_pin_count(uint32_t value);
+bool la_set_samples(uint32_t value);
+bool la_set_divider(uint32_t value);
+bool la_set_trigger_pin(uint32_t value);
+void la_set_trigger_level(bool value);
+bool la_set_trigger_mode_edge(bool edge_mode);
+
+uint32_t la_get_pin_base(void);
+uint32_t la_get_pin_count(void);
+uint32_t la_get_samples(void);
+uint32_t la_get_divider(void);
+uint32_t la_get_trigger_pin(void);
+bool la_get_trigger_level(void);
+bool la_get_trigger_mode_edge(void);
+
+bool la_initiate(void);
+bool la_fetch(uint8_t const **data, size_t *len);
+uint32_t la_status(void);
+
+bool la_stream_start(void);
+void la_stream_stop(void);
+bool la_stream_is_enabled(void);
+uint32_t la_stream_get_sequence(void);
+uint32_t la_stream_get_overruns(void);
+bool la_stream_next_frame(uint8_t const **data, size_t *len, uint32_t *sequence);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/application/main.c
+++ b/src/application/main.c
@@ -1,12 +1,10 @@
-#include "pico/stdlib.h"
+#include "application/protocol.h"
 
 int main(void)
 {
-    stdio_init_all();
+    protocol_init();
 
-    while (1) {
-        tight_loop_contents();
+    while (true) {
+        protocol_task();
     }
-
-    __builtin_unreachable();
 }

--- a/src/application/protocol.h
+++ b/src/application/protocol.h
@@ -19,7 +19,7 @@ extern "C" {
 /**
  * @brief Initialize the SCPI protocol
  *
- * This function initializes the USB interface, ADC, and SCPI parser.
+ * This function initializes the USB interface and SCPI parser.
  * Must be called before using any other protocol functions.
  *
  * @return true on success, false on failure
@@ -29,7 +29,7 @@ bool protocol_init(void);
 /**
  * @brief Deinitialize the SCPI protocol
  *
- * Cleans up all resources used by the protocol including USB and ADC.
+ * Cleans up all resources used by the protocol.
  */
 void protocol_deinit(void);
 

--- a/src/application/protocol/common.c
+++ b/src/application/protocol/common.c
@@ -6,65 +6,56 @@
  * USB communication, SCPI context management, and IEEE 488.2 commands.
  */
 
-#include "protocol.h"
+#include "application/protocol.h"
 
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 
-#include "lib/scpi/error.h"
-#include "lib/scpi/scpi.h"
+#include "scpi/error.h"
+#include "scpi/scpi.h"
 
-#include "system/bus/usb.h"
-#include "system/system.h"
-#include "util/error.h"
-#include "util/util.h"
+#include "application/logic_analyser_commands.h"
+#include "platform/status_led.h"
+#include "platform/test_signal.h"
+#include "platform/usb_cdc.h"
 
 // Buffer sizes for USB communication (internal to this module)
 enum {
-    USB_RX_BUFFER_SIZE = 512,
-    USB_TX_BUFFER_SIZE = 512,
+    USB_RX_CHUNK_SIZE = 64,
     SCPI_INPUT_BUFFER_SIZE = 256,
     SCPI_ERROR_QUEUE_SIZE = 16
 };
 
-// Forward declarations of DMM functions needed by common
-extern scpi_result_t scpi_cmd_configure_voltage_dc(scpi_t *context);
-extern scpi_result_t scpi_cmd_initiate_voltage_dc(scpi_t *context);
-extern scpi_result_t scpi_cmd_fetch_voltage_dc(scpi_t *context);
-extern scpi_result_t scpi_cmd_read_voltage_dc(scpi_t *context);
-extern scpi_result_t scpi_cmd_measure_voltage_dc(scpi_t *context);
-extern void dmm_reset_state(void);
+// Forward declarations of logic analyser functions needed by common
+extern scpi_result_t scpi_cmd_configure_logic_analyser_pinbase(scpi_t *context);
+extern scpi_result_t scpi_cmd_configure_logic_analyser_pinbase_q(scpi_t *context);
+extern scpi_result_t scpi_cmd_configure_logic_analyser_pincount(scpi_t *context);
+extern scpi_result_t scpi_cmd_configure_logic_analyser_pincount_q(scpi_t *context);
+extern scpi_result_t scpi_cmd_configure_logic_analyser_samples(scpi_t *context);
+extern scpi_result_t scpi_cmd_configure_logic_analyser_samples_q(scpi_t *context);
+extern scpi_result_t scpi_cmd_configure_logic_analyser_divider(scpi_t *context);
+extern scpi_result_t scpi_cmd_configure_logic_analyser_divider_q(scpi_t *context);
+extern scpi_result_t scpi_cmd_configure_logic_analyser_trigger_pin(scpi_t *context);
+extern scpi_result_t scpi_cmd_configure_logic_analyser_trigger_pin_q(scpi_t *context);
+extern scpi_result_t scpi_cmd_configure_logic_analyser_trigger_level(scpi_t *context);
+extern scpi_result_t scpi_cmd_configure_logic_analyser_trigger_level_q(scpi_t *context);
+extern scpi_result_t scpi_cmd_configure_logic_analyser_trigger_mode(scpi_t *context);
+extern scpi_result_t scpi_cmd_configure_logic_analyser_trigger_mode_q(scpi_t *context);
+extern scpi_result_t scpi_cmd_initiate_logic_analyser(scpi_t *context);
+extern scpi_result_t scpi_cmd_fetch_logic_analyser_data_q(scpi_t *context);
+extern scpi_result_t scpi_cmd_read_logic_analyser_q(scpi_t *context);
+extern scpi_result_t scpi_cmd_status_logic_analyser_q(scpi_t *context);
+extern scpi_result_t scpi_cmd_stream_logic_analyser_start(scpi_t *context);
+extern scpi_result_t scpi_cmd_stream_logic_analyser_stop(scpi_t *context);
+extern scpi_result_t scpi_cmd_stream_logic_analyser_status_q(scpi_t *context);
 
-// Forward declarations of DSO functions needed by common
-extern scpi_result_t scpi_cmd_configure_oscilloscope_channel(scpi_t *context);
-extern scpi_result_t scpi_cmd_configure_oscilloscope_channel_q(scpi_t *context);
-extern scpi_result_t scpi_cmd_configure_oscilloscope_timebase(scpi_t *context);
-extern scpi_result_t scpi_cmd_configure_oscilloscope_timebase_q(scpi_t *context
-);
-extern scpi_result_t scpi_cmd_configure_oscilloscope_acquire_points(
-    scpi_t *context
-);
-extern scpi_result_t scpi_cmd_configure_oscilloscope_acquire_points_q(
-    scpi_t *context
-);
-extern scpi_result_t scpi_cmd_configure_oscilloscope_acquire_srate_q(
-    scpi_t *context
-);
-extern scpi_result_t scpi_cmd_initiate_oscilloscope(scpi_t *context);
-extern scpi_result_t scpi_cmd_fetch_oscilloscope_data_q(scpi_t *context);
-extern scpi_result_t scpi_cmd_read_oscilloscope_q(scpi_t *context);
-extern scpi_result_t scpi_cmd_measure_oscilloscope_q(scpi_t *context);
-extern scpi_result_t scpi_cmd_abort_oscilloscope(scpi_t *context);
-extern scpi_result_t scpi_cmd_status_oscilloscope_acquisition_q(scpi_t *context
-);
-extern void dso_reset_state(void);
-
-// Static storage for buffers
-static uint8_t g_usb_rx_buffer_data[USB_RX_BUFFER_SIZE];
-static uint8_t g_usb_tx_buffer_data[USB_TX_BUFFER_SIZE];
-static CircularBuffer g_usb_rx_buffer;
-static CircularBuffer g_usb_tx_buffer;
-static USB_Handle *g_usb_handle = nullptr;
+// Forward declarations of test signal functions needed by common
+extern scpi_result_t scpi_cmd_test_square(scpi_t *context);
+extern scpi_result_t scpi_cmd_test_square_q(scpi_t *context);
+extern scpi_result_t scpi_cmd_test_square_configure(scpi_t *context);
+extern scpi_result_t scpi_cmd_test_square_pin_q(scpi_t *context);
+extern scpi_result_t scpi_cmd_test_square_frequency_q(scpi_t *context);
 
 // SCPI context and buffers (internal to protocol module)
 static scpi_t g_scpi_context;
@@ -75,27 +66,12 @@ static scpi_error_t g_scpi_error_queue_data[SCPI_ERROR_QUEUE_SIZE];
 static bool g_protocol_initialized = false;
 
 /**
- * @brief USB RX callback - called when data is received
- */
-static void usb_rx_callback(USB_Handle *handle, uint32_t bytes_available)
-{
-    (void)handle; // Unused parameter
-    (void)bytes_available; // Unused parameter
-    // Data processing will happen in the main protocol task
-}
-
-/**
  * @brief SCPI write function - sends data via USB
  */
 static size_t protocol_write(scpi_t *context, char const *data, size_t len)
 {
     (void)context; // Unused parameter
-
-    if (!g_usb_handle) {
-        return 0;
-    }
-
-    return USB_write(g_usb_handle, (uint8_t const *)data, (uint32_t)len);
+    return usb_cdc_write((uint8_t const *)data, len);
 }
 
 /**
@@ -104,22 +80,16 @@ static size_t protocol_write(scpi_t *context, char const *data, size_t len)
 static scpi_result_t protocol_reset(scpi_t *context)
 {
     (void)context; // Unused parameter
-
-    // Reset DMM state (implemented in dmm.c)
-    dmm_reset_state();
-
-    // Reset DSO state (implemented in dso.c)
-    dso_reset_state();
-
+    la_reset_state();
     return SCPI_RES_OK;
 }
 
 // SCPI interface implementation
 static scpi_interface_t g_scpi_interface = {
-    .error = nullptr,
+    .error = NULL,
     .write = protocol_write,
-    .control = nullptr,
-    .flush = nullptr,
+    .control = NULL,
+    .flush = NULL,
     .reset = protocol_reset,
 };
 
@@ -145,35 +115,35 @@ static scpi_command_t const g_SCPI_COMMANDS[] = {
     { "SYSTem:ERRor:COUNt?", SCPI_SystemErrorCountQ },
     { "SYSTem:VERSion?", SCPI_SystemVersionQ },
 
-    // DMM commands (Digital Multimeter)
-    { "DMM:CONFigure[:VOLTage][:DC]", scpi_cmd_configure_voltage_dc },
-    { "DMM:INITiate[:VOLTage][:DC]", scpi_cmd_initiate_voltage_dc },
-    { "DMM:FETCh[:VOLTage][:DC]?", scpi_cmd_fetch_voltage_dc },
-    { "DMM:READ[:VOLTage][:DC]?", scpi_cmd_read_voltage_dc },
-    { "DMM:MEASure[:VOLTage][:DC]?", scpi_cmd_measure_voltage_dc },
+    // Logic analyser commands
+    { "LA:CONFigure:PINBase", scpi_cmd_configure_logic_analyser_pinbase },
+    { "LA:CONFigure:PINBase?", scpi_cmd_configure_logic_analyser_pinbase_q },
+    { "LA:CONFigure:PINCount", scpi_cmd_configure_logic_analyser_pincount },
+    { "LA:CONFigure:PINCount?", scpi_cmd_configure_logic_analyser_pincount_q },
+    { "LA:CONFigure:SAMPles", scpi_cmd_configure_logic_analyser_samples },
+    { "LA:CONFigure:SAMPles?", scpi_cmd_configure_logic_analyser_samples_q },
+    { "LA:CONFigure:DIVider", scpi_cmd_configure_logic_analyser_divider },
+    { "LA:CONFigure:DIVider?", scpi_cmd_configure_logic_analyser_divider_q },
+    { "LA:CONFigure:TRIGger:PIN", scpi_cmd_configure_logic_analyser_trigger_pin },
+    { "LA:CONFigure:TRIGger:PIN?", scpi_cmd_configure_logic_analyser_trigger_pin_q },
+    { "LA:CONFigure:TRIGger:LEVel", scpi_cmd_configure_logic_analyser_trigger_level },
+    { "LA:CONFigure:TRIGger:LEVel?", scpi_cmd_configure_logic_analyser_trigger_level_q },
+    { "LA:CONFigure:TRIGger:MODE", scpi_cmd_configure_logic_analyser_trigger_mode },
+    { "LA:CONFigure:TRIGger:MODE?", scpi_cmd_configure_logic_analyser_trigger_mode_q },
+    { "LA:INITiate", scpi_cmd_initiate_logic_analyser },
+    { "LA:FETCh[:DATa]?", scpi_cmd_fetch_logic_analyser_data_q },
+    { "LA:READ?", scpi_cmd_read_logic_analyser_q },
+    { "LA:STATus?", scpi_cmd_status_logic_analyser_q },
+    { "LA:STREAM:STARt", scpi_cmd_stream_logic_analyser_start },
+    { "LA:STREAM:STOP", scpi_cmd_stream_logic_analyser_stop },
+    { "LA:STREAM:STATus?", scpi_cmd_stream_logic_analyser_status_q },
 
-    // DSO commands (Digital Storage Oscilloscope)
-    { "OSCilloscope:CONFigure:CHANnel",
-      scpi_cmd_configure_oscilloscope_channel },
-    { "OSCilloscope:CONFigure:CHANnel?",
-      scpi_cmd_configure_oscilloscope_channel_q },
-    { "OSCilloscope:CONFigure:TIMEbase",
-      scpi_cmd_configure_oscilloscope_timebase },
-    { "OSCilloscope:CONFigure:TIMEbase?",
-      scpi_cmd_configure_oscilloscope_timebase_q },
-    { "OSCilloscope:CONFigure:ACQuire[:POINts]",
-      scpi_cmd_configure_oscilloscope_acquire_points },
-    { "OSCilloscope:CONFigure:ACQuire[:POINts]?",
-      scpi_cmd_configure_oscilloscope_acquire_points_q },
-    { "OSCilloscope:CONFigure:ACQuire:SRATe?",
-      scpi_cmd_configure_oscilloscope_acquire_srate_q },
-    { "OSCilloscope:INITiate", scpi_cmd_initiate_oscilloscope },
-    { "OSCilloscope:FETCh[:DATa]?", scpi_cmd_fetch_oscilloscope_data_q },
-    { "OSCilloscope:READ?", scpi_cmd_read_oscilloscope_q },
-    { "OSCilloscope:MEASure?", scpi_cmd_measure_oscilloscope_q },
-    { "OSCilloscope:ABORt", scpi_cmd_abort_oscilloscope },
-    { "OSCilloscope:STATus:ACQuisition?",
-      scpi_cmd_status_oscilloscope_acquisition_q },
+    // Built-in test signal commands
+    { "TEST:SQUare", scpi_cmd_test_square },
+    { "TEST:SQUare?", scpi_cmd_test_square_q },
+    { "TEST:SQUare:CONFigure", scpi_cmd_test_square_configure },
+    { "TEST:SQUare:PIN?", scpi_cmd_test_square_pin_q },
+    { "TEST:SQUare:FREQuency?", scpi_cmd_test_square_frequency_q },
 
     SCPI_CMD_LIST_END
 };
@@ -187,24 +157,9 @@ bool protocol_init(void)
         return true;
     }
 
-    // Initialize USB RX buffer
-    circular_buffer_init(
-        &g_usb_rx_buffer, g_usb_rx_buffer_data, USB_RX_BUFFER_SIZE
-    );
-
-    // Initialize USB TX buffer
-    circular_buffer_init(
-        &g_usb_tx_buffer, g_usb_tx_buffer_data, USB_TX_BUFFER_SIZE
-    );
-
-    // Initialize USB interface
-    g_usb_handle = USB_init(0, &g_usb_rx_buffer, &g_usb_tx_buffer);
-    if (!g_usb_handle) {
-        return false;
-    }
-
-    // Set USB RX callback
-    USB_set_rx_callback(g_usb_handle, usb_rx_callback, 1);
+    usb_cdc_init();
+    status_led_init();
+    test_signal_init();
 
     // Initialize SCPI context
     SCPI_Init(
@@ -213,9 +168,9 @@ bool protocol_init(void)
         &g_scpi_interface,
         scpi_units_def,
         "FOSSASIA",
-        "PSLab",
+        "PSLab Pico",
         "1.0",
-        "v1.0.0",
+        "v0.1.0",
         g_scpi_input_buffer,
         SCPI_INPUT_BUFFER_SIZE,
         g_scpi_error_queue_data,
@@ -235,12 +190,6 @@ void protocol_deinit(void)
         return;
     }
 
-    // Deinitialize USB
-    if (g_usb_handle) {
-        USB_deinit(g_usb_handle);
-        g_usb_handle = nullptr;
-    }
-
     protocol_reset((scpi_t *)0);
     g_protocol_initialized = false;
 }
@@ -250,21 +199,36 @@ void protocol_deinit(void)
  */
 void protocol_task(void)
 {
-    if (!g_protocol_initialized || !g_usb_handle) {
+    if (!g_protocol_initialized) {
         return;
     }
 
     // Step USB task
-    USB_task(g_usb_handle);
+    usb_cdc_task();
 
-    // Process incoming USB data
-    if (USB_rx_ready(g_usb_handle)) {
-        uint8_t buffer[64];
-        uint32_t bytes_read = USB_read(g_usb_handle, buffer, sizeof(buffer));
+    uint8_t buffer[USB_RX_CHUNK_SIZE];
+    uint32_t bytes_read = usb_cdc_read(buffer, sizeof(buffer));
+    if (bytes_read > 0) {
+        status_led_command_received();
+        SCPI_Input(&g_scpi_context, (char *)buffer, (int)bytes_read);
+    }
 
-        if (bytes_read > 0) {
-            // Feed data to SCPI parser
-            SCPI_Input(&g_scpi_context, (char *)buffer, (int)bytes_read);
+    if (la_stream_is_enabled()) {
+        uint8_t const *data;
+        size_t len;
+        uint32_t sequence;
+        if (la_stream_next_frame(&data, &len, &sequence)) {
+            char frame_header[48];
+            snprintf(
+                frame_header,
+                sizeof(frame_header),
+                "LA:STREAM:FRAME %lu %lu\n",
+                (unsigned long)sequence,
+                (unsigned long)len
+            );
+            usb_cdc_write((uint8_t const *)frame_header, strlen(frame_header));
+            SCPI_ResultArbitraryBlock(&g_scpi_context, data, len);
+            usb_cdc_write((uint8_t const *)"\n", 1);
         }
     }
 }

--- a/src/application/protocol/la.c
+++ b/src/application/protocol/la.c
@@ -1,0 +1,262 @@
+/**
+ * @file la.c
+ * @brief Logic analyser-specific SCPI commands implementation
+ *
+ * This module implements the SCPI commands specific to logic analyser
+ * functionality, including configuration, triggering, capture, fetch, and
+ * streaming control.
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+
+#include "scpi/error.h"
+#include "scpi/scpi.h"
+
+#include "application/logic_analyser_commands.h"
+#include "platform/test_signal.h"
+
+static scpi_result_t result_ok(void) { return SCPI_RES_OK; }
+
+static scpi_result_t result_illegal_parameter(scpi_t *context)
+{
+    SCPI_ErrorPush(context, SCPI_ERROR_ILLEGAL_PARAMETER_VALUE);
+    return SCPI_RES_ERR;
+}
+
+static scpi_result_t result_execution_error(scpi_t *context)
+{
+    SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+    return SCPI_RES_ERR;
+}
+
+static scpi_result_t configure_uint32(
+    scpi_t *context,
+    bool (*setter)(uint32_t)
+)
+{
+    uint32_t value = 0;
+    if (!SCPI_ParamUInt32(context, &value, TRUE)) {
+        SCPI_ErrorPush(context, SCPI_ERROR_MISSING_PARAMETER);
+        return SCPI_RES_ERR;
+    }
+
+    return setter(value) ? result_ok() : result_illegal_parameter(context);
+}
+
+scpi_result_t scpi_cmd_configure_logic_analyser_pinbase(scpi_t *context)
+{
+    return configure_uint32(context, la_set_pin_base);
+}
+
+scpi_result_t scpi_cmd_configure_logic_analyser_pinbase_q(scpi_t *context)
+{
+    SCPI_ResultUInt32(context, la_get_pin_base());
+    return SCPI_RES_OK;
+}
+
+scpi_result_t scpi_cmd_configure_logic_analyser_pincount(scpi_t *context)
+{
+    return configure_uint32(context, la_set_pin_count);
+}
+
+scpi_result_t scpi_cmd_configure_logic_analyser_pincount_q(scpi_t *context)
+{
+    SCPI_ResultUInt32(context, la_get_pin_count());
+    return SCPI_RES_OK;
+}
+
+scpi_result_t scpi_cmd_configure_logic_analyser_samples(scpi_t *context)
+{
+    return configure_uint32(context, la_set_samples);
+}
+
+scpi_result_t scpi_cmd_configure_logic_analyser_samples_q(scpi_t *context)
+{
+    SCPI_ResultUInt32(context, la_get_samples());
+    return SCPI_RES_OK;
+}
+
+scpi_result_t scpi_cmd_configure_logic_analyser_divider(scpi_t *context)
+{
+    return configure_uint32(context, la_set_divider);
+}
+
+scpi_result_t scpi_cmd_configure_logic_analyser_divider_q(scpi_t *context)
+{
+    SCPI_ResultUInt32(context, la_get_divider());
+    return SCPI_RES_OK;
+}
+
+scpi_result_t scpi_cmd_configure_logic_analyser_trigger_pin(scpi_t *context)
+{
+    return configure_uint32(context, la_set_trigger_pin);
+}
+
+scpi_result_t scpi_cmd_configure_logic_analyser_trigger_pin_q(scpi_t *context)
+{
+    SCPI_ResultUInt32(context, la_get_trigger_pin());
+    return SCPI_RES_OK;
+}
+
+scpi_result_t scpi_cmd_configure_logic_analyser_trigger_level(scpi_t *context)
+{
+    scpi_bool_t value = FALSE;
+    if (!SCPI_ParamBool(context, &value, TRUE)) {
+        SCPI_ErrorPush(context, SCPI_ERROR_MISSING_PARAMETER);
+        return SCPI_RES_ERR;
+    }
+
+    la_set_trigger_level(value == TRUE);
+    return SCPI_RES_OK;
+}
+
+scpi_result_t scpi_cmd_configure_logic_analyser_trigger_level_q(scpi_t *context)
+{
+    SCPI_ResultBool(context, la_get_trigger_level() ? TRUE : FALSE);
+    return SCPI_RES_OK;
+}
+
+scpi_result_t scpi_cmd_configure_logic_analyser_trigger_mode(scpi_t *context)
+{
+    enum { TRIGGER_MODE_EDGE, TRIGGER_MODE_LEVEL };
+    scpi_choice_def_t const trigger_mode_choices[] = {
+        { "EDGE", TRIGGER_MODE_EDGE },
+        { "LEVEL", TRIGGER_MODE_LEVEL },
+        SCPI_CHOICE_LIST_END
+    };
+    int32_t choice = -1;
+
+    if (!SCPI_ParamChoice(context, trigger_mode_choices, &choice, TRUE)) {
+        SCPI_ErrorPush(context, SCPI_ERROR_MISSING_PARAMETER);
+        return SCPI_RES_ERR;
+    }
+
+    return la_set_trigger_mode_edge(choice == TRIGGER_MODE_EDGE)
+               ? result_ok()
+               : result_illegal_parameter(context);
+}
+
+scpi_result_t scpi_cmd_configure_logic_analyser_trigger_mode_q(scpi_t *context)
+{
+    SCPI_ResultText(context, la_get_trigger_mode_edge() ? "EDGE" : "LEVEL");
+    return SCPI_RES_OK;
+}
+
+scpi_result_t scpi_cmd_initiate_logic_analyser(scpi_t *context)
+{
+    return la_initiate() ? result_ok() : result_execution_error(context);
+}
+
+scpi_result_t scpi_cmd_fetch_logic_analyser_data_q(scpi_t *context)
+{
+    uint8_t const *data = NULL;
+    size_t len = 0;
+
+    if (!la_fetch(&data, &len)) {
+        return result_execution_error(context);
+    }
+
+    SCPI_ResultArbitraryBlock(context, data, len);
+    return SCPI_RES_OK;
+}
+
+scpi_result_t scpi_cmd_read_logic_analyser_q(scpi_t *context)
+{
+    if (!la_initiate()) {
+        return result_execution_error(context);
+    }
+
+    return scpi_cmd_fetch_logic_analyser_data_q(context);
+}
+
+scpi_result_t scpi_cmd_status_logic_analyser_q(scpi_t *context)
+{
+    SCPI_ResultUInt32(context, la_status());
+    return SCPI_RES_OK;
+}
+
+scpi_result_t scpi_cmd_stream_logic_analyser_start(scpi_t *context)
+{
+    return la_stream_start() ? result_ok() : result_execution_error(context);
+}
+
+scpi_result_t scpi_cmd_stream_logic_analyser_stop(scpi_t *context)
+{
+    (void)context;
+    la_stream_stop();
+    return SCPI_RES_OK;
+}
+
+scpi_result_t scpi_cmd_stream_logic_analyser_status_q(scpi_t *context)
+{
+    char status[80];
+    snprintf(
+        status,
+        sizeof(status),
+        "%u,%lu,%lu",
+        la_stream_is_enabled() ? 1u : 0u,
+        (unsigned long)la_stream_get_sequence(),
+        (unsigned long)la_stream_get_overruns()
+    );
+    SCPI_ResultText(context, status);
+    return SCPI_RES_OK;
+}
+
+scpi_result_t scpi_cmd_test_square(scpi_t *context)
+{
+    scpi_bool_t enable = FALSE;
+    if (!SCPI_ParamBool(context, &enable, TRUE)) {
+        SCPI_ErrorPush(context, SCPI_ERROR_MISSING_PARAMETER);
+        return SCPI_RES_ERR;
+    }
+
+    if (enable == TRUE) {
+        return test_signal_start(
+                   TEST_SIGNAL_DEFAULT_PIN,
+                   TEST_SIGNAL_DEFAULT_FREQUENCY_HZ
+               )
+                   ? result_ok()
+                   : result_execution_error(context);
+    }
+
+    test_signal_stop();
+    return SCPI_RES_OK;
+}
+
+scpi_result_t scpi_cmd_test_square_q(scpi_t *context)
+{
+    SCPI_ResultBool(context, test_signal_is_enabled() ? TRUE : FALSE);
+    return SCPI_RES_OK;
+}
+
+scpi_result_t scpi_cmd_test_square_configure(scpi_t *context)
+{
+    uint32_t pin = 0;
+    uint32_t frequency = 0;
+
+    if (!SCPI_ParamUInt32(context, &pin, TRUE) ||
+        !SCPI_ParamUInt32(context, &frequency, TRUE)) {
+        SCPI_ErrorPush(context, SCPI_ERROR_MISSING_PARAMETER);
+        return SCPI_RES_ERR;
+    }
+
+    if (pin > 29 || frequency == 0) {
+        return result_illegal_parameter(context);
+    }
+
+    return test_signal_start(pin, frequency) ? result_ok()
+                                             : result_execution_error(context);
+}
+
+scpi_result_t scpi_cmd_test_square_pin_q(scpi_t *context)
+{
+    SCPI_ResultUInt32(context, test_signal_get_pin());
+    return SCPI_RES_OK;
+}
+
+scpi_result_t scpi_cmd_test_square_frequency_q(scpi_t *context)
+{
+    SCPI_ResultUInt32(context, test_signal_get_frequency_hz());
+    return SCPI_RES_OK;
+}

--- a/src/platform/status_led.c
+++ b/src/platform/status_led.c
@@ -1,0 +1,66 @@
+#include "platform/status_led.h"
+
+#include <stdbool.h>
+
+#include "pico/stdlib.h"
+
+enum {
+    BLINK_ON_MS = 80,
+    BLINK_OFF_MS = 80,
+};
+
+static bool initialized;
+
+void status_led_init(void)
+{
+#ifdef PICO_DEFAULT_LED_PIN
+    gpio_init(PICO_DEFAULT_LED_PIN);
+    gpio_set_dir(PICO_DEFAULT_LED_PIN, GPIO_OUT);
+    gpio_put(PICO_DEFAULT_LED_PIN, 0);
+#endif
+    initialized = true;
+}
+
+void status_led_set(bool on)
+{
+    if (!initialized) {
+        return;
+    }
+
+#ifdef PICO_DEFAULT_LED_PIN
+    gpio_put(PICO_DEFAULT_LED_PIN, on ? 1 : 0);
+#else
+    (void)on;
+#endif
+}
+
+void status_led_blink(unsigned int count)
+{
+    if (!initialized) {
+        return;
+    }
+
+    for (unsigned int i = 0; i < count; ++i) {
+        status_led_set(true);
+        sleep_ms(BLINK_ON_MS);
+        status_led_set(false);
+        sleep_ms(BLINK_OFF_MS);
+    }
+}
+
+void status_led_command_received(void)
+{
+    status_led_blink(1);
+}
+
+void status_led_capture_started(void)
+{
+    status_led_blink(2);
+    status_led_set(true);
+}
+
+void status_led_capture_finished(void)
+{
+    status_led_blink(2);
+    status_led_set(false);
+}

--- a/src/platform/status_led.h
+++ b/src/platform/status_led.h
@@ -1,0 +1,21 @@
+#ifndef STATUS_LED_H
+#define STATUS_LED_H
+
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void status_led_init(void);
+void status_led_set(bool on);
+void status_led_blink(unsigned int count);
+void status_led_command_received(void);
+void status_led_capture_started(void);
+void status_led_capture_finished(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/platform/test_signal.c
+++ b/src/platform/test_signal.c
@@ -1,0 +1,85 @@
+#include "platform/test_signal.h"
+
+#include "hardware/clocks.h"
+#include "hardware/gpio.h"
+#include "hardware/pwm.h"
+
+static bool enabled;
+static uint32_t output_pin = TEST_SIGNAL_DEFAULT_PIN;
+static uint32_t frequency_hz = TEST_SIGNAL_DEFAULT_FREQUENCY_HZ;
+
+void test_signal_init(void)
+{
+    test_signal_stop();
+}
+
+bool test_signal_start(uint32_t gpio, uint32_t requested_frequency_hz)
+{
+    if (gpio > 29 || requested_frequency_hz == 0) {
+        return false;
+    }
+
+    test_signal_stop();
+
+    uint32_t clock_hz = clock_get_hz(clk_sys);
+    uint32_t period_counts = clock_hz / requested_frequency_hz;
+    if (period_counts < 2) {
+        return false;
+    }
+
+    float divider = 1.0f;
+    uint32_t wrap = period_counts - 1;
+    if (wrap > 65535) {
+        wrap = 65535;
+        divider = (float)clock_hz /
+                  ((float)requested_frequency_hz * (float)(wrap + 1));
+    }
+
+    if (divider < 1.0f || divider > 255.0f) {
+        return false;
+    }
+
+    gpio_set_function((uint)gpio, GPIO_FUNC_PWM);
+    uint slice = pwm_gpio_to_slice_num((uint)gpio);
+    uint channel = pwm_gpio_to_channel((uint)gpio);
+
+    pwm_config config = pwm_get_default_config();
+    pwm_config_set_clkdiv(&config, divider);
+    pwm_config_set_wrap(&config, (uint16_t)wrap);
+    pwm_init(slice, &config, false);
+    pwm_set_chan_level(slice, channel, (uint16_t)((wrap + 1) / 2));
+    pwm_set_enabled(slice, true);
+
+    output_pin = gpio;
+    frequency_hz = requested_frequency_hz;
+    enabled = true;
+    return true;
+}
+
+void test_signal_stop(void)
+{
+    if (enabled) {
+        uint slice = pwm_gpio_to_slice_num((uint)output_pin);
+        pwm_set_enabled(slice, false);
+        gpio_init(output_pin);
+        gpio_set_dir(output_pin, GPIO_OUT);
+        gpio_put(output_pin, 0);
+    }
+
+    enabled = false;
+}
+
+bool test_signal_is_enabled(void)
+{
+    return enabled;
+}
+
+uint32_t test_signal_get_pin(void)
+{
+    return output_pin;
+}
+
+uint32_t test_signal_get_frequency_hz(void)
+{
+    return frequency_hz;
+}

--- a/src/platform/test_signal.h
+++ b/src/platform/test_signal.h
@@ -1,0 +1,27 @@
+#ifndef TEST_SIGNAL_H
+#define TEST_SIGNAL_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum {
+    TEST_SIGNAL_DEFAULT_PIN = 15,
+    TEST_SIGNAL_DEFAULT_FREQUENCY_HZ = 1000,
+};
+
+void test_signal_init(void);
+bool test_signal_start(uint32_t gpio, uint32_t frequency_hz);
+void test_signal_stop(void);
+bool test_signal_is_enabled(void);
+uint32_t test_signal_get_pin(void);
+uint32_t test_signal_get_frequency_hz(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
Adds the SCPI interface in the application layer, modified to match the current firmware.

Uses the SCPI parser library and adds logic analyzer commands. 

Address Issue #157 and follows up on #179.

This PR marks the first functional, buildable prototype of the RP2350 PSLab firmware with the logic analyser instrument.
