### PR TITLE
feat: added initial mixed signal capture

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ target_sources(pslab_pico PRIVATE
         src/application/logic_analyser_commands.c
         src/application/dso_commands.c
         src/system/instrument/dso.c
+        src/system/instrument/mixed_signal.c
         src/platform/adc_capture.c
         src/platform/logic_analyser_ll.c
         src/platform/platform.c

--- a/src/platform/adc_capture.c
+++ b/src/platform/adc_capture.c
@@ -11,9 +11,12 @@ enum {
 };
 
 static AdcCaptureConfig active_config;
+static AdcCaptureInfo armed_info;
 static int dma_chan = -1;
 static bool initialized;
 static bool busy;
+static bool armed;
+static bool running;
 
 uint32_t adc_capture_channel_to_gpio(uint32_t channel)
 {
@@ -75,6 +78,8 @@ void adc_capture_deinit(void)
     dma_chan = -1;
     initialized = false;
     busy = false;
+    armed = false;
+    running = false;
 }
 
 bool adc_capture_configure(AdcCaptureConfig const *config)
@@ -103,6 +108,24 @@ bool adc_capture_run(
     AdcCaptureInfo *info
 )
 {
+    if (!adc_capture_arm(buffer, sample_count, info)) {
+        return false;
+    }
+
+    if (!adc_capture_start()) {
+        adc_capture_abort();
+        return false;
+    }
+
+    return adc_capture_wait();
+}
+
+bool adc_capture_arm(
+    uint16_t *buffer,
+    uint32_t sample_count,
+    AdcCaptureInfo *info
+)
+{
     if (!initialized || busy || !buffer || sample_count == 0) {
         return false;
     }
@@ -120,31 +143,71 @@ bool adc_capture_run(
     channel_config_set_dreq(&dma_config, DREQ_ADC);
 
     busy = true;
+    armed = true;
+    running = false;
     dma_channel_configure(
         (uint)dma_chan,
         &dma_config,
         buffer,
         &adc_hw->fifo,
         sample_count,
-        true
+        false
     );
 
+    armed_info = (AdcCaptureInfo){
+        .channel = active_config.channel,
+        .gpio = adc_capture_channel_to_gpio(active_config.channel),
+        .sample_rate_hz = active_config.sample_rate_hz,
+        .sample_count = sample_count,
+    };
+
+    if (info) {
+        *info = armed_info;
+    }
+
+    return true;
+}
+
+bool adc_capture_start(void)
+{
+    if (!initialized || !busy || !armed || running || dma_chan < 0) {
+        return false;
+    }
+
+    dma_channel_start((uint)dma_chan);
     adc_run(true);
+    running = true;
+    armed = false;
+    return true;
+}
+
+bool adc_capture_wait(void)
+{
+    if (!initialized || !busy || !running || dma_chan < 0) {
+        return false;
+    }
+
     dma_channel_wait_for_finish_blocking((uint)dma_chan);
     adc_run(false);
     adc_fifo_drain();
     busy = false;
-
-    if (info) {
-        *info = (AdcCaptureInfo){
-            .channel = active_config.channel,
-            .gpio = adc_capture_channel_to_gpio(active_config.channel),
-            .sample_rate_hz = active_config.sample_rate_hz,
-            .sample_count = sample_count,
-        };
-    }
+    running = false;
 
     return true;
+}
+
+void adc_capture_abort(void)
+{
+    if (!initialized || dma_chan < 0) {
+        return;
+    }
+
+    adc_run(false);
+    dma_channel_abort((uint)dma_chan);
+    adc_fifo_drain();
+    busy = false;
+    armed = false;
+    running = false;
 }
 
 bool adc_capture_read_once(uint16_t *sample)

--- a/src/platform/adc_capture.h
+++ b/src/platform/adc_capture.h
@@ -35,6 +35,14 @@ bool adc_capture_run(
     uint32_t sample_count,
     AdcCaptureInfo *info
 );
+bool adc_capture_arm(
+    uint16_t *buffer,
+    uint32_t sample_count,
+    AdcCaptureInfo *info
+);
+bool adc_capture_start(void);
+bool adc_capture_wait(void);
+void adc_capture_abort(void);
 bool adc_capture_read_once(uint16_t *sample);
 bool adc_capture_is_busy(void);
 uint32_t adc_capture_channel_to_gpio(uint32_t channel);

--- a/src/platform/logic_analyser_ll.c
+++ b/src/platform/logic_analyser_ll.c
@@ -169,7 +169,54 @@ static void wait_for_trigger_rearm(uint32_t trigger_pin, bool trigger_level)
     }
 }
 
+void logic_analyser_ll_wait_for_trigger(
+    uint32_t trigger_pin,
+    bool trigger_level,
+    bool edge_trigger
+)
+{
+    prepare_trigger_pin(trigger_pin, trigger_level);
+    if (edge_trigger) {
+        wait_for_trigger_rearm(trigger_pin, trigger_level);
+    }
+
+    while (gpio_get(trigger_pin) != trigger_level) {
+        tight_loop_contents();
+    }
+}
+
 bool logic_analyser_ll_capture_start(
+    LogicAnalyserLL *la,
+    uint32_t trigger_pin,
+    bool trigger_level,
+    bool edge_trigger,
+    uint32_t *capture_buf,
+    uint32_t sample_count,
+    uint32_t word_count,
+    uint32_t bits_per_word,
+    LogicAnalyserLLCaptureInfo *info,
+    bool wait_for_trigger
+)
+{
+    if (!logic_analyser_ll_capture_arm(
+            la,
+            trigger_pin,
+            trigger_level,
+            edge_trigger,
+            capture_buf,
+            sample_count,
+            word_count,
+            bits_per_word,
+            info,
+            wait_for_trigger
+        )) {
+        return false;
+    }
+
+    return logic_analyser_ll_capture_start_armed(la);
+}
+
+bool logic_analyser_ll_capture_arm(
     LogicAnalyserLL *la,
     uint32_t trigger_pin,
     bool trigger_level,
@@ -212,7 +259,7 @@ bool logic_analyser_ll_capture_start(
         capture_buf,
         &pio->rxf[la->config.sm],
         word_count,
-        true
+        false
     );
 
     if (wait_for_trigger) {
@@ -222,8 +269,6 @@ bool logic_analyser_ll_capture_start(
             pio_encode_wait_gpio(trigger_level, trigger_pin)
         );
     }
-    pio_sm_set_enabled(pio, la->config.sm, true);
-
     if (info) {
         *info = (LogicAnalyserLLCaptureInfo){
             .pin_base = la->config.pin_base,
@@ -234,6 +279,19 @@ bool logic_analyser_ll_capture_start(
         };
     }
 
+    return true;
+}
+
+bool logic_analyser_ll_capture_start_armed(LogicAnalyserLL *la)
+{
+    if (!la || !la->initialized || la->dma_chan < 0 ||
+        dma_channel_is_busy((uint)la->dma_chan)) {
+        return false;
+    }
+
+    PIO pio = config_pio(&la->config);
+    dma_channel_start((uint)la->dma_chan);
+    pio_sm_set_enabled(pio, la->config.sm, true);
     return true;
 }
 

--- a/src/platform/logic_analyser_ll.c
+++ b/src/platform/logic_analyser_ll.c
@@ -162,11 +162,26 @@ static void prepare_trigger_pin(uint32_t trigger_pin, bool trigger_level)
     gpio_set_input_enabled(trigger_pin, true);
 }
 
-static void wait_for_trigger_rearm(uint32_t trigger_pin, bool trigger_level)
+static bool trigger_wait_timed_out(bool use_timeout, uint64_t deadline_us)
+{
+    return use_timeout && time_us_64() >= deadline_us;
+}
+
+static bool wait_for_trigger_rearm(
+    uint32_t trigger_pin,
+    bool trigger_level,
+    bool use_timeout,
+    uint64_t deadline_us
+)
 {
     while (gpio_get(trigger_pin) == trigger_level) {
+        if (trigger_wait_timed_out(use_timeout, deadline_us)) {
+            return false;
+        }
         tight_loop_contents();
     }
+
+    return true;
 }
 
 void logic_analyser_ll_wait_for_trigger(
@@ -175,14 +190,44 @@ void logic_analyser_ll_wait_for_trigger(
     bool edge_trigger
 )
 {
+    (void)logic_analyser_ll_wait_for_trigger_timeout(
+        trigger_pin,
+        trigger_level,
+        edge_trigger,
+        0
+    );
+}
+
+bool logic_analyser_ll_wait_for_trigger_timeout(
+    uint32_t trigger_pin,
+    bool trigger_level,
+    bool edge_trigger,
+    uint32_t timeout_us
+)
+{
     prepare_trigger_pin(trigger_pin, trigger_level);
+    bool use_timeout = timeout_us > 0;
+    uint64_t deadline_us = use_timeout ? time_us_64() + timeout_us : 0;
+
     if (edge_trigger) {
-        wait_for_trigger_rearm(trigger_pin, trigger_level);
+        if (!wait_for_trigger_rearm(
+                trigger_pin,
+                trigger_level,
+                use_timeout,
+                deadline_us
+            )) {
+            return false;
+        }
     }
 
     while (gpio_get(trigger_pin) != trigger_level) {
+        if (trigger_wait_timed_out(use_timeout, deadline_us)) {
+            return false;
+        }
         tight_loop_contents();
     }
+
+    return true;
 }
 
 bool logic_analyser_ll_capture_start(
@@ -239,7 +284,7 @@ bool logic_analyser_ll_capture_arm(
         prepare_trigger_pin(trigger_pin, trigger_level);
     }
     if (wait_for_trigger && edge_trigger) {
-        wait_for_trigger_rearm(trigger_pin, trigger_level);
+        (void)wait_for_trigger_rearm(trigger_pin, trigger_level, false, 0);
     }
 
     PIO pio = config_pio(&la->config);

--- a/src/platform/logic_analyser_ll.h
+++ b/src/platform/logic_analyser_ll.h
@@ -57,6 +57,24 @@ bool logic_analyser_ll_capture_start(
     LogicAnalyserLLCaptureInfo *info,
     bool wait_for_trigger
 );
+bool logic_analyser_ll_capture_arm(
+    LogicAnalyserLL *la,
+    uint32_t trigger_pin,
+    bool trigger_level,
+    bool edge_trigger,
+    uint32_t *capture_buf,
+    uint32_t sample_count,
+    uint32_t word_count,
+    uint32_t bits_per_word,
+    LogicAnalyserLLCaptureInfo *info,
+    bool wait_for_trigger
+);
+bool logic_analyser_ll_capture_start_armed(LogicAnalyserLL *la);
+void logic_analyser_ll_wait_for_trigger(
+    uint32_t trigger_pin,
+    bool trigger_level,
+    bool edge_trigger
+);
 bool logic_analyser_ll_capture_complete(LogicAnalyserLL *la);
 void logic_analyser_ll_capture_wait(LogicAnalyserLL *la);
 void logic_analyser_ll_capture_abort(LogicAnalyserLL *la);

--- a/src/platform/logic_analyser_ll.h
+++ b/src/platform/logic_analyser_ll.h
@@ -75,6 +75,12 @@ void logic_analyser_ll_wait_for_trigger(
     bool trigger_level,
     bool edge_trigger
 );
+bool logic_analyser_ll_wait_for_trigger_timeout(
+    uint32_t trigger_pin,
+    bool trigger_level,
+    bool edge_trigger,
+    uint32_t timeout_us
+);
 bool logic_analyser_ll_capture_complete(LogicAnalyserLL *la);
 void logic_analyser_ll_capture_wait(LogicAnalyserLL *la);
 void logic_analyser_ll_capture_abort(LogicAnalyserLL *la);

--- a/src/system/instrument/mixed_signal.c
+++ b/src/system/instrument/mixed_signal.c
@@ -16,6 +16,7 @@ enum {
     MIXED_SIGNAL_DEFAULT_TRIGGER_PIN = 16,
     MIXED_SIGNAL_MAX_DIGITAL_PIN_COUNT = 8,
     MIXED_SIGNAL_MAX_GPIO_PIN = 29,
+    MIXED_SIGNAL_TRIGGER_TIMEOUT_US = 1000000,
 };
 
 static LogicAnalyser logic_analyser;
@@ -317,11 +318,19 @@ bool mixed_signal_initiate(void)
     }
 
     status_led_capture_started();
-    logic_analyser_wait_for_trigger(
+    bool triggered = logic_analyser_wait_for_trigger_timeout(
         state.trigger_pin,
         state.trigger_level,
-        state.trigger_mode
+        state.trigger_mode,
+        MIXED_SIGNAL_TRIGGER_TIMEOUT_US
     );
+    if (!triggered) {
+        adc_capture_abort();
+        logic_analyser_capture_abort(&logic_analyser);
+        status_led_capture_finished();
+        capture_valid = false;
+        return false;
+    }
 
     bool adc_started = adc_capture_start();
     bool logic_started = logic_analyser_capture_start_armed(&logic_analyser);
@@ -383,11 +392,11 @@ bool mixed_signal_fetch_analog(uint8_t const **data, size_t *len)
     return true;
 }
 
-uint32_t mixed_signal_status(void)
+MixedSignalStatus mixed_signal_status(void)
 {
     if (logic_analyser_is_busy(&logic_analyser) || adc_capture_is_busy()) {
-        return 2;
+        return MIXED_SIGNAL_STATUS_BUSY;
     }
 
-    return capture_valid ? 1 : 0;
+    return capture_valid ? MIXED_SIGNAL_STATUS_READY : MIXED_SIGNAL_STATUS_IDLE;
 }

--- a/src/system/instrument/mixed_signal.c
+++ b/src/system/instrument/mixed_signal.c
@@ -1,0 +1,393 @@
+#include "system/instrument/mixed_signal.h"
+
+#include <stddef.h>
+#include <string.h>
+
+#include "platform/adc_capture.h"
+#include "platform/platform.h"
+#include "platform/status_led.h"
+
+enum {
+    MIXED_SIGNAL_DEFAULT_DIGITAL_PIN_BASE = 16,
+    MIXED_SIGNAL_DEFAULT_DIGITAL_PIN_COUNT = 1,
+    MIXED_SIGNAL_DEFAULT_ANALOG_CHANNEL = 0,
+    MIXED_SIGNAL_DEFAULT_SAMPLE_RATE_HZ = 500000,
+    MIXED_SIGNAL_DEFAULT_SAMPLES = 1024,
+    MIXED_SIGNAL_DEFAULT_TRIGGER_PIN = 16,
+    MIXED_SIGNAL_MAX_DIGITAL_PIN_COUNT = 8,
+    MIXED_SIGNAL_MAX_GPIO_PIN = 29,
+};
+
+static LogicAnalyser logic_analyser;
+static bool logic_analyser_initialized;
+static bool adc_initialized;
+static bool capture_valid;
+
+static uint32_t digital_buffer[MIXED_SIGNAL_MAX_SAMPLES];
+static uint16_t analog_buffer[MIXED_SIGNAL_MAX_SAMPLES];
+static MixedSignalCaptureInfo last_capture;
+
+static struct {
+    uint32_t digital_pin_base;
+    uint32_t digital_pin_count;
+    uint32_t analog_channel;
+    uint32_t sample_rate_hz;
+    uint32_t samples;
+    uint32_t trigger_pin;
+    bool trigger_level;
+    LogicAnalyserTriggerMode trigger_mode;
+} state = {
+    .digital_pin_base = MIXED_SIGNAL_DEFAULT_DIGITAL_PIN_BASE,
+    .digital_pin_count = MIXED_SIGNAL_DEFAULT_DIGITAL_PIN_COUNT,
+    .analog_channel = MIXED_SIGNAL_DEFAULT_ANALOG_CHANNEL,
+    .sample_rate_hz = MIXED_SIGNAL_DEFAULT_SAMPLE_RATE_HZ,
+    .samples = MIXED_SIGNAL_DEFAULT_SAMPLES,
+    .trigger_pin = MIXED_SIGNAL_DEFAULT_TRIGGER_PIN,
+    .trigger_level = true,
+    .trigger_mode = LOGIC_ANALYSER_TRIGGER_EDGE,
+};
+
+static bool digital_pins_are_valid(void)
+{
+    return state.digital_pin_count >= 1 &&
+           state.digital_pin_count <= MIXED_SIGNAL_MAX_DIGITAL_PIN_COUNT &&
+           state.digital_pin_base <= MIXED_SIGNAL_MAX_GPIO_PIN &&
+           state.digital_pin_base + state.digital_pin_count - 1 <=
+               MIXED_SIGNAL_MAX_GPIO_PIN;
+}
+
+static bool config_is_valid(void)
+{
+    return digital_pins_are_valid() &&
+           state.analog_channel <= ADC_CAPTURE_MAX_CHANNEL &&
+           state.sample_rate_hz >= ADC_CAPTURE_MIN_SAMPLE_RATE_HZ &&
+           state.sample_rate_hz <= ADC_CAPTURE_MAX_SAMPLE_RATE_HZ &&
+           state.samples >= 1 && state.samples <= MIXED_SIGNAL_MAX_SAMPLES &&
+           state.trigger_pin <= MIXED_SIGNAL_MAX_GPIO_PIN;
+}
+
+static float logic_analyser_clock_divider(void)
+{
+    uint32_t sys_clock =
+        PLATFORM_get_peripheral_clock_speed(PLATFORM_CLOCK_SYS);
+    if (sys_clock == 0 || state.sample_rate_hz == 0) {
+        return 0.0f;
+    }
+
+    return (float)sys_clock / (float)state.sample_rate_hz;
+}
+
+static bool apply_config(void)
+{
+    if (!config_is_valid()) {
+        return false;
+    }
+
+    LogicAnalyserConfig logic_config = {
+        .pin_base = state.digital_pin_base,
+        .pin_count = state.digital_pin_count,
+        .clk_div = logic_analyser_clock_divider(),
+    };
+
+    AdcCaptureConfig adc_config = {
+        .channel = state.analog_channel,
+        .sample_rate_hz = state.sample_rate_hz,
+    };
+
+    bool logic_ready = logic_analyser_initialized
+                           ? logic_analyser_configure(
+                                 &logic_analyser,
+                                 &logic_config
+                             )
+                           : logic_analyser_init(
+                                 &logic_analyser,
+                                 &logic_config
+                             );
+    if (!logic_ready) {
+        return false;
+    }
+    logic_analyser_initialized = true;
+
+    bool adc_ready = adc_initialized ? adc_capture_configure(&adc_config)
+                                     : adc_capture_init(&adc_config);
+    if (!adc_ready) {
+        return false;
+    }
+    adc_initialized = true;
+
+    return true;
+}
+
+static bool set_and_maybe_reconfigure(
+    uint32_t *target,
+    uint32_t value,
+    uint32_t min,
+    uint32_t max,
+    bool reconfigure
+)
+{
+    if (value < min || value > max) {
+        return false;
+    }
+
+    uint32_t old_value = *target;
+    *target = value;
+    capture_valid = false;
+
+    if (reconfigure && !apply_config()) {
+        *target = old_value;
+        (void)apply_config();
+        return false;
+    }
+
+    return true;
+}
+
+void mixed_signal_reset_state(void)
+{
+    if (logic_analyser_initialized) {
+        logic_analyser_deinit(&logic_analyser);
+    }
+    if (adc_initialized) {
+        adc_capture_deinit();
+    }
+
+    logic_analyser_initialized = false;
+    adc_initialized = false;
+    capture_valid = false;
+    state.digital_pin_base = MIXED_SIGNAL_DEFAULT_DIGITAL_PIN_BASE;
+    state.digital_pin_count = MIXED_SIGNAL_DEFAULT_DIGITAL_PIN_COUNT;
+    state.analog_channel = MIXED_SIGNAL_DEFAULT_ANALOG_CHANNEL;
+    state.sample_rate_hz = MIXED_SIGNAL_DEFAULT_SAMPLE_RATE_HZ;
+    state.samples = MIXED_SIGNAL_DEFAULT_SAMPLES;
+    state.trigger_pin = MIXED_SIGNAL_DEFAULT_TRIGGER_PIN;
+    state.trigger_level = true;
+    state.trigger_mode = LOGIC_ANALYSER_TRIGGER_EDGE;
+}
+
+bool mixed_signal_set_digital_pin_base(uint32_t value)
+{
+    return set_and_maybe_reconfigure(
+        &state.digital_pin_base,
+        value,
+        0,
+        MIXED_SIGNAL_MAX_GPIO_PIN,
+        true
+    );
+}
+
+bool mixed_signal_set_digital_pin_count(uint32_t value)
+{
+    return set_and_maybe_reconfigure(
+        &state.digital_pin_count,
+        value,
+        1,
+        MIXED_SIGNAL_MAX_DIGITAL_PIN_COUNT,
+        true
+    );
+}
+
+bool mixed_signal_set_analog_channel(uint32_t value)
+{
+    return set_and_maybe_reconfigure(
+        &state.analog_channel,
+        value,
+        0,
+        ADC_CAPTURE_MAX_CHANNEL,
+        true
+    );
+}
+
+bool mixed_signal_set_sample_rate(uint32_t value)
+{
+    return set_and_maybe_reconfigure(
+        &state.sample_rate_hz,
+        value,
+        ADC_CAPTURE_MIN_SAMPLE_RATE_HZ,
+        ADC_CAPTURE_MAX_SAMPLE_RATE_HZ,
+        true
+    );
+}
+
+bool mixed_signal_set_samples(uint32_t value)
+{
+    return set_and_maybe_reconfigure(
+        &state.samples,
+        value,
+        1,
+        MIXED_SIGNAL_MAX_SAMPLES,
+        false
+    );
+}
+
+bool mixed_signal_set_trigger_pin(uint32_t value)
+{
+    return set_and_maybe_reconfigure(
+        &state.trigger_pin,
+        value,
+        0,
+        MIXED_SIGNAL_MAX_GPIO_PIN,
+        false
+    );
+}
+
+void mixed_signal_set_trigger_level(bool value)
+{
+    state.trigger_level = value;
+    capture_valid = false;
+}
+
+bool mixed_signal_set_trigger_mode_edge(bool edge_mode)
+{
+    state.trigger_mode = edge_mode ? LOGIC_ANALYSER_TRIGGER_EDGE
+                                   : LOGIC_ANALYSER_TRIGGER_LEVEL;
+    capture_valid = false;
+    return true;
+}
+
+uint32_t mixed_signal_get_digital_pin_base(void)
+{
+    return state.digital_pin_base;
+}
+
+uint32_t mixed_signal_get_digital_pin_count(void)
+{
+    return state.digital_pin_count;
+}
+
+uint32_t mixed_signal_get_analog_channel(void) { return state.analog_channel; }
+
+uint32_t mixed_signal_get_sample_rate(void) { return state.sample_rate_hz; }
+
+uint32_t mixed_signal_get_samples(void) { return state.samples; }
+
+uint32_t mixed_signal_get_trigger_pin(void) { return state.trigger_pin; }
+
+bool mixed_signal_get_trigger_level(void) { return state.trigger_level; }
+
+bool mixed_signal_get_trigger_mode_edge(void)
+{
+    return state.trigger_mode == LOGIC_ANALYSER_TRIGGER_EDGE;
+}
+
+MixedSignalCaptureInfo const *mixed_signal_get_last_info(void)
+{
+    return capture_valid ? &last_capture : NULL;
+}
+
+bool mixed_signal_initiate(void)
+{
+    if ((!logic_analyser_initialized || !adc_initialized) && !apply_config()) {
+        return false;
+    }
+
+    uint32_t digital_word_count = logic_analyser_capture_word_count(
+        state.digital_pin_count,
+        state.samples
+    );
+    uint32_t digital_bits_per_word =
+        logic_analyser_bits_packed_per_word(state.digital_pin_count);
+    if (digital_word_count == 0 || digital_word_count > MIXED_SIGNAL_MAX_SAMPLES ||
+        digital_bits_per_word == 0) {
+        return false;
+    }
+
+    memset(digital_buffer, 0, digital_word_count * sizeof(digital_buffer[0]));
+    memset(analog_buffer, 0, state.samples * sizeof(analog_buffer[0]));
+
+    AdcCaptureInfo adc_info;
+    LogicAnalyserCaptureInfo logic_info;
+    if (!adc_capture_arm(analog_buffer, state.samples, &adc_info)) {
+        return false;
+    }
+
+    bool logic_armed = logic_analyser_capture_arm(
+        &logic_analyser,
+        state.trigger_pin,
+        state.trigger_level,
+        state.trigger_mode,
+        digital_buffer,
+        state.samples,
+        &logic_info,
+        false
+    );
+    if (!logic_armed) {
+        adc_capture_abort();
+        return false;
+    }
+
+    status_led_capture_started();
+    logic_analyser_wait_for_trigger(
+        state.trigger_pin,
+        state.trigger_level,
+        state.trigger_mode
+    );
+
+    bool adc_started = adc_capture_start();
+    bool logic_started = logic_analyser_capture_start_armed(&logic_analyser);
+    if (!adc_started || !logic_started) {
+        adc_capture_abort();
+        logic_analyser_capture_abort(&logic_analyser);
+        status_led_capture_finished();
+        return false;
+    }
+
+    logic_analyser_capture_wait(&logic_analyser);
+    bool adc_completed = adc_capture_wait();
+    bool logic_completed = logic_analyser_capture_complete(&logic_analyser);
+    status_led_capture_finished();
+
+    if (!adc_completed || !logic_completed) {
+        capture_valid = false;
+        return false;
+    }
+
+    last_capture = (MixedSignalCaptureInfo){
+        .sample_rate_hz = state.sample_rate_hz,
+        .sample_count = state.samples,
+        .digital_pin_base = logic_info.pin_base,
+        .digital_pin_count = logic_info.pin_count,
+        .digital_word_count = logic_info.word_count,
+        .digital_bits_per_word = logic_info.bits_per_word,
+        .analog_channel = adc_info.channel,
+        .analog_gpio = adc_info.gpio,
+        .trigger_pin = state.trigger_pin,
+        .trigger_level = state.trigger_level,
+        .trigger_mode = state.trigger_mode,
+        .digital_start_offset_ns = 0,
+        .analog_start_offset_ns = 0,
+    };
+    capture_valid = true;
+    return true;
+}
+
+bool mixed_signal_fetch_digital(uint8_t const **data, size_t *len)
+{
+    if (!capture_valid || !data || !len) {
+        return false;
+    }
+
+    *data = (uint8_t const *)digital_buffer;
+    *len = last_capture.digital_word_count * sizeof(digital_buffer[0]);
+    return true;
+}
+
+bool mixed_signal_fetch_analog(uint8_t const **data, size_t *len)
+{
+    if (!capture_valid || !data || !len) {
+        return false;
+    }
+
+    *data = (uint8_t const *)analog_buffer;
+    *len = last_capture.sample_count * sizeof(analog_buffer[0]);
+    return true;
+}
+
+uint32_t mixed_signal_status(void)
+{
+    if (logic_analyser_is_busy(&logic_analyser) || adc_capture_is_busy()) {
+        return 2;
+    }
+
+    return capture_valid ? 1 : 0;
+}

--- a/src/system/instrument/mixed_signal.h
+++ b/src/system/instrument/mixed_signal.h
@@ -15,6 +15,12 @@ enum {
     MIXED_SIGNAL_MAX_SAMPLES = 4096,
 };
 
+typedef enum {
+    MIXED_SIGNAL_STATUS_IDLE = 0,
+    MIXED_SIGNAL_STATUS_READY = 1,
+    MIXED_SIGNAL_STATUS_BUSY = 2,
+} MixedSignalStatus;
+
 typedef struct {
     uint32_t sample_rate_hz;
     uint32_t sample_count;
@@ -55,7 +61,7 @@ MixedSignalCaptureInfo const *mixed_signal_get_last_info(void);
 bool mixed_signal_initiate(void);
 bool mixed_signal_fetch_digital(uint8_t const **data, size_t *len);
 bool mixed_signal_fetch_analog(uint8_t const **data, size_t *len);
-uint32_t mixed_signal_status(void);
+MixedSignalStatus mixed_signal_status(void);
 
 #ifdef __cplusplus
 }

--- a/src/system/instrument/mixed_signal.h
+++ b/src/system/instrument/mixed_signal.h
@@ -1,0 +1,64 @@
+#ifndef MIXED_SIGNAL_H
+#define MIXED_SIGNAL_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "system/logic_analyser.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum {
+    MIXED_SIGNAL_MAX_SAMPLES = 4096,
+};
+
+typedef struct {
+    uint32_t sample_rate_hz;
+    uint32_t sample_count;
+    uint32_t digital_pin_base;
+    uint32_t digital_pin_count;
+    uint32_t digital_word_count;
+    uint32_t digital_bits_per_word;
+    uint32_t analog_channel;
+    uint32_t analog_gpio;
+    uint32_t trigger_pin;
+    bool trigger_level;
+    LogicAnalyserTriggerMode trigger_mode;
+    int32_t digital_start_offset_ns;
+    int32_t analog_start_offset_ns;
+} MixedSignalCaptureInfo;
+
+void mixed_signal_reset_state(void);
+
+bool mixed_signal_set_digital_pin_base(uint32_t value);
+bool mixed_signal_set_digital_pin_count(uint32_t value);
+bool mixed_signal_set_analog_channel(uint32_t value);
+bool mixed_signal_set_sample_rate(uint32_t value);
+bool mixed_signal_set_samples(uint32_t value);
+bool mixed_signal_set_trigger_pin(uint32_t value);
+void mixed_signal_set_trigger_level(bool value);
+bool mixed_signal_set_trigger_mode_edge(bool edge_mode);
+
+uint32_t mixed_signal_get_digital_pin_base(void);
+uint32_t mixed_signal_get_digital_pin_count(void);
+uint32_t mixed_signal_get_analog_channel(void);
+uint32_t mixed_signal_get_sample_rate(void);
+uint32_t mixed_signal_get_samples(void);
+uint32_t mixed_signal_get_trigger_pin(void);
+bool mixed_signal_get_trigger_level(void);
+bool mixed_signal_get_trigger_mode_edge(void);
+MixedSignalCaptureInfo const *mixed_signal_get_last_info(void);
+
+bool mixed_signal_initiate(void);
+bool mixed_signal_fetch_digital(uint8_t const **data, size_t *len);
+bool mixed_signal_fetch_analog(uint8_t const **data, size_t *len);
+uint32_t mixed_signal_status(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/system/logic_analyser.c
+++ b/src/system/logic_analyser.c
@@ -113,6 +113,19 @@ bool logic_analyser_is_busy(LogicAnalyser const *la)
            logic_analyser_ll_is_busy(&la->platform);
 }
 
+void logic_analyser_wait_for_trigger(
+    uint32_t trigger_pin,
+    bool trigger_level,
+    LogicAnalyserTriggerMode trigger_mode
+)
+{
+    logic_analyser_ll_wait_for_trigger(
+        trigger_pin,
+        trigger_level,
+        trigger_mode == LOGIC_ANALYSER_TRIGGER_EDGE
+    );
+}
+
 bool logic_analyser_capture(
     LogicAnalyser *la,
     uint32_t trigger_pin,
@@ -151,6 +164,33 @@ bool logic_analyser_capture_start(
     bool wait_for_trigger
 )
 {
+    if (!logic_analyser_capture_arm(
+            la,
+            trigger_pin,
+            trigger_level,
+            trigger_mode,
+            capture_buf,
+            sample_count,
+            info,
+            wait_for_trigger
+        )) {
+        return false;
+    }
+
+    return logic_analyser_capture_start_armed(la);
+}
+
+bool logic_analyser_capture_arm(
+    LogicAnalyser *la,
+    uint32_t trigger_pin,
+    bool trigger_level,
+    LogicAnalyserTriggerMode trigger_mode,
+    uint32_t *capture_buf,
+    uint32_t sample_count,
+    LogicAnalyserCaptureInfo *info,
+    bool wait_for_trigger
+)
+{
     if (!la || !la->initialized || !capture_buf || sample_count == 0 ||
         logic_analyser_is_busy(la)) {
         return false;
@@ -167,7 +207,7 @@ bool logic_analyser_capture_start(
     }
 
     LogicAnalyserLLCaptureInfo ll_info;
-    bool started = logic_analyser_ll_capture_start(
+    bool armed = logic_analyser_ll_capture_arm(
         &la->platform,
         trigger_pin,
         trigger_level,
@@ -179,12 +219,30 @@ bool logic_analyser_capture_start(
         &ll_info,
         wait_for_trigger
     );
-    if (!started) {
+    if (!armed) {
         return false;
     }
 
     copy_capture_info(info, &ll_info);
     return true;
+}
+
+bool logic_analyser_capture_start_armed(LogicAnalyser *la)
+{
+    if (!la || !la->initialized) {
+        return false;
+    }
+
+    return logic_analyser_ll_capture_start_armed(&la->platform);
+}
+
+void logic_analyser_capture_wait(LogicAnalyser *la)
+{
+    if (!la || !la->initialized) {
+        return;
+    }
+
+    logic_analyser_ll_capture_wait(&la->platform);
 }
 
 bool logic_analyser_capture_complete(LogicAnalyser *la)

--- a/src/system/logic_analyser.c
+++ b/src/system/logic_analyser.c
@@ -119,10 +119,26 @@ void logic_analyser_wait_for_trigger(
     LogicAnalyserTriggerMode trigger_mode
 )
 {
-    logic_analyser_ll_wait_for_trigger(
+    (void)logic_analyser_wait_for_trigger_timeout(
         trigger_pin,
         trigger_level,
-        trigger_mode == LOGIC_ANALYSER_TRIGGER_EDGE
+        trigger_mode,
+        0
+    );
+}
+
+bool logic_analyser_wait_for_trigger_timeout(
+    uint32_t trigger_pin,
+    bool trigger_level,
+    LogicAnalyserTriggerMode trigger_mode,
+    uint32_t timeout_us
+)
+{
+    return logic_analyser_ll_wait_for_trigger_timeout(
+        trigger_pin,
+        trigger_level,
+        trigger_mode == LOGIC_ANALYSER_TRIGGER_EDGE,
+        timeout_us
     );
 }
 

--- a/src/system/logic_analyser.h
+++ b/src/system/logic_analyser.h
@@ -54,9 +54,26 @@ bool logic_analyser_capture_start(
     LogicAnalyserCaptureInfo *info,
     bool wait_for_trigger
 );
+bool logic_analyser_capture_arm(
+    LogicAnalyser *la,
+    uint32_t trigger_pin,
+    bool trigger_level,
+    LogicAnalyserTriggerMode trigger_mode,
+    uint32_t *capture_buf,
+    uint32_t sample_count,
+    LogicAnalyserCaptureInfo *info,
+    bool wait_for_trigger
+);
+bool logic_analyser_capture_start_armed(LogicAnalyser *la);
+void logic_analyser_capture_wait(LogicAnalyser *la);
 bool logic_analyser_capture_complete(LogicAnalyser *la);
 void logic_analyser_capture_abort(LogicAnalyser *la);
 bool logic_analyser_is_busy(LogicAnalyser const *la);
+void logic_analyser_wait_for_trigger(
+    uint32_t trigger_pin,
+    bool trigger_level,
+    LogicAnalyserTriggerMode trigger_mode
+);
 uint32_t logic_analyser_capture_word_count(
     uint32_t pin_count,
     uint32_t sample_count

--- a/src/system/logic_analyser.h
+++ b/src/system/logic_analyser.h
@@ -74,6 +74,12 @@ void logic_analyser_wait_for_trigger(
     bool trigger_level,
     LogicAnalyserTriggerMode trigger_mode
 );
+bool logic_analyser_wait_for_trigger_timeout(
+    uint32_t trigger_pin,
+    bool trigger_level,
+    LogicAnalyserTriggerMode trigger_mode,
+    uint32_t timeout_us
+);
 uint32_t logic_analyser_capture_word_count(
     uint32_t pin_count,
     uint32_t sample_count


### PR DESCRIPTION
Adds an initial mixed signal capture path. Fixes #190.
This introduces an `MSO` instrument layer that coordinates the existing logic analyser capture engine and ADC capture engine so digital GPIO samples and analog ADC samples can be taken from a shared trigger.

- Added a mixed signal system instrument.
- Added application layer wrappers.
- Added SCPI command handlers under `src/application/protocol/mso.c`.
- Added `MSO:` SCPI commands for:
  - sample rate
  - sample count
  - digital pin base/count
  - analog ADC channel
  - trigger pin/level/mode
  - initiate capture
  - fetch digital data
  - fetch analog data
  - capture metadata/status
- Split ADC capture into arm/start/wait operations.
- Split logic analyser capture into arm/start/wait operations.

~Diff is large due to previous PRs, should go down once they are merged.
I will mark this as draft for now.~ Marked as ready for review