### PR TITLE
feat: add syscalls and system init for uart logging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,8 @@ target_sources(pslab_pico PRIVATE
         src/platform/test_signal.c
         src/system/bus/uart.c
         src/system/logic_analyser.c
+        src/system/syscalls.c
+        src/system/system.c
         src/util/circular_buffer.c
         src/util/error.c
         src/util/fixed_point.c

--- a/README.md
+++ b/README.md
@@ -89,6 +89,20 @@ specific UART backend lives in `src/platform/uart_ll.*`; it exposes the same
 low-level API expected by the system UART layer while using RP2040/RP2350 UART
 interrupts internally.
 
+## System Init And Newlib Syscalls
+
+- `src/system/system.c`
+- `src/system/system.h`
+- `src/system/syscalls.c`
+
+`SYSTEM_init()` is called before protocol initialization. It initializes the
+platform layer, utility logging, UART-backed stdout/stderr syscalls, status LED,
+test signal generation, and USB CDC. The protocol layer then owns only SCPI
+context setup and command processing.
+
+Newlib writes to `stdout` and `stderr` are routed to the hardware UART transport.
+USB CDC remains dedicated to SCPI commands and binary instrument data.
+
 ## SCPI Command Interface
 
 - `src/application/protocol/common.c`: SCPI context, transport callbacks, and

--- a/src/application/main.c
+++ b/src/application/main.c
@@ -1,7 +1,9 @@
 #include "application/protocol.h"
+#include "system/system.h"
 
 int main(void)
 {
+    SYSTEM_init();
     protocol_init();
 
     while (true) {

--- a/src/application/protocol/common.c
+++ b/src/application/protocol/common.c
@@ -18,7 +18,6 @@
 #include "application/dso_commands.h"
 #include "application/logic_analyser_commands.h"
 #include "platform/status_led.h"
-#include "platform/test_signal.h"
 #include "platform/usb_cdc.h"
 
 // Buffer sizes for USB communication (internal to this module)
@@ -202,10 +201,6 @@ bool protocol_init(void)
     if (g_protocol_initialized) {
         return true;
     }
-
-    usb_cdc_init();
-    status_led_init();
-    test_signal_init();
 
     // Initialize SCPI context
     SCPI_Init(

--- a/src/system/syscalls.c
+++ b/src/system/syscalls.c
@@ -25,6 +25,8 @@
 
 #include <errno.h>
 #include <reent.h>
+#include <stddef.h>
+#include <stdint.h>
 #include <string.h>
 #include <sys/stat.h>
 #include <unistd.h>
@@ -36,11 +38,11 @@
 #include "system/bus/uart.h"
 
 // Static handle for UART I/O
-static UART_Handle *g_uart_handle = nullptr;
+static UART_Handle *g_uart_handle = NULL;
 
 static int check_args(struct _reent *r, void const *buf, size_t cnt)
 {
-    if (buf == nullptr) {
+    if (buf == NULL) {
         r->_errno = EFAULT;
         return -1;
     }
@@ -61,7 +63,7 @@ static int check_args(struct _reent *r, void const *buf, size_t cnt)
  */
 void syscalls_init(UART_Handle *handle)
 {
-    if (g_uart_handle != nullptr) {
+    if (g_uart_handle != NULL) {
         THROW(ERROR_RESOURCE_BUSY);
     }
     g_uart_handle = handle;
@@ -80,12 +82,12 @@ void syscalls_deinit(UART_Handle *handle)
     if (g_uart_handle != handle) {
         THROW(ERROR_INVALID_ARGUMENT);
     }
-    g_uart_handle = nullptr;
+    g_uart_handle = NULL;
 }
 
 bool syscalls_uart_flush(uint32_t timeout)
 {
-    if (g_uart_handle == nullptr) {
+    if (g_uart_handle == NULL) {
         return false;
     }
 
@@ -110,7 +112,7 @@ _ssize_t _read_r(struct _reent *r, int fd, void *buf, size_t cnt)
     }
 
     // Check for null buffer
-    if (buf == nullptr) {
+    if (buf == NULL) {
         r->_errno = EFAULT;
         return -1;
     }
@@ -134,7 +136,7 @@ _ssize_t _write_r(struct _reent *r, int fd, void const *buf, size_t cnt)
     }
 
     if (fd == STDOUT_FILENO || fd == STDERR_FILENO) {
-        if (g_uart_handle == nullptr) {
+        if (g_uart_handle == NULL) {
             r->_errno = EIO;
             return -1;
         }
@@ -164,7 +166,7 @@ _ssize_t _write_r(struct _reent *r, int fd, void const *buf, size_t cnt)
  */
 int _fstat_r(struct _reent *r, int fd, struct stat *st)
 {
-    if (st == nullptr) {
+    if (st == NULL) {
         r->_errno = EFAULT;
         return -1;
     }

--- a/src/system/system.c
+++ b/src/system/system.c
@@ -11,18 +11,20 @@
 #include <stdint.h>
 
 #include "platform/platform.h"
+#include "platform/status_led.h"
+#include "platform/test_signal.h"
 #include "platform/uart_ll.h"
+#include "platform/usb_cdc.h"
 #include "util/error.h"
 #include "util/logging.h"
 #include "util/si_prefix.h"
 #include "util/util.h"
 
 #include "bus/uart.h"
-#include "led.h"
 #include "system.h"
 
 // Global variables for logging
-static UART_Handle *g_logging_uart_handle = nullptr;
+static UART_Handle *g_logging_uart_handle = NULL;
 static uint8_t g_log_buf[1024];
 static uint8_t g_log_rx_buf[1];
 static CircularBuffer g_log_cb;
@@ -37,14 +39,16 @@ void SYSTEM_init(void)
     // Set up log output
     circular_buffer_init(&g_log_cb, g_log_buf, sizeof(g_log_buf));
     circular_buffer_init(&g_log_rx_cb, g_log_rx_buf, sizeof(g_log_rx_buf));
-    uint8_t log_bus = 2;
+    uint8_t log_bus = 0;
     g_logging_uart_handle = UART_init(log_bus, &g_log_rx_cb, &g_log_cb);
     extern void syscalls_init(UART_Handle * handle);
     syscalls_init(g_logging_uart_handle);
     // Buffered log messages can now be output with LOG_task
     LOG_task(0xFF);
 
-    LED_init();
+    status_led_init();
+    test_signal_init();
+    usb_cdc_init();
 }
 
 uint32_t SYSTEM_get_tick(void) { return PLATFORM_get_tick(); }


### PR DESCRIPTION
Solves #170 

- Wires in existing `src/system/system.c` and `src/system/syscalls.c`. Modifies for Pico SDK.
- Calls SYSTEM_init() from main() before protocol_init()
- Routes newlib stdout/stderr writes through the UART syscall layer.
- Keeps USB CDC dedicated to SCPI/data.

This PR follows #183