### PR TITLE
feat: add SPI communication with ESP32

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,11 +16,13 @@ target_sources(pslab_pico PRIVATE
         src/application/protocol/common.c
         src/application/protocol/la.c
         src/application/protocol/dso.c
+        src/application/communication_commands.c
         src/application/logic_analyser_commands.c
         src/application/dso_commands.c
         src/system/instrument/dso.c
         src/platform/adc_capture.c
         src/platform/platform.c
+        src/platform/esp_spi_bridge.c
         src/platform/uart_ll.c
         src/platform/usb_cdc.c
         src/platform/usb_descriptors.c
@@ -28,6 +30,7 @@ target_sources(pslab_pico PRIVATE
         src/platform/test_signal.c
         src/system/bus/uart.c
         src/system/logic_analyser.c
+        src/system/transport.c
         src/system/syscalls.c
         src/system/system.c
         src/util/circular_buffer.c
@@ -65,6 +68,7 @@ target_link_libraries(pslab_pico PRIVATE
         hardware_dma
         hardware_adc
         hardware_pwm
+        hardware_spi
         hardware_uart
         hardware_clocks
         tinyusb_device

--- a/src/application/communication_commands.c
+++ b/src/application/communication_commands.c
@@ -25,7 +25,7 @@ scpi_result_t scpi_cmd_comm_transport(scpi_t *context)
     };
     int32_t choice = -1;
 
-    if (!SCPI_ParamChoice(context, choices, &choice, true)) {
+    if (!SCPI_ParamChoice(context, choices, &choice, TRUE)) {
         SCPI_ErrorPush(context, SCPI_ERROR_MISSING_PARAMETER);
         return SCPI_RES_ERR;
     }

--- a/src/application/communication_commands.c
+++ b/src/application/communication_commands.c
@@ -1,0 +1,69 @@
+#include "application/communication_commands.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include "scpi/error.h"
+#include "scpi/types.h"
+
+#include "system/transport.h"
+
+scpi_result_t scpi_cmd_comm_transport(scpi_t *context)
+{
+    enum {
+        COMM_TRANSPORT_USB,
+        COMM_TRANSPORT_WIFI,
+        COMM_TRANSPORT_AUTO
+    };
+    scpi_choice_def_t const choices[] = {
+        { "USB", COMM_TRANSPORT_USB },
+        { "WIFI", COMM_TRANSPORT_WIFI },
+        { "WIRELESS", COMM_TRANSPORT_WIFI },
+        { "AUTO", COMM_TRANSPORT_AUTO },
+        SCPI_CHOICE_LIST_END
+    };
+    int32_t choice = -1;
+
+    if (!SCPI_ParamChoice(context, choices, &choice, true)) {
+        SCPI_ErrorPush(context, SCPI_ERROR_MISSING_PARAMETER);
+        return SCPI_RES_ERR;
+    }
+
+    switch (choice) {
+    case COMM_TRANSPORT_WIFI:
+        transport_set_mode(TRANSPORT_MODE_WIFI);
+        break;
+    case COMM_TRANSPORT_AUTO:
+        transport_set_mode(TRANSPORT_MODE_AUTO);
+        break;
+    case COMM_TRANSPORT_USB:
+    default:
+        transport_set_mode(TRANSPORT_MODE_USB);
+        break;
+    }
+
+    return SCPI_RES_OK;
+}
+
+scpi_result_t scpi_cmd_comm_transport_q(scpi_t *context)
+{
+    SCPI_ResultText(context, transport_get_mode_name());
+    return SCPI_RES_OK;
+}
+
+scpi_result_t scpi_cmd_comm_wifi_status_q(scpi_t *context)
+{
+    char status[96];
+    snprintf(
+        status,
+        sizeof(status),
+        "%u,%lu,%lu,%lu",
+        transport_wifi_is_effective() ? 1u : 0u,
+        (unsigned long)transport_get_sent_frames(),
+        (unsigned long)transport_get_dropped_frames(),
+        (unsigned long)transport_get_timeouts()
+    );
+    SCPI_ResultText(context, status);
+    return SCPI_RES_OK;
+}

--- a/src/application/communication_commands.h
+++ b/src/application/communication_commands.h
@@ -1,0 +1,18 @@
+#ifndef PSLAB_COMMUNICATION_COMMANDS_H
+#define PSLAB_COMMUNICATION_COMMANDS_H
+
+#include "scpi/scpi.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+scpi_result_t scpi_cmd_comm_transport(scpi_t *context);
+scpi_result_t scpi_cmd_comm_transport_q(scpi_t *context);
+scpi_result_t scpi_cmd_comm_wifi_status_q(scpi_t *context);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/application/main.c
+++ b/src/application/main.c
@@ -2,6 +2,8 @@
 #include "system/system.h"
 #include "util/logging.h"
 
+#include <stdbool.h>
+
 int main(void)
 {
     SYSTEM_init();

--- a/src/application/protocol/common.c
+++ b/src/application/protocol/common.c
@@ -16,10 +16,12 @@
 #include "scpi/error.h"
 #include "scpi/scpi.h"
 
+#include "application/communication_commands.h"
 #include "application/dso_commands.h"
 #include "application/logic_analyser_commands.h"
 #include "platform/status_led.h"
 #include "platform/usb_cdc.h"
+#include "system/transport.h"
 #include "util/logging.h"
 
 // Buffer sizes for USB communication (internal to this module)
@@ -140,6 +142,11 @@ static scpi_command_t const g_SCPI_COMMANDS[] = {
     { "SYSTem:ERRor:COUNt?", SCPI_SystemErrorCountQ },
     { "SYSTem:VERSion?", SCPI_SystemVersionQ },
 
+    // Communication transport commands
+    { "COMM:TRANsport", scpi_cmd_comm_transport },
+    { "COMM:TRANsport?", scpi_cmd_comm_transport_q },
+    { "COMM:WIFI:STATus?", scpi_cmd_comm_wifi_status_q },
+
     // Logic analyser commands
     { "LA:CONFigure:PINBase", scpi_cmd_configure_logic_analyser_pinbase },
     { "LA:CONFigure:PINBase?", scpi_cmd_configure_logic_analyser_pinbase_q },
@@ -242,6 +249,83 @@ void protocol_deinit(void)
     LOG_DEBUG("SCPI protocol deinitialized");
 }
 
+static void write_usb_stream_frame(
+    char const *prefix,
+    uint32_t sequence,
+    uint8_t const *data,
+    size_t len
+)
+{
+    char frame_header[48];
+    snprintf(
+        frame_header,
+        sizeof(frame_header),
+        "%s %lu %lu\n",
+        prefix,
+        (unsigned long)sequence,
+        (unsigned long)len
+    );
+    usb_cdc_write((uint8_t const *)frame_header, strlen(frame_header));
+    SCPI_ResultArbitraryBlock(&g_scpi_context, data, len);
+    usb_cdc_write((uint8_t const *)"\n", 1);
+}
+
+static void write_logic_analyser_stream_frame(
+    uint32_t sequence,
+    uint8_t const *data,
+    size_t len
+)
+{
+    if (transport_wifi_is_effective()) {
+        TransportCaptureMeta meta = {
+            .sample_rate_hz = 150000000u / la_get_divider(),
+            .sample_count = la_get_samples(),
+            .channel_count = la_get_pin_count(),
+            .pin_base_or_channel = la_get_pin_base(),
+            .trigger_mode = la_get_trigger_mode_edge() ? 1u : 2u,
+            .data_format = TRANSPORT_DATA_FORMAT_LA_U32_PACKED,
+        };
+        (void)transport_send_capture(
+            TRANSPORT_INSTRUMENT_LA,
+            sequence,
+            &meta,
+            data,
+            len
+        );
+        return;
+    }
+
+    write_usb_stream_frame("LA:STREAM:FRAME", sequence, data, len);
+}
+
+static void write_dso_stream_frame(
+    uint32_t sequence,
+    uint8_t const *data,
+    size_t len
+)
+{
+    if (transport_wifi_is_effective()) {
+        TransportCaptureMeta meta = {
+            .sample_rate_hz = dso_commands_get_sample_rate(),
+            .sample_count = dso_commands_get_samples(),
+            .channel_count = 1,
+            .pin_base_or_channel = dso_commands_get_channel(),
+            .trigger_mode = 0,
+            .data_format = TRANSPORT_DATA_FORMAT_DSO_U16_LE,
+        };
+        (void)transport_send_capture(
+            TRANSPORT_INSTRUMENT_DSO,
+            sequence,
+            &meta,
+            data,
+            len
+        );
+        return;
+    }
+
+    write_usb_stream_frame("DSO:STREAM:FRAME", sequence, data, len);
+}
+
 /**
  * @brief Main protocol task - processes USB data and SCPI commands
  */
@@ -266,17 +350,7 @@ void protocol_task(void)
         size_t len;
         uint32_t sequence;
         if (la_stream_next_frame(&data, &len, &sequence)) {
-            char frame_header[48];
-            snprintf(
-                frame_header,
-                sizeof(frame_header),
-                "LA:STREAM:FRAME %lu %lu\n",
-                (unsigned long)sequence,
-                (unsigned long)len
-            );
-            usb_cdc_write((uint8_t const *)frame_header, strlen(frame_header));
-            SCPI_ResultArbitraryBlock(&g_scpi_context, data, len);
-            usb_cdc_write((uint8_t const *)"\n", 1);
+            write_logic_analyser_stream_frame(sequence, data, len);
         }
     }
 
@@ -285,17 +359,7 @@ void protocol_task(void)
         size_t len;
         uint32_t sequence;
         if (dso_commands_stream_next_frame(&data, &len, &sequence)) {
-            char frame_header[48];
-            snprintf(
-                frame_header,
-                sizeof(frame_header),
-                "DSO:STREAM:FRAME %lu %lu\n",
-                (unsigned long)sequence,
-                (unsigned long)len
-            );
-            usb_cdc_write((uint8_t const *)frame_header, strlen(frame_header));
-            SCPI_ResultArbitraryBlock(&g_scpi_context, data, len);
-            usb_cdc_write((uint8_t const *)"\n", 1);
+            write_dso_stream_frame(sequence, data, len);
         }
     }
 }

--- a/src/application/protocol/common.c
+++ b/src/application/protocol/common.c
@@ -29,6 +29,7 @@
 // Buffer sizes for USB communication (internal to this module)
 enum {
     USB_RX_CHUNK_SIZE = 64,
+    WIFI_RX_CHUNK_SIZE = 256,
     SCPI_INPUT_BUFFER_SIZE = 256,
     SCPI_ERROR_QUEUE_SIZE = 16
 };
@@ -78,6 +79,9 @@ extern scpi_result_t scpi_cmd_stream_dso_start(scpi_t *context);
 extern scpi_result_t scpi_cmd_stream_dso_stop(scpi_t *context);
 extern scpi_result_t scpi_cmd_stream_dso_status_q(scpi_t *context);
 
+static scpi_result_t scpi_cmd_la_wifi_read_q(scpi_t *context);
+static scpi_result_t scpi_cmd_dso_wifi_read_q(scpi_t *context);
+
 // Forward declarations of test signal functions needed by common
 extern scpi_result_t scpi_cmd_test_square(scpi_t *context);
 extern scpi_result_t scpi_cmd_test_square_q(scpi_t *context);
@@ -93,9 +97,29 @@ static scpi_error_t g_scpi_error_queue_data[SCPI_ERROR_QUEUE_SIZE];
 // Protocol state (internal to common.c)
 static bool g_protocol_initialized = false;
 
-static void protocol_transport_yield(void)
+typedef enum {
+    PROTOCOL_SOURCE_USB,
+    PROTOCOL_SOURCE_WIFI,
+} ProtocolSource;
+
+static ProtocolSource g_active_source = PROTOCOL_SOURCE_USB;
+static uint8_t g_wifi_scpi_response[512];
+static size_t g_wifi_scpi_response_len;
+static uint32_t g_la_wifi_capture_sequence;
+static uint32_t g_dso_wifi_capture_sequence;
+
+static size_t protocol_flush_wifi_response(void)
 {
-    usb_cdc_task();
+    if (g_wifi_scpi_response_len == 0) {
+        return 0;
+    }
+
+    size_t sent = transport_send_scpi_response(
+        g_wifi_scpi_response,
+        g_wifi_scpi_response_len
+    );
+    g_wifi_scpi_response_len = 0;
+    return sent;
 }
 
 /**
@@ -104,6 +128,29 @@ static void protocol_transport_yield(void)
 static size_t protocol_write(scpi_t *context, char const *data, size_t len)
 {
     (void)context; // Unused parameter
+    if (g_active_source == PROTOCOL_SOURCE_WIFI) {
+        if (len >= sizeof(g_wifi_scpi_response)) {
+            (void)protocol_flush_wifi_response();
+            return transport_send_scpi_response((uint8_t const *)data, len);
+        }
+
+        if (g_wifi_scpi_response_len + len > sizeof(g_wifi_scpi_response)) {
+            (void)protocol_flush_wifi_response();
+        }
+
+        memcpy(
+            &g_wifi_scpi_response[g_wifi_scpi_response_len],
+            data,
+            len
+        );
+        g_wifi_scpi_response_len += len;
+
+        if (memchr(data, '\n', len) || memchr(data, '\r', len)) {
+            (void)protocol_flush_wifi_response();
+        }
+        return len;
+    }
+
     return usb_cdc_write((uint8_t const *)data, len);
 }
 
@@ -176,6 +223,7 @@ static scpi_command_t const g_SCPI_COMMANDS[] = {
     { "LA:STREAM:STARt", scpi_cmd_stream_logic_analyser_start },
     { "LA:STREAM:STOP", scpi_cmd_stream_logic_analyser_stop },
     { "LA:STREAM:STATus?", scpi_cmd_stream_logic_analyser_status_q },
+    { "LA:WIFI:READ?", scpi_cmd_la_wifi_read_q },
 
     // Oscilloscope commands
     { "DSO:CONFigure:CHANnel", scpi_cmd_configure_dso_channel },
@@ -198,6 +246,7 @@ static scpi_command_t const g_SCPI_COMMANDS[] = {
     { "DSO:STREAM:STARt", scpi_cmd_stream_dso_start },
     { "DSO:STREAM:STOP", scpi_cmd_stream_dso_stop },
     { "DSO:STREAM:STATus?", scpi_cmd_stream_dso_status_q },
+    { "DSO:WIFI:READ?", scpi_cmd_dso_wifi_read_q },
 
     // Built-in test signal commands
     { "TEST:SQUare", scpi_cmd_test_square },
@@ -219,7 +268,6 @@ bool protocol_init(void)
     }
 
     LOG_INIT("SCPI protocol");
-    transport_set_yield_callback(protocol_transport_yield);
 
     // Initialize SCPI context
     SCPI_Init(
@@ -278,60 +326,111 @@ static void write_usb_stream_frame(
     usb_cdc_write((uint8_t const *)"\n", 1);
 }
 
-static void write_logic_analyser_stream_frame(
+static void write_stream_frame(
+    TransportInstrument instrument,
+    char const *prefix,
     uint32_t sequence,
     uint8_t const *data,
     size_t len
 )
 {
     if (transport_wifi_is_effective()) {
-        TransportCaptureMeta meta = {
-            .sample_rate_hz = clock_get_hz(clk_sys) / la_get_divider(),
-            .sample_count = la_get_samples(),
-            .channel_count = la_get_pin_count(),
-            .pin_base_or_channel = la_get_pin_base(),
-            .trigger_mode = la_get_trigger_mode_edge() ? 1u : 2u,
-            .data_format = TRANSPORT_DATA_FORMAT_LA_U32_PACKED,
-        };
-        (void)transport_send_capture(
+        TransportCaptureMeta meta = {0};
+        if (instrument == TRANSPORT_INSTRUMENT_LA) {
+            meta = (TransportCaptureMeta){
+                .sample_rate_hz = clock_get_hz(clk_sys) / la_get_divider(),
+                .sample_count = la_get_samples(),
+                .channel_count = la_get_pin_count(),
+                .pin_base_or_channel = la_get_pin_base(),
+                .trigger_mode = la_get_trigger_mode_edge() ? 1u : 2u,
+                .data_format = 1,
+            };
+        } else {
+            meta = (TransportCaptureMeta){
+                .sample_rate_hz = dso_commands_get_sample_rate(),
+                .sample_count = dso_commands_get_samples(),
+                .channel_count = 1,
+                .pin_base_or_channel = dso_commands_get_channel(),
+                .trigger_mode = 0,
+                .data_format = 2,
+            };
+        }
+
+        (void)transport_send_capture(instrument, sequence, &meta, data, len);
+        return;
+    }
+
+    write_usb_stream_frame(prefix, sequence, data, len);
+}
+
+static scpi_result_t scpi_cmd_la_wifi_read_q(scpi_t *context)
+{
+    uint8_t const *data = NULL;
+    size_t len = 0;
+    uint32_t sequence = g_la_wifi_capture_sequence++;
+
+    transport_set_mode(TRANSPORT_MODE_WIFI);
+    if (!la_initiate() || !la_fetch(&data, &len)) {
+        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+        return SCPI_RES_ERR;
+    }
+
+    TransportCaptureMeta meta = {
+        .sample_rate_hz = clock_get_hz(clk_sys) / la_get_divider(),
+        .sample_count = la_get_samples(),
+        .channel_count = la_get_pin_count(),
+        .pin_base_or_channel = la_get_pin_base(),
+        .trigger_mode = la_get_trigger_mode_edge() ? 1u : 2u,
+        .data_format = 1,
+    };
+    if (!transport_send_capture(
             TRANSPORT_INSTRUMENT_LA,
             sequence,
             &meta,
             data,
             len
-        );
-        return;
+        )) {
+        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+        return SCPI_RES_ERR;
     }
 
-    write_usb_stream_frame("LA:STREAM:FRAME", sequence, data, len);
+    SCPI_ResultUInt32(context, sequence);
+    return SCPI_RES_OK;
 }
 
-static void write_dso_stream_frame(
-    uint32_t sequence,
-    uint8_t const *data,
-    size_t len
-)
+static scpi_result_t scpi_cmd_dso_wifi_read_q(scpi_t *context)
 {
-    if (transport_wifi_is_effective()) {
-        TransportCaptureMeta meta = {
-            .sample_rate_hz = dso_commands_get_sample_rate(),
-            .sample_count = dso_commands_get_samples(),
-            .channel_count = 1,
-            .pin_base_or_channel = dso_commands_get_channel(),
-            .trigger_mode = 0,
-            .data_format = TRANSPORT_DATA_FORMAT_DSO_U16_LE,
-        };
-        (void)transport_send_capture(
+    uint8_t const *data = NULL;
+    size_t len = 0;
+    uint32_t sequence = g_dso_wifi_capture_sequence++;
+
+    transport_set_mode(TRANSPORT_MODE_WIFI);
+    if (!dso_commands_initiate() || !dso_commands_fetch(&data, &len)) {
+        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+        return SCPI_RES_ERR;
+    }
+
+    TransportCaptureMeta meta = {
+        .sample_rate_hz = dso_commands_get_sample_rate(),
+        .sample_count = dso_commands_get_samples(),
+        .channel_count = 1,
+        .pin_base_or_channel = dso_commands_get_channel(),
+        .trigger_mode = 0,
+        .data_format = 2,
+    };
+    if (!transport_send_capture(
             TRANSPORT_INSTRUMENT_DSO,
             sequence,
             &meta,
             data,
             len
-        );
-        return;
+        )) {
+        SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+        return SCPI_RES_ERR;
     }
 
-    write_usb_stream_frame("DSO:STREAM:FRAME", sequence, data, len);
+    SCPI_ResultUInt32(context, sequence);
+    return SCPI_RES_OK;
 }
 
 /**
@@ -350,7 +449,17 @@ void protocol_task(void)
     uint32_t bytes_read = usb_cdc_read(buffer, sizeof(buffer));
     if (bytes_read > 0) {
         status_led_command_received();
+        g_active_source = PROTOCOL_SOURCE_USB;
         SCPI_Input(&g_scpi_context, (char *)buffer, (int)bytes_read);
+    }
+
+    uint8_t wifi_buffer[WIFI_RX_CHUNK_SIZE];
+    size_t wifi_len = 0;
+    if (transport_poll_scpi_command(wifi_buffer, sizeof(wifi_buffer), &wifi_len)) {
+        status_led_command_received();
+        g_active_source = PROTOCOL_SOURCE_WIFI;
+        SCPI_Input(&g_scpi_context, (char *)wifi_buffer, (int)wifi_len);
+        g_active_source = PROTOCOL_SOURCE_USB;
     }
 
     if (la_stream_is_enabled()) {
@@ -358,7 +467,13 @@ void protocol_task(void)
         size_t len;
         uint32_t sequence;
         if (la_stream_next_frame(&data, &len, &sequence)) {
-            write_logic_analyser_stream_frame(sequence, data, len);
+            write_stream_frame(
+                TRANSPORT_INSTRUMENT_LA,
+                "LA:STREAM:FRAME",
+                sequence,
+                data,
+                len
+            );
         }
     }
 
@@ -367,7 +482,13 @@ void protocol_task(void)
         size_t len;
         uint32_t sequence;
         if (dso_commands_stream_next_frame(&data, &len, &sequence)) {
-            write_dso_stream_frame(sequence, data, len);
+            write_stream_frame(
+                TRANSPORT_INSTRUMENT_DSO,
+                "DSO:STREAM:FRAME",
+                sequence,
+                data,
+                len
+            );
         }
     }
 }

--- a/src/application/protocol/common.c
+++ b/src/application/protocol/common.c
@@ -13,6 +13,8 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "hardware/clocks.h"
+
 #include "scpi/error.h"
 #include "scpi/scpi.h"
 
@@ -90,6 +92,11 @@ static scpi_error_t g_scpi_error_queue_data[SCPI_ERROR_QUEUE_SIZE];
 
 // Protocol state (internal to common.c)
 static bool g_protocol_initialized = false;
+
+static void protocol_transport_yield(void)
+{
+    usb_cdc_task();
+}
 
 /**
  * @brief SCPI write function - sends data via USB
@@ -212,6 +219,7 @@ bool protocol_init(void)
     }
 
     LOG_INIT("SCPI protocol");
+    transport_set_yield_callback(protocol_transport_yield);
 
     // Initialize SCPI context
     SCPI_Init(
@@ -278,7 +286,7 @@ static void write_logic_analyser_stream_frame(
 {
     if (transport_wifi_is_effective()) {
         TransportCaptureMeta meta = {
-            .sample_rate_hz = 150000000u / la_get_divider(),
+            .sample_rate_hz = clock_get_hz(clk_sys) / la_get_divider(),
             .sample_count = la_get_samples(),
             .channel_count = la_get_pin_count(),
             .pin_base_or_channel = la_get_pin_base(),

--- a/src/platform/esp_spi_bridge.c
+++ b/src/platform/esp_spi_bridge.c
@@ -13,10 +13,9 @@ enum {
     ESP_SPI_BRIDGE_PIN_RX = 4,
     ESP_SPI_BRIDGE_PIN_CSN = 5,
     ESP_SPI_BRIDGE_PIN_READY = 6,
-    ESP_SPI_BRIDGE_BAUDRATE_HZ = 20000000u,
+    ESP_SPI_BRIDGE_BAUDRATE_HZ = 1000000u,
     ESP_SPI_BRIDGE_READY_TIMEOUT_US = 1000,
     ESP_SPI_BRIDGE_MAGIC = 0xa5,
-    ESP_SPI_BRIDGE_FRAME_TYPE_DATA = 0x02,
 };
 
 static bool g_initialized;
@@ -49,6 +48,11 @@ static void put_u32_le(uint8_t *data, uint32_t value)
     data[1] = (uint8_t)(value >> 8);
     data[2] = (uint8_t)(value >> 16);
     data[3] = (uint8_t)(value >> 24);
+}
+
+static uint16_t get_u16_le(uint8_t const *data)
+{
+    return (uint16_t)data[0] | ((uint16_t)data[1] << 8);
 }
 
 static bool wait_ready_high(uint32_t timeout_us)
@@ -135,14 +139,6 @@ bool esp_spi_bridge_init(void)
     g_tx_dma = dma_claim_unused_channel(false);
     g_rx_dma = dma_claim_unused_channel(false);
     if (g_tx_dma < 0 || g_rx_dma < 0) {
-        if (g_tx_dma >= 0) {
-            dma_channel_unclaim((uint)g_tx_dma);
-            g_tx_dma = -1;
-        }
-        if (g_rx_dma >= 0) {
-            dma_channel_unclaim((uint)g_rx_dma);
-            g_rx_dma = -1;
-        }
         return false;
     }
 
@@ -155,10 +151,15 @@ bool esp_spi_bridge_is_ready(void)
     return g_initialized && gpio_get(ESP_SPI_BRIDGE_PIN_READY);
 }
 
-bool esp_spi_bridge_send_payload(
+bool esp_spi_bridge_exchange(
+    EspSpiBridgeFrameType tx_type,
     uint32_t sequence,
-    uint8_t const *payload,
-    size_t payload_len
+    uint8_t const *tx_payload,
+    size_t tx_payload_len,
+    EspSpiBridgeFrameType *rx_type,
+    uint8_t *rx_payload,
+    size_t rx_payload_size,
+    size_t *rx_payload_len
 )
 {
     if (!g_initialized && !esp_spi_bridge_init()) {
@@ -166,7 +167,8 @@ bool esp_spi_bridge_send_payload(
         return false;
     }
 
-    if (!payload || payload_len > ESP_SPI_BRIDGE_PAYLOAD_LEN) {
+    if ((!tx_payload && tx_payload_len > 0) ||
+        tx_payload_len > ESP_SPI_BRIDGE_PAYLOAD_LEN) {
         ++g_dropped_frames;
         return false;
     }
@@ -180,15 +182,67 @@ bool esp_spi_bridge_send_payload(
     memset(g_tx_frame, 0, sizeof(g_tx_frame));
     memset(g_rx_frame, 0, sizeof(g_rx_frame));
     g_tx_frame[0] = ESP_SPI_BRIDGE_MAGIC;
-    g_tx_frame[1] = ESP_SPI_BRIDGE_FRAME_TYPE_DATA;
+    g_tx_frame[1] = (uint8_t)tx_type;
     put_u32_le(&g_tx_frame[2], sequence);
-    put_u16_le(&g_tx_frame[6], (uint16_t)payload_len);
+    put_u16_le(&g_tx_frame[6], (uint16_t)tx_payload_len);
     g_tx_frame[8] = checksum8(g_tx_frame, 8);
-    memcpy(&g_tx_frame[ESP_SPI_BRIDGE_HEADER_LEN], payload, payload_len);
+    if (tx_payload_len > 0) {
+        memcpy(&g_tx_frame[ESP_SPI_BRIDGE_HEADER_LEN], tx_payload, tx_payload_len);
+    }
 
     transfer_frame_dma();
     ++g_sent_frames;
+
+    if (rx_payload_len) {
+        *rx_payload_len = 0;
+    }
+    if (rx_type) {
+        *rx_type = ESP_SPI_BRIDGE_FRAME_POLL;
+    }
+
+    if (g_rx_frame[0] != ESP_SPI_BRIDGE_MAGIC ||
+        g_rx_frame[8] != checksum8(g_rx_frame, 8)) {
+        return true;
+    }
+
+    uint16_t payload_len = get_u16_le(&g_rx_frame[6]);
+    if (payload_len > ESP_SPI_BRIDGE_PAYLOAD_LEN) {
+        return true;
+    }
+
+    if (rx_type) {
+        *rx_type = (EspSpiBridgeFrameType)g_rx_frame[1];
+    }
+    if (rx_payload && rx_payload_len) {
+        size_t copy_len = payload_len;
+        if (copy_len > rx_payload_size) {
+            copy_len = rx_payload_size;
+        }
+        if (copy_len > 0) {
+            memcpy(rx_payload, &g_rx_frame[ESP_SPI_BRIDGE_HEADER_LEN], copy_len);
+        }
+        *rx_payload_len = copy_len;
+    }
+
     return true;
+}
+
+bool esp_spi_bridge_send_payload(
+    uint32_t sequence,
+    uint8_t const *payload,
+    size_t payload_len
+)
+{
+    return esp_spi_bridge_exchange(
+        ESP_SPI_BRIDGE_FRAME_DATA,
+        sequence,
+        payload,
+        payload_len,
+        NULL,
+        NULL,
+        0,
+        NULL
+    );
 }
 
 uint32_t esp_spi_bridge_get_sent_frames(void) { return g_sent_frames; }

--- a/src/platform/esp_spi_bridge.c
+++ b/src/platform/esp_spi_bridge.c
@@ -1,0 +1,198 @@
+#include "platform/esp_spi_bridge.h"
+
+#include <string.h>
+
+#include "hardware/dma.h"
+#include "hardware/gpio.h"
+#include "hardware/spi.h"
+#include "pico/stdlib.h"
+
+enum {
+    ESP_SPI_BRIDGE_PIN_SCK = 2,
+    ESP_SPI_BRIDGE_PIN_TX = 3,
+    ESP_SPI_BRIDGE_PIN_RX = 4,
+    ESP_SPI_BRIDGE_PIN_CSN = 5,
+    ESP_SPI_BRIDGE_PIN_READY = 6,
+    ESP_SPI_BRIDGE_BAUDRATE_HZ = 20000000u,
+    ESP_SPI_BRIDGE_READY_TIMEOUT_US = 1000,
+    ESP_SPI_BRIDGE_MAGIC = 0xa5,
+    ESP_SPI_BRIDGE_FRAME_TYPE_DATA = 0x02,
+};
+
+static bool g_initialized;
+static int g_tx_dma = -1;
+static int g_rx_dma = -1;
+static uint8_t g_tx_frame[ESP_SPI_BRIDGE_FRAME_LEN];
+static uint8_t g_rx_frame[ESP_SPI_BRIDGE_FRAME_LEN];
+static uint32_t g_sent_frames;
+static uint32_t g_dropped_frames;
+static uint32_t g_timeouts;
+
+static uint8_t checksum8(uint8_t const *data, size_t len)
+{
+    uint8_t sum = 0;
+    for (size_t i = 0; i < len; ++i) {
+        sum = (uint8_t)(sum + data[i]);
+    }
+    return sum;
+}
+
+static void put_u16_le(uint8_t *data, uint16_t value)
+{
+    data[0] = (uint8_t)value;
+    data[1] = (uint8_t)(value >> 8);
+}
+
+static void put_u32_le(uint8_t *data, uint32_t value)
+{
+    data[0] = (uint8_t)value;
+    data[1] = (uint8_t)(value >> 8);
+    data[2] = (uint8_t)(value >> 16);
+    data[3] = (uint8_t)(value >> 24);
+}
+
+static bool wait_ready_high(uint32_t timeout_us)
+{
+    absolute_time_t deadline = make_timeout_time_us(timeout_us);
+    while (!gpio_get(ESP_SPI_BRIDGE_PIN_READY)) {
+        if (absolute_time_diff_us(get_absolute_time(), deadline) <= 0) {
+            return false;
+        }
+        tight_loop_contents();
+    }
+    return true;
+}
+
+static void drain_spi_rx_fifo(void)
+{
+    while (spi_is_readable(spi0)) {
+        (void)spi_get_hw(spi0)->dr;
+    }
+}
+
+static void transfer_frame_dma(void)
+{
+    drain_spi_rx_fifo();
+
+    dma_channel_config rx_cfg = dma_channel_get_default_config(g_rx_dma);
+    channel_config_set_transfer_data_size(&rx_cfg, DMA_SIZE_8);
+    channel_config_set_read_increment(&rx_cfg, false);
+    channel_config_set_write_increment(&rx_cfg, true);
+    channel_config_set_dreq(&rx_cfg, spi_get_dreq(spi0, false));
+
+    dma_channel_config tx_cfg = dma_channel_get_default_config(g_tx_dma);
+    channel_config_set_transfer_data_size(&tx_cfg, DMA_SIZE_8);
+    channel_config_set_read_increment(&tx_cfg, true);
+    channel_config_set_write_increment(&tx_cfg, false);
+    channel_config_set_dreq(&tx_cfg, spi_get_dreq(spi0, true));
+
+    dma_channel_configure(
+        g_rx_dma,
+        &rx_cfg,
+        g_rx_frame,
+        &spi_get_hw(spi0)->dr,
+        ESP_SPI_BRIDGE_FRAME_LEN,
+        false
+    );
+    dma_channel_configure(
+        g_tx_dma,
+        &tx_cfg,
+        &spi_get_hw(spi0)->dr,
+        g_tx_frame,
+        ESP_SPI_BRIDGE_FRAME_LEN,
+        false
+    );
+
+    gpio_put(ESP_SPI_BRIDGE_PIN_CSN, 0);
+    sleep_us(2);
+    dma_start_channel_mask((1u << g_rx_dma) | (1u << g_tx_dma));
+    dma_channel_wait_for_finish_blocking(g_rx_dma);
+    dma_channel_wait_for_finish_blocking(g_tx_dma);
+    sleep_us(2);
+    gpio_put(ESP_SPI_BRIDGE_PIN_CSN, 1);
+}
+
+bool esp_spi_bridge_init(void)
+{
+    if (g_initialized) {
+        return true;
+    }
+
+    gpio_init(ESP_SPI_BRIDGE_PIN_READY);
+    gpio_set_dir(ESP_SPI_BRIDGE_PIN_READY, GPIO_IN);
+    gpio_pull_down(ESP_SPI_BRIDGE_PIN_READY);
+
+    gpio_init(ESP_SPI_BRIDGE_PIN_CSN);
+    gpio_set_dir(ESP_SPI_BRIDGE_PIN_CSN, GPIO_OUT);
+    gpio_put(ESP_SPI_BRIDGE_PIN_CSN, 1);
+
+    spi_init(spi0, ESP_SPI_BRIDGE_BAUDRATE_HZ);
+    spi_set_format(spi0, 8, SPI_CPOL_0, SPI_CPHA_0, SPI_MSB_FIRST);
+    gpio_set_function(ESP_SPI_BRIDGE_PIN_RX, GPIO_FUNC_SPI);
+    gpio_set_function(ESP_SPI_BRIDGE_PIN_SCK, GPIO_FUNC_SPI);
+    gpio_set_function(ESP_SPI_BRIDGE_PIN_TX, GPIO_FUNC_SPI);
+
+    g_tx_dma = dma_claim_unused_channel(false);
+    g_rx_dma = dma_claim_unused_channel(false);
+    if (g_tx_dma < 0 || g_rx_dma < 0) {
+        if (g_tx_dma >= 0) {
+            dma_channel_unclaim((uint)g_tx_dma);
+            g_tx_dma = -1;
+        }
+        if (g_rx_dma >= 0) {
+            dma_channel_unclaim((uint)g_rx_dma);
+            g_rx_dma = -1;
+        }
+        return false;
+    }
+
+    g_initialized = true;
+    return true;
+}
+
+bool esp_spi_bridge_is_ready(void)
+{
+    return g_initialized && gpio_get(ESP_SPI_BRIDGE_PIN_READY);
+}
+
+bool esp_spi_bridge_send_payload(
+    uint32_t sequence,
+    uint8_t const *payload,
+    size_t payload_len
+)
+{
+    if (!g_initialized && !esp_spi_bridge_init()) {
+        ++g_dropped_frames;
+        return false;
+    }
+
+    if (!payload || payload_len > ESP_SPI_BRIDGE_PAYLOAD_LEN) {
+        ++g_dropped_frames;
+        return false;
+    }
+
+    if (!wait_ready_high(ESP_SPI_BRIDGE_READY_TIMEOUT_US)) {
+        ++g_timeouts;
+        ++g_dropped_frames;
+        return false;
+    }
+
+    memset(g_tx_frame, 0, sizeof(g_tx_frame));
+    memset(g_rx_frame, 0, sizeof(g_rx_frame));
+    g_tx_frame[0] = ESP_SPI_BRIDGE_MAGIC;
+    g_tx_frame[1] = ESP_SPI_BRIDGE_FRAME_TYPE_DATA;
+    put_u32_le(&g_tx_frame[2], sequence);
+    put_u16_le(&g_tx_frame[6], (uint16_t)payload_len);
+    g_tx_frame[8] = checksum8(g_tx_frame, 8);
+    memcpy(&g_tx_frame[ESP_SPI_BRIDGE_HEADER_LEN], payload, payload_len);
+
+    transfer_frame_dma();
+    ++g_sent_frames;
+    return true;
+}
+
+uint32_t esp_spi_bridge_get_sent_frames(void) { return g_sent_frames; }
+
+uint32_t esp_spi_bridge_get_dropped_frames(void) { return g_dropped_frames; }
+
+uint32_t esp_spi_bridge_get_timeouts(void) { return g_timeouts; }

--- a/src/platform/esp_spi_bridge.h
+++ b/src/platform/esp_spi_bridge.h
@@ -1,0 +1,35 @@
+#ifndef ESP_SPI_BRIDGE_H
+#define ESP_SPI_BRIDGE_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum {
+    ESP_SPI_BRIDGE_FRAME_LEN = 512,
+    ESP_SPI_BRIDGE_HEADER_LEN = 12,
+    ESP_SPI_BRIDGE_PAYLOAD_LEN =
+        ESP_SPI_BRIDGE_FRAME_LEN - ESP_SPI_BRIDGE_HEADER_LEN,
+};
+
+bool esp_spi_bridge_init(void);
+bool esp_spi_bridge_is_ready(void);
+bool esp_spi_bridge_send_payload(
+    uint32_t sequence,
+    uint8_t const *payload,
+    size_t payload_len
+);
+
+uint32_t esp_spi_bridge_get_sent_frames(void);
+uint32_t esp_spi_bridge_get_dropped_frames(void);
+uint32_t esp_spi_bridge_get_timeouts(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/platform/esp_spi_bridge.h
+++ b/src/platform/esp_spi_bridge.h
@@ -16,8 +16,24 @@ enum {
         ESP_SPI_BRIDGE_FRAME_LEN - ESP_SPI_BRIDGE_HEADER_LEN,
 };
 
+typedef enum {
+    ESP_SPI_BRIDGE_FRAME_POLL = 0x00,
+    ESP_SPI_BRIDGE_FRAME_DATA = 0x02,
+    ESP_SPI_BRIDGE_FRAME_SCPI = 0x03,
+} EspSpiBridgeFrameType;
+
 bool esp_spi_bridge_init(void);
 bool esp_spi_bridge_is_ready(void);
+bool esp_spi_bridge_exchange(
+    EspSpiBridgeFrameType tx_type,
+    uint32_t sequence,
+    uint8_t const *tx_payload,
+    size_t tx_payload_len,
+    EspSpiBridgeFrameType *rx_type,
+    uint8_t *rx_payload,
+    size_t rx_payload_size,
+    size_t *rx_payload_len
+);
 bool esp_spi_bridge_send_payload(
     uint32_t sequence,
     uint8_t const *payload,

--- a/src/system/system.c
+++ b/src/system/system.c
@@ -16,6 +16,7 @@
 #include "platform/test_signal.h"
 #include "platform/uart_ll.h"
 #include "platform/usb_cdc.h"
+#include "system/transport.h"
 #include "util/error.h"
 #include "util/logging.h"
 #include "util/si_prefix.h"
@@ -50,6 +51,7 @@ void SYSTEM_init(void)
     status_led_init();
     test_signal_init();
     usb_cdc_init();
+    transport_init();
 }
 
 uint32_t SYSTEM_get_tick(void) { return PLATFORM_get_tick(); }

--- a/src/system/transport.c
+++ b/src/system/transport.c
@@ -16,6 +16,7 @@ enum {
 
 static TransportMode g_mode = TRANSPORT_MODE_USB;
 static uint32_t g_frame_sequence;
+static TransportYieldCallback g_yield_callback;
 
 static void put_u16_le(uint8_t *data, uint16_t value)
 {
@@ -68,6 +69,19 @@ void transport_init(void)
 {
     g_mode = TRANSPORT_MODE_USB;
     g_frame_sequence = 0;
+    g_yield_callback = NULL;
+}
+
+void transport_set_yield_callback(TransportYieldCallback callback)
+{
+    g_yield_callback = callback;
+}
+
+static void transport_yield(void)
+{
+    if (g_yield_callback) {
+        g_yield_callback();
+    }
 }
 
 void transport_set_mode(TransportMode mode)
@@ -142,6 +156,7 @@ bool transport_send_capture(
     if (!esp_spi_bridge_send_payload(g_frame_sequence++, payload, ESP_SPI_BRIDGE_PAYLOAD_LEN)) {
         return false;
     }
+    transport_yield();
 
     uint16_t chunk_count = (uint16_t)((len + PSLAB_DATA_BYTES_PER_FRAME - 1u) /
                                       PSLAB_DATA_BYTES_PER_FRAME);
@@ -176,6 +191,7 @@ bool transport_send_capture(
             )) {
             return false;
         }
+        transport_yield();
     }
 
     return true;

--- a/src/system/transport.c
+++ b/src/system/transport.c
@@ -158,6 +158,11 @@ bool transport_poll_scpi_command(uint8_t *buffer, size_t buffer_size, size_t *le
         return false;
     }
 
+    if (!transport_wifi_is_effective()) {
+        *len = 0;
+        return false;
+    }
+
     if (g_pending_scpi_len == 0 && esp_spi_bridge_init() &&
         esp_spi_bridge_is_ready()) {
         (void)exchange_and_store_scpi(ESP_SPI_BRIDGE_FRAME_POLL, NULL, 0);

--- a/src/system/transport.c
+++ b/src/system/transport.c
@@ -1,0 +1,197 @@
+#include "system/transport.h"
+
+#include <string.h>
+
+#include "platform/esp_spi_bridge.h"
+
+enum {
+    PSLAB_PAYLOAD_MAGIC = 0x424c5350u, /* "PSLB" little-endian */
+    PSLAB_PAYLOAD_VERSION = 1,
+    PSLAB_SUBTYPE_META = 1,
+    PSLAB_SUBTYPE_DATA = 2,
+    PSLAB_PAYLOAD_HEADER_LEN = 32,
+    PSLAB_DATA_BYTES_PER_FRAME =
+        ESP_SPI_BRIDGE_PAYLOAD_LEN - PSLAB_PAYLOAD_HEADER_LEN,
+};
+
+static TransportMode g_mode = TRANSPORT_MODE_USB;
+static uint32_t g_frame_sequence;
+
+static void put_u16_le(uint8_t *data, uint16_t value)
+{
+    data[0] = (uint8_t)value;
+    data[1] = (uint8_t)(value >> 8);
+}
+
+static void put_u32_le(uint8_t *data, uint32_t value)
+{
+    data[0] = (uint8_t)value;
+    data[1] = (uint8_t)(value >> 8);
+    data[2] = (uint8_t)(value >> 16);
+    data[3] = (uint8_t)(value >> 24);
+}
+
+static void prepare_payload_header(
+    uint8_t *payload,
+    TransportInstrument instrument,
+    uint8_t subtype,
+    uint32_t capture_sequence,
+    uint16_t chunk_index,
+    uint16_t chunk_count,
+    uint16_t payload_len
+)
+{
+    memset(payload, 0, ESP_SPI_BRIDGE_PAYLOAD_LEN);
+    put_u32_le(&payload[0], PSLAB_PAYLOAD_MAGIC);
+    payload[4] = PSLAB_PAYLOAD_VERSION;
+    payload[5] = (uint8_t)instrument;
+    payload[6] = subtype;
+    payload[7] = 0;
+    put_u32_le(&payload[8], capture_sequence);
+    put_u16_le(&payload[12], chunk_index);
+    put_u16_le(&payload[14], chunk_count);
+    put_u16_le(&payload[16], payload_len);
+}
+
+static uint32_t sample_rate_for_meta(
+    TransportInstrument instrument,
+    TransportCaptureMeta const *meta
+)
+{
+    if (instrument == TRANSPORT_INSTRUMENT_LA && meta->sample_rate_hz == 0) {
+        return 0;
+    }
+    return meta->sample_rate_hz;
+}
+
+void transport_init(void)
+{
+    g_mode = TRANSPORT_MODE_USB;
+    g_frame_sequence = 0;
+}
+
+void transport_set_mode(TransportMode mode)
+{
+    if (mode <= TRANSPORT_MODE_AUTO) {
+        g_mode = mode;
+        if (mode == TRANSPORT_MODE_WIFI || mode == TRANSPORT_MODE_AUTO) {
+            (void)esp_spi_bridge_init();
+        }
+    }
+}
+
+TransportMode transport_get_mode(void) { return g_mode; }
+
+char const *transport_get_mode_name(void)
+{
+    switch (g_mode) {
+    case TRANSPORT_MODE_WIFI:
+        return "WIFI";
+    case TRANSPORT_MODE_AUTO:
+        return "AUTO";
+    case TRANSPORT_MODE_USB:
+    default:
+        return "USB";
+    }
+}
+
+bool transport_wifi_is_effective(void)
+{
+    if (g_mode == TRANSPORT_MODE_WIFI) {
+        return true;
+    }
+
+    return g_mode == TRANSPORT_MODE_AUTO && esp_spi_bridge_is_ready();
+}
+
+bool transport_send_capture(
+    TransportInstrument instrument,
+    uint32_t capture_sequence,
+    TransportCaptureMeta const *meta,
+    uint8_t const *data,
+    size_t len
+)
+{
+    if (!transport_wifi_is_effective() || !meta || (!data && len > 0)) {
+        return false;
+    }
+
+    uint8_t payload[ESP_SPI_BRIDGE_PAYLOAD_LEN];
+    prepare_payload_header(
+        payload,
+        instrument,
+        PSLAB_SUBTYPE_META,
+        capture_sequence,
+        0,
+        0,
+        24
+    );
+    put_u32_le(&payload[PSLAB_PAYLOAD_HEADER_LEN + 0], sample_rate_for_meta(instrument, meta));
+    put_u32_le(&payload[PSLAB_PAYLOAD_HEADER_LEN + 4], meta->sample_count);
+    put_u32_le(&payload[PSLAB_PAYLOAD_HEADER_LEN + 8], meta->channel_count);
+    put_u32_le(&payload[PSLAB_PAYLOAD_HEADER_LEN + 12], meta->pin_base_or_channel);
+    put_u32_le(&payload[PSLAB_PAYLOAD_HEADER_LEN + 16], meta->trigger_mode);
+    put_u32_le(
+        &payload[PSLAB_PAYLOAD_HEADER_LEN + 20],
+        meta->data_format != 0 ? meta->data_format :
+            (instrument == TRANSPORT_INSTRUMENT_DSO ?
+                TRANSPORT_DATA_FORMAT_DSO_U16_LE :
+                TRANSPORT_DATA_FORMAT_LA_U32_PACKED)
+    );
+
+    if (!esp_spi_bridge_send_payload(g_frame_sequence++, payload, ESP_SPI_BRIDGE_PAYLOAD_LEN)) {
+        return false;
+    }
+
+    uint16_t chunk_count = (uint16_t)((len + PSLAB_DATA_BYTES_PER_FRAME - 1u) /
+                                      PSLAB_DATA_BYTES_PER_FRAME);
+    if (chunk_count == 0) {
+        chunk_count = 1;
+    }
+
+    for (uint16_t chunk = 0; chunk < chunk_count; ++chunk) {
+        size_t offset = (size_t)chunk * PSLAB_DATA_BYTES_PER_FRAME;
+        size_t remaining = len > offset ? len - offset : 0;
+        size_t chunk_len =
+            remaining > PSLAB_DATA_BYTES_PER_FRAME ? PSLAB_DATA_BYTES_PER_FRAME
+                                                   : remaining;
+
+        prepare_payload_header(
+            payload,
+            instrument,
+            PSLAB_SUBTYPE_DATA,
+            capture_sequence,
+            chunk,
+            chunk_count,
+            (uint16_t)chunk_len
+        );
+        if (chunk_len > 0) {
+            memcpy(&payload[PSLAB_PAYLOAD_HEADER_LEN], &data[offset], chunk_len);
+        }
+
+        if (!esp_spi_bridge_send_payload(
+                g_frame_sequence++,
+                payload,
+                ESP_SPI_BRIDGE_PAYLOAD_LEN
+            )) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+uint32_t transport_get_sent_frames(void)
+{
+    return esp_spi_bridge_get_sent_frames();
+}
+
+uint32_t transport_get_dropped_frames(void)
+{
+    return esp_spi_bridge_get_dropped_frames();
+}
+
+uint32_t transport_get_timeouts(void)
+{
+    return esp_spi_bridge_get_timeouts();
+}

--- a/src/system/transport.c
+++ b/src/system/transport.c
@@ -12,11 +12,15 @@ enum {
     PSLAB_PAYLOAD_HEADER_LEN = 32,
     PSLAB_DATA_BYTES_PER_FRAME =
         ESP_SPI_BRIDGE_PAYLOAD_LEN - PSLAB_PAYLOAD_HEADER_LEN,
+    PSLAB_FORMAT_LA_U32_PACKED = 1,
+    PSLAB_FORMAT_DSO_U16_LE = 2,
+    TRANSPORT_SCPI_BUFFER_SIZE = ESP_SPI_BRIDGE_PAYLOAD_LEN,
 };
 
 static TransportMode g_mode = TRANSPORT_MODE_USB;
 static uint32_t g_frame_sequence;
-static TransportYieldCallback g_yield_callback;
+static uint8_t g_pending_scpi[TRANSPORT_SCPI_BUFFER_SIZE];
+static size_t g_pending_scpi_len;
 
 static void put_u16_le(uint8_t *data, uint16_t value)
 {
@@ -69,19 +73,7 @@ void transport_init(void)
 {
     g_mode = TRANSPORT_MODE_USB;
     g_frame_sequence = 0;
-    g_yield_callback = NULL;
-}
-
-void transport_set_yield_callback(TransportYieldCallback callback)
-{
-    g_yield_callback = callback;
-}
-
-static void transport_yield(void)
-{
-    if (g_yield_callback) {
-        g_yield_callback();
-    }
+    g_pending_scpi_len = 0;
 }
 
 void transport_set_mode(TransportMode mode)
@@ -118,6 +110,101 @@ bool transport_wifi_is_effective(void)
     return g_mode == TRANSPORT_MODE_AUTO && esp_spi_bridge_is_ready();
 }
 
+static void store_scpi_payload(
+    EspSpiBridgeFrameType rx_type,
+    uint8_t const *payload,
+    size_t payload_len
+)
+{
+    if (rx_type != ESP_SPI_BRIDGE_FRAME_SCPI || !payload || payload_len == 0) {
+        return;
+    }
+
+    if (payload_len > sizeof(g_pending_scpi)) {
+        payload_len = sizeof(g_pending_scpi);
+    }
+    memcpy(g_pending_scpi, payload, payload_len);
+    g_pending_scpi_len = payload_len;
+}
+
+static bool exchange_and_store_scpi(
+    EspSpiBridgeFrameType tx_type,
+    uint8_t const *payload,
+    size_t payload_len
+)
+{
+    uint8_t rx_payload[ESP_SPI_BRIDGE_PAYLOAD_LEN];
+    size_t rx_len = 0;
+    EspSpiBridgeFrameType rx_type = ESP_SPI_BRIDGE_FRAME_POLL;
+    bool ok = esp_spi_bridge_exchange(
+        tx_type,
+        g_frame_sequence++,
+        payload,
+        payload_len,
+        &rx_type,
+        rx_payload,
+        sizeof(rx_payload),
+        &rx_len
+    );
+    if (ok) {
+        store_scpi_payload(rx_type, rx_payload, rx_len);
+    }
+    return ok;
+}
+
+bool transport_poll_scpi_command(uint8_t *buffer, size_t buffer_size, size_t *len)
+{
+    if (!buffer || buffer_size == 0 || !len) {
+        return false;
+    }
+
+    if (g_pending_scpi_len == 0 && esp_spi_bridge_init() &&
+        esp_spi_bridge_is_ready()) {
+        (void)exchange_and_store_scpi(ESP_SPI_BRIDGE_FRAME_POLL, NULL, 0);
+    }
+
+    if (g_pending_scpi_len == 0) {
+        *len = 0;
+        return false;
+    }
+
+    size_t copy_len = g_pending_scpi_len;
+    if (copy_len > buffer_size) {
+        copy_len = buffer_size;
+    }
+    memcpy(buffer, g_pending_scpi, copy_len);
+    g_pending_scpi_len = 0;
+    *len = copy_len;
+    return true;
+}
+
+size_t transport_send_scpi_response(uint8_t const *data, size_t len)
+{
+    if ((!data && len > 0) || !esp_spi_bridge_init()) {
+        return 0;
+    }
+
+    size_t sent = 0;
+    while (sent < len || (len == 0 && sent == 0)) {
+        size_t chunk_len = len - sent;
+        if (chunk_len > ESP_SPI_BRIDGE_PAYLOAD_LEN) {
+            chunk_len = ESP_SPI_BRIDGE_PAYLOAD_LEN;
+        }
+        if (!exchange_and_store_scpi(
+                ESP_SPI_BRIDGE_FRAME_SCPI,
+                data ? &data[sent] : NULL,
+                chunk_len
+            )) {
+            break;
+        }
+        sent += chunk_len;
+        if (len == 0) {
+            break;
+        }
+    }
+    return sent;
+}
+
 bool transport_send_capture(
     TransportInstrument instrument,
     uint32_t capture_sequence,
@@ -148,15 +235,17 @@ bool transport_send_capture(
     put_u32_le(
         &payload[PSLAB_PAYLOAD_HEADER_LEN + 20],
         meta->data_format != 0 ? meta->data_format :
-            (instrument == TRANSPORT_INSTRUMENT_DSO ?
-                TRANSPORT_DATA_FORMAT_DSO_U16_LE :
-                TRANSPORT_DATA_FORMAT_LA_U32_PACKED)
+            (instrument == TRANSPORT_INSTRUMENT_DSO ? PSLAB_FORMAT_DSO_U16_LE
+                                                    : PSLAB_FORMAT_LA_U32_PACKED)
     );
 
-    if (!esp_spi_bridge_send_payload(g_frame_sequence++, payload, ESP_SPI_BRIDGE_PAYLOAD_LEN)) {
+    if (!exchange_and_store_scpi(
+            ESP_SPI_BRIDGE_FRAME_DATA,
+            payload,
+            ESP_SPI_BRIDGE_PAYLOAD_LEN
+        )) {
         return false;
     }
-    transport_yield();
 
     uint16_t chunk_count = (uint16_t)((len + PSLAB_DATA_BYTES_PER_FRAME - 1u) /
                                       PSLAB_DATA_BYTES_PER_FRAME);
@@ -184,14 +273,13 @@ bool transport_send_capture(
             memcpy(&payload[PSLAB_PAYLOAD_HEADER_LEN], &data[offset], chunk_len);
         }
 
-        if (!esp_spi_bridge_send_payload(
-                g_frame_sequence++,
+        if (!exchange_and_store_scpi(
+                ESP_SPI_BRIDGE_FRAME_DATA,
                 payload,
                 ESP_SPI_BRIDGE_PAYLOAD_LEN
             )) {
             return false;
         }
-        transport_yield();
     }
 
     return true;

--- a/src/system/transport.h
+++ b/src/system/transport.h
@@ -1,0 +1,58 @@
+#ifndef PSLAB_TRANSPORT_H
+#define PSLAB_TRANSPORT_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    TRANSPORT_MODE_USB = 0,
+    TRANSPORT_MODE_WIFI = 1,
+    TRANSPORT_MODE_AUTO = 2,
+} TransportMode;
+
+typedef enum {
+    TRANSPORT_INSTRUMENT_LA = 1,
+    TRANSPORT_INSTRUMENT_DSO = 2,
+} TransportInstrument;
+
+typedef enum {
+    TRANSPORT_DATA_FORMAT_DEFAULT = 0,
+    TRANSPORT_DATA_FORMAT_LA_U32_PACKED = 1,
+    TRANSPORT_DATA_FORMAT_DSO_U16_LE = 2,
+} TransportDataFormat;
+
+typedef struct {
+    uint32_t sample_rate_hz;
+    uint32_t sample_count;
+    uint32_t channel_count;
+    uint32_t pin_base_or_channel;
+    uint32_t trigger_mode;
+    uint32_t data_format;
+} TransportCaptureMeta;
+
+void transport_init(void);
+void transport_set_mode(TransportMode mode);
+TransportMode transport_get_mode(void);
+char const *transport_get_mode_name(void);
+bool transport_wifi_is_effective(void);
+bool transport_send_capture(
+    TransportInstrument instrument,
+    uint32_t capture_sequence,
+    TransportCaptureMeta const *meta,
+    uint8_t const *data,
+    size_t len
+);
+uint32_t transport_get_sent_frames(void);
+uint32_t transport_get_dropped_frames(void);
+uint32_t transport_get_timeouts(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/system/transport.h
+++ b/src/system/transport.h
@@ -20,12 +20,6 @@ typedef enum {
     TRANSPORT_INSTRUMENT_DSO = 2,
 } TransportInstrument;
 
-typedef enum {
-    TRANSPORT_DATA_FORMAT_DEFAULT = 0,
-    TRANSPORT_DATA_FORMAT_LA_U32_PACKED = 1,
-    TRANSPORT_DATA_FORMAT_DSO_U16_LE = 2,
-} TransportDataFormat;
-
 typedef struct {
     uint32_t sample_rate_hz;
     uint32_t sample_count;
@@ -35,14 +29,13 @@ typedef struct {
     uint32_t data_format;
 } TransportCaptureMeta;
 
-typedef void (*TransportYieldCallback)(void);
-
 void transport_init(void);
-void transport_set_yield_callback(TransportYieldCallback callback);
 void transport_set_mode(TransportMode mode);
 TransportMode transport_get_mode(void);
 char const *transport_get_mode_name(void);
 bool transport_wifi_is_effective(void);
+bool transport_poll_scpi_command(uint8_t *buffer, size_t buffer_size, size_t *len);
+size_t transport_send_scpi_response(uint8_t const *data, size_t len);
 bool transport_send_capture(
     TransportInstrument instrument,
     uint32_t capture_sequence,

--- a/src/system/transport.h
+++ b/src/system/transport.h
@@ -35,7 +35,10 @@ typedef struct {
     uint32_t data_format;
 } TransportCaptureMeta;
 
+typedef void (*TransportYieldCallback)(void);
+
 void transport_init(void);
+void transport_set_yield_callback(TransportYieldCallback callback);
 void transport_set_mode(TransportMode mode);
 TransportMode transport_get_mode(void);
 char const *transport_get_mode_name(void);


### PR DESCRIPTION
- Adds SPI communication with ESP32
- RP2350 is the master and ESP32 is the slave. 
- Adds SPI platform driver, system transport layer and application SCPI commands.
- USB CDC remains the command and control path, however data can be streamed over wifi/USB as per configuration
 ```
COMM:TRAN WIFI
    tries Wi-Fi/SPI transport directly; each frame waits for READY.

COMM:TRAN AUTO
    only uses Wi-Fi/SPI if READY is currently high, otherwise falls back to USB.

COMM:WIFI:STAT?
    first field reports whether Wi-Fi transport is effectively active.
```

This feature can be tested with [pslab-python](https://github.com/IM-TechieScientist/pslab-python)

~Draft PR for now~ Marked as ready for review