### PR TITLE
feat: wire error handling and logging utilities

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,11 @@ target_sources(pslab_pico PRIVATE
         src/platform/status_led.c
         src/platform/test_signal.c
         src/system/logic_analyser.c
+        src/util/circular_buffer.c
+        src/util/error.c
+        src/util/fixed_point.c
+        src/util/logging.c
+        lib/CException-1.3.4/CException.c
         lib/scpi-parser-2.3/src/error.c
         lib/scpi-parser-2.3/src/expression.c
         lib/scpi-parser-2.3/src/fifo.c
@@ -37,9 +42,15 @@ target_sources(pslab_pico PRIVATE
         )
 
 target_include_directories(pslab_pico PRIVATE
+        ${CMAKE_CURRENT_LIST_DIR}
         ${CMAKE_CURRENT_LIST_DIR}/src
         ${CMAKE_CURRENT_LIST_DIR}/src/platform
+        ${CMAKE_CURRENT_LIST_DIR}/lib/CException-1.3.4
         ${CMAKE_CURRENT_LIST_DIR}/lib/scpi-parser-2.3/inc
+        )
+
+target_compile_definitions(pslab_pico PRIVATE
+        CEXCEPTION_USE_CONFIG_FILE
         )
 
 target_link_libraries(pslab_pico PRIVATE

--- a/README.md
+++ b/README.md
@@ -58,6 +58,22 @@ Default oscilloscope configuration:
 - Trigger level: `2048`
 - Trigger slope: `RISE`
 
+## Utility, Error, And Logging Support
+
+- `src/util/error.h`: STM32 firmware error API wrapper around CException.
+- `src/util/error.c`: Pico default uncaught exception halt handler.
+- `src/util/logging.c`
+- `src/util/logging.h`
+- `src/util/circular_buffer.c`
+- `src/util/fixed_point.c`
+- `src/util/fixed_point.h`
+- `lib/CException-1.3.4`: CException library used by the retained error API.
+
+This branch wires the retained utility layer into the Pico build. `LOG_task`
+still writes through the C library output path; the later UART logging
+transport/system-init branch will route that output to hardware UART so USB CDC
+can stay dedicated to SCPI commands and binary instrument data.
+
 ## SCPI Command Interface
 
 - `src/application/protocol/common.c`: SCPI context, transport callbacks, and

--- a/src/util/error.c
+++ b/src/util/error.c
@@ -1,0 +1,21 @@
+/**
+ * @file error.c
+ * @brief Error handling integration for PSLab Pico firmware
+ *
+ * Provides the default uncaught CException halt path for the Pico build. The
+ * system layer may override this weak handler once reset/logging integration is
+ * wired in.
+ */
+
+#include <stdint.h>
+
+#include "pico/stdlib.h"
+
+__attribute__((weak, noreturn)) void EXCEPTION_halt(uint32_t id)
+{
+    (void)id;
+
+    for (;;) {
+        tight_loop_contents();
+    }
+}

--- a/src/util/fixed_point.c
+++ b/src/util/fixed_point.c
@@ -6,6 +6,7 @@
  * in fixed_point.h.
  */
 #include <inttypes.h>
+#include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
@@ -21,8 +22,8 @@ char *FIXED_to_string(
     // Worst case: 1 minus sign, 5 integer digits, 1 decimal point,
     // 5 fractional digits, 1 null terminator == 13
     unsigned const buffer_min_size = 13;
-    if (buffer == nullptr || buffer_size < buffer_min_size) {
-        return nullptr;
+    if (buffer == NULL || buffer_size < buffer_min_size) {
+        return NULL;
     }
 
     // Get integer and fractional parts
@@ -41,12 +42,12 @@ char *FIXED_to_string(
     );
 
     if (result < 0 || (size_t)result >= buffer_size) {
-        return nullptr;
+        return NULL;
     }
 
     // Find the decimal point and truncate trailing zeros
     char *decimal_point = strchr(buffer, '.');
-    if (decimal_point != nullptr) {
+    if (decimal_point != NULL) {
         char *end = buffer + result - 1;
 
         // Remove trailing zeros, but keep at least one decimal place
@@ -59,5 +60,5 @@ char *FIXED_to_string(
     }
 
     // Should be unreachable
-    return nullptr;
+    return NULL;
 }


### PR DESCRIPTION
- Added util, CException sources to CMakeLists.txt
- Added Pico fallback uncaught exception halt handler in src/util/error.c
- Fixed src/util/fixed_point.c to use C compatible NULL instead of nullptr

This PR addresses #169 and follows #181.