### PR TITLE
 feat: add UART bus gateway 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,10 +14,12 @@ add_executable(pslab_pico)
 target_sources(pslab_pico PRIVATE
         src/application/main.c
         src/application/protocol/common.c
+        src/application/protocol/bus/uart.c
         src/application/protocol/la.c
         src/application/protocol/dso.c
         src/application/protocol/mso.c
         src/application/communication_commands.c
+        src/application/gateway/uart_commands.c
         src/application/logic_analyser_commands.c
         src/application/dso_commands.c
         src/application/mixed_signal_commands.c

--- a/README.md
+++ b/README.md
@@ -161,6 +161,40 @@ The repo includes an out-of-tree `libsigrok` hardware driver package in
 unpacks `LA:READ?` binary blocks into sigrok logic samples, so PulseView can use
 its normal protocol decoders for UART, I2C, SPI, and other digital buses.
 
+## SCPI Bus Gateway
+
+The bus gateway exposes UART1 through SCPI so a host can talk
+to external serial sensors or peripherals through the PSLab Pico.
+
+Initial UART gateway uses the platform defaults:
+
+- UART1 TX: GPIO4
+- UART1 RX: GPIO5
+- Format: 8N1
+
+UART0 is reserved by the firmware logging so the gateway currently allows UART1 only.
+
+Available commands:
+
+- `BUS:UART:CONFigure:BUS <1>`
+- `BUS:UART:CONFigure:BUS?`
+- `BUS:UART:CONFigure:BAUD <baud>`
+- `BUS:UART:CONFigure:BAUD?`
+- `BUS:UART:CONFigure:TIMEout <ms>`
+- `BUS:UART:CONFigure:TIMEout?`
+- `BUS:UART:OPEN`
+- `BUS:UART:OPEN?`
+- `BUS:UART:CLOSe`
+- `BUS:UART:WRITe <arbitrary_block>`
+- `BUS:UART:READ? [max_bytes]`
+- `BUS:UART:AVAILable?`
+- `BUS:UART:CLEar`
+- `BUS:UART:FLUSh`
+- `BUS:UART:TRANsact? <arbitrary_block>`
+
+`WRITe`, `READ?`, and `TRANsact?` use SCPI arbitrary blocks so binary payloads
+are safe. The current implementation caps each transfer at 512 bytes.
+
 ## Build
 
 Configure from the project root:

--- a/src/application/gateway/uart_commands.c
+++ b/src/application/gateway/uart_commands.c
@@ -1,0 +1,228 @@
+#include "application/gateway/uart_commands.h"
+
+#include <string.h>
+
+#include "system/bus/uart.h"
+#include "platform/platform.h"
+#include "util/error.h"
+#include "util/util.h"
+
+enum {
+    UART_GATEWAY_RX_BUFFER_SIZE = 512,
+    UART_GATEWAY_TX_BUFFER_SIZE = 512,
+    UART_GATEWAY_MIN_BAUD = 1200,
+    UART_GATEWAY_MAX_BAUD = 3000000,
+    UART_GATEWAY_MAX_TIMEOUT_MS = 60000,
+    UART_GATEWAY_TRANSACTION_IDLE_MS = 5,
+};
+
+static UART_Handle *gateway_uart;
+static uint8_t rx_data[UART_GATEWAY_RX_BUFFER_SIZE];
+static uint8_t tx_data[UART_GATEWAY_TX_BUFFER_SIZE];
+static CircularBuffer rx_buffer;
+static CircularBuffer tx_buffer;
+
+static struct {
+    uint32_t bus;
+    uint32_t baud;
+    uint32_t timeout_ms;
+} state = {
+    .bus = UART_GATEWAY_DEFAULT_BUS,
+    .baud = UART_GATEWAY_DEFAULT_BAUD,
+    .timeout_ms = UART_GATEWAY_DEFAULT_TIMEOUT_MS,
+};
+
+static bool bus_is_allowed(uint32_t bus)
+{
+    /*
+     * UART0 is currently owned by the firmware logging/stdout path.
+     * Keep the gateway on UART1 until bus ownership is made explicit.
+     */
+    return bus == 1 && bus < UART_get_bus_count();
+}
+
+bool uart_gateway_set_bus(uint32_t bus)
+{
+    if (gateway_uart || !bus_is_allowed(bus)) {
+        return false;
+    }
+
+    state.bus = bus;
+    return true;
+}
+
+uint32_t uart_gateway_get_bus(void) { return state.bus; }
+
+bool uart_gateway_set_baud(uint32_t baud)
+{
+    if (gateway_uart || baud < UART_GATEWAY_MIN_BAUD ||
+        baud > UART_GATEWAY_MAX_BAUD) {
+        return false;
+    }
+
+    state.baud = baud;
+    return true;
+}
+
+uint32_t uart_gateway_get_baud(void) { return state.baud; }
+
+bool uart_gateway_set_timeout(uint32_t timeout_ms)
+{
+    if (timeout_ms > UART_GATEWAY_MAX_TIMEOUT_MS) {
+        return false;
+    }
+
+    state.timeout_ms = timeout_ms;
+    return true;
+}
+
+uint32_t uart_gateway_get_timeout(void) { return state.timeout_ms; }
+
+bool uart_gateway_open(void)
+{
+    if (gateway_uart) {
+        return true;
+    }
+
+    if (!bus_is_allowed(state.bus)) {
+        return false;
+    }
+
+    circular_buffer_init(&rx_buffer, rx_data, sizeof(rx_data));
+    circular_buffer_init(&tx_buffer, tx_data, sizeof(tx_data));
+
+    Error err = ERROR_NONE;
+    TRY
+    {
+        gateway_uart = UART_init_with_baud(
+            state.bus,
+            &rx_buffer,
+            &tx_buffer,
+            state.baud
+        );
+    }
+    CATCH(err)
+    {
+        gateway_uart = NULL;
+        (void)err;
+        return false;
+    }
+
+    return gateway_uart != NULL;
+}
+
+void uart_gateway_close(void)
+{
+    if (!gateway_uart) {
+        return;
+    }
+
+    UART_Handle *handle = gateway_uart;
+    gateway_uart = NULL;
+
+    Error err = ERROR_NONE;
+    TRY { UART_deinit(handle); }
+    CATCH(err)
+    {
+        (void)err;
+    }
+}
+
+bool uart_gateway_is_open(void) { return gateway_uart != NULL; }
+
+uint32_t uart_gateway_write(uint8_t const *data, size_t len)
+{
+    if (!gateway_uart || !data || len == 0) {
+        return 0;
+    }
+
+    if (len > UART_GATEWAY_MAX_TRANSFER) {
+        len = UART_GATEWAY_MAX_TRANSFER;
+    }
+
+    return UART_write(gateway_uart, data, (uint32_t)len);
+}
+
+uint32_t uart_gateway_read(uint8_t *data, size_t max_len)
+{
+    if (!gateway_uart || !data || max_len == 0) {
+        return 0;
+    }
+
+    if (max_len > UART_GATEWAY_MAX_TRANSFER) {
+        max_len = UART_GATEWAY_MAX_TRANSFER;
+    }
+
+    return UART_read(gateway_uart, data, (uint32_t)max_len);
+}
+
+uint32_t uart_gateway_available(void)
+{
+    return gateway_uart ? UART_rx_available(gateway_uart) : 0;
+}
+
+void uart_gateway_clear(void)
+{
+    uint8_t scratch[64];
+
+    if (!gateway_uart) {
+        return;
+    }
+
+    while (UART_rx_available(gateway_uart) > 0) {
+        if (UART_read(gateway_uart, scratch, sizeof(scratch)) == 0) {
+            break;
+        }
+    }
+}
+
+bool uart_gateway_flush(void)
+{
+    return gateway_uart && UART_flush(gateway_uart, state.timeout_ms);
+}
+
+uint32_t uart_gateway_transact(
+    uint8_t const *tx_data,
+    size_t tx_len,
+    uint8_t *rx_data_out,
+    size_t rx_max_len
+)
+{
+    if (!gateway_uart || !tx_data || tx_len == 0 || !rx_data_out ||
+        rx_max_len == 0) {
+        return 0;
+    }
+
+    uart_gateway_clear();
+
+    uint32_t written = uart_gateway_write(tx_data, tx_len);
+    if (written != tx_len || !uart_gateway_flush()) {
+        return 0;
+    }
+
+    uint32_t start = PLATFORM_get_tick();
+    uint32_t last_change = start;
+    uint32_t last_available = 0;
+
+    while (true) {
+        uint32_t now = PLATFORM_get_tick();
+        uint32_t available = uart_gateway_available();
+
+        if (available != last_available) {
+            last_available = available;
+            last_change = now;
+        }
+
+        if (available >= rx_max_len ||
+            (available > 0 &&
+             (now - last_change) >= UART_GATEWAY_TRANSACTION_IDLE_MS)) {
+            break;
+        }
+
+        if (state.timeout_ms && (now - start) >= state.timeout_ms) {
+            break;
+        }
+    }
+
+    return uart_gateway_read(rx_data_out, rx_max_len);
+}

--- a/src/application/gateway/uart_commands.h
+++ b/src/application/gateway/uart_commands.h
@@ -1,0 +1,48 @@
+#ifndef PSLAB_APPLICATION_GATEWAY_UART_COMMANDS_H
+#define PSLAB_APPLICATION_GATEWAY_UART_COMMANDS_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum {
+    UART_GATEWAY_DEFAULT_BUS = 1,
+    UART_GATEWAY_DEFAULT_BAUD = 115200,
+    UART_GATEWAY_DEFAULT_TIMEOUT_MS = 100,
+    UART_GATEWAY_MAX_TRANSFER = 512,
+};
+
+bool uart_gateway_set_bus(uint32_t bus);
+uint32_t uart_gateway_get_bus(void);
+
+bool uart_gateway_set_baud(uint32_t baud);
+uint32_t uart_gateway_get_baud(void);
+
+bool uart_gateway_set_timeout(uint32_t timeout_ms);
+uint32_t uart_gateway_get_timeout(void);
+
+bool uart_gateway_open(void);
+void uart_gateway_close(void);
+bool uart_gateway_is_open(void);
+
+uint32_t uart_gateway_write(uint8_t const *data, size_t len);
+uint32_t uart_gateway_read(uint8_t *data, size_t max_len);
+uint32_t uart_gateway_available(void);
+void uart_gateway_clear(void);
+bool uart_gateway_flush(void);
+uint32_t uart_gateway_transact(
+    uint8_t const *tx_data,
+    size_t tx_len,
+    uint8_t *rx_data,
+    size_t rx_max_len
+);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/application/protocol/bus/uart.c
+++ b/src/application/protocol/bus/uart.c
@@ -1,0 +1,176 @@
+#include "application/protocol/bus/uart.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "scpi/error.h"
+#include "scpi/scpi.h"
+
+#include "application/gateway/uart_commands.h"
+
+static uint8_t response_buffer[UART_GATEWAY_MAX_TRANSFER];
+
+static scpi_result_t result_ok(void) { return SCPI_RES_OK; }
+
+static scpi_result_t result_missing_parameter(scpi_t *context)
+{
+    SCPI_ErrorPush(context, SCPI_ERROR_MISSING_PARAMETER);
+    return SCPI_RES_ERR;
+}
+
+static scpi_result_t result_illegal_parameter(scpi_t *context)
+{
+    SCPI_ErrorPush(context, SCPI_ERROR_ILLEGAL_PARAMETER_VALUE);
+    return SCPI_RES_ERR;
+}
+
+static scpi_result_t result_execution_error(scpi_t *context)
+{
+    SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+    return SCPI_RES_ERR;
+}
+
+static scpi_result_t configure_uint32(
+    scpi_t *context,
+    bool (*setter)(uint32_t)
+)
+{
+    uint32_t value = 0;
+    if (!SCPI_ParamUInt32(context, &value, TRUE)) {
+        return result_missing_parameter(context);
+    }
+
+    return setter(value) ? result_ok() : result_illegal_parameter(context);
+}
+
+scpi_result_t scpi_cmd_bus_uart_open(scpi_t *context)
+{
+    return uart_gateway_open() ? result_ok() : result_execution_error(context);
+}
+
+scpi_result_t scpi_cmd_bus_uart_close(scpi_t *context)
+{
+    (void)context;
+    uart_gateway_close();
+    return SCPI_RES_OK;
+}
+
+scpi_result_t scpi_cmd_bus_uart_open_q(scpi_t *context)
+{
+    SCPI_ResultBool(context, uart_gateway_is_open() ? TRUE : FALSE);
+    return SCPI_RES_OK;
+}
+
+scpi_result_t scpi_cmd_bus_uart_configure_bus(scpi_t *context)
+{
+    return configure_uint32(context, uart_gateway_set_bus);
+}
+
+scpi_result_t scpi_cmd_bus_uart_configure_bus_q(scpi_t *context)
+{
+    SCPI_ResultUInt32(context, uart_gateway_get_bus());
+    return SCPI_RES_OK;
+}
+
+scpi_result_t scpi_cmd_bus_uart_configure_baud(scpi_t *context)
+{
+    return configure_uint32(context, uart_gateway_set_baud);
+}
+
+scpi_result_t scpi_cmd_bus_uart_configure_baud_q(scpi_t *context)
+{
+    SCPI_ResultUInt32(context, uart_gateway_get_baud());
+    return SCPI_RES_OK;
+}
+
+scpi_result_t scpi_cmd_bus_uart_configure_timeout(scpi_t *context)
+{
+    return configure_uint32(context, uart_gateway_set_timeout);
+}
+
+scpi_result_t scpi_cmd_bus_uart_configure_timeout_q(scpi_t *context)
+{
+    SCPI_ResultUInt32(context, uart_gateway_get_timeout());
+    return SCPI_RES_OK;
+}
+
+scpi_result_t scpi_cmd_bus_uart_write(scpi_t *context)
+{
+    char const *data = NULL;
+    size_t len = 0;
+
+    if (!SCPI_ParamArbitraryBlock(context, &data, &len, TRUE)) {
+        return result_missing_parameter(context);
+    }
+
+    if (!uart_gateway_is_open()) {
+        return result_execution_error(context);
+    }
+
+    SCPI_ResultUInt32(
+        context,
+        uart_gateway_write((uint8_t const *)data, len)
+    );
+    return SCPI_RES_OK;
+}
+
+scpi_result_t scpi_cmd_bus_uart_read_q(scpi_t *context)
+{
+    uint32_t max_len = UART_GATEWAY_MAX_TRANSFER;
+
+    (void)SCPI_ParamUInt32(context, &max_len, FALSE);
+
+    if (!uart_gateway_is_open()) {
+        return result_execution_error(context);
+    }
+
+    if (max_len > UART_GATEWAY_MAX_TRANSFER) {
+        max_len = UART_GATEWAY_MAX_TRANSFER;
+    }
+
+    uint32_t bytes_read = uart_gateway_read(response_buffer, max_len);
+    SCPI_ResultArbitraryBlock(context, response_buffer, bytes_read);
+    return SCPI_RES_OK;
+}
+
+scpi_result_t scpi_cmd_bus_uart_available_q(scpi_t *context)
+{
+    SCPI_ResultUInt32(context, uart_gateway_available());
+    return SCPI_RES_OK;
+}
+
+scpi_result_t scpi_cmd_bus_uart_clear(scpi_t *context)
+{
+    (void)context;
+    uart_gateway_clear();
+    return SCPI_RES_OK;
+}
+
+scpi_result_t scpi_cmd_bus_uart_flush(scpi_t *context)
+{
+    return uart_gateway_flush() ? result_ok() : result_execution_error(context);
+}
+
+scpi_result_t scpi_cmd_bus_uart_transact_q(scpi_t *context)
+{
+    char const *data = NULL;
+    size_t len = 0;
+
+    if (!SCPI_ParamArbitraryBlock(context, &data, &len, TRUE)) {
+        return result_missing_parameter(context);
+    }
+
+    if (!uart_gateway_is_open()) {
+        return result_execution_error(context);
+    }
+
+    uint32_t bytes_read = uart_gateway_transact(
+        (uint8_t const *)data,
+        len,
+        response_buffer,
+        sizeof(response_buffer)
+    );
+    SCPI_ResultArbitraryBlock(context, response_buffer, bytes_read);
+    return SCPI_RES_OK;
+}

--- a/src/application/protocol/bus/uart.h
+++ b/src/application/protocol/bus/uart.h
@@ -1,0 +1,30 @@
+#ifndef PSLAB_APPLICATION_PROTOCOL_BUS_UART_H
+#define PSLAB_APPLICATION_PROTOCOL_BUS_UART_H
+
+#include "scpi/types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+scpi_result_t scpi_cmd_bus_uart_open(scpi_t *context);
+scpi_result_t scpi_cmd_bus_uart_close(scpi_t *context);
+scpi_result_t scpi_cmd_bus_uart_open_q(scpi_t *context);
+scpi_result_t scpi_cmd_bus_uart_configure_bus(scpi_t *context);
+scpi_result_t scpi_cmd_bus_uart_configure_bus_q(scpi_t *context);
+scpi_result_t scpi_cmd_bus_uart_configure_baud(scpi_t *context);
+scpi_result_t scpi_cmd_bus_uart_configure_baud_q(scpi_t *context);
+scpi_result_t scpi_cmd_bus_uart_configure_timeout(scpi_t *context);
+scpi_result_t scpi_cmd_bus_uart_configure_timeout_q(scpi_t *context);
+scpi_result_t scpi_cmd_bus_uart_write(scpi_t *context);
+scpi_result_t scpi_cmd_bus_uart_read_q(scpi_t *context);
+scpi_result_t scpi_cmd_bus_uart_available_q(scpi_t *context);
+scpi_result_t scpi_cmd_bus_uart_clear(scpi_t *context);
+scpi_result_t scpi_cmd_bus_uart_flush(scpi_t *context);
+scpi_result_t scpi_cmd_bus_uart_transact_q(scpi_t *context);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/application/protocol/common.c
+++ b/src/application/protocol/common.c
@@ -20,6 +20,7 @@
 #include "application/dso_commands.h"
 #include "application/logic_analyser_commands.h"
 #include "application/mixed_signal_commands.h"
+#include "application/protocol/bus/uart.h"
 #include "platform/platform.h"
 #include "platform/status_led.h"
 #include "platform/usb_cdc.h"
@@ -30,7 +31,7 @@
 enum {
     USB_RX_CHUNK_SIZE = 64,
     WIFI_RX_CHUNK_SIZE = 256,
-    SCPI_INPUT_BUFFER_SIZE = 256,
+    SCPI_INPUT_BUFFER_SIZE = 1024,
     SCPI_ERROR_QUEUE_SIZE = 16
 };
 
@@ -246,6 +247,23 @@ static scpi_command_t const g_SCPI_COMMANDS[] = {
     { "COMM:TRANsport", scpi_cmd_comm_transport },
     { "COMM:TRANsport?", scpi_cmd_comm_transport_q },
     { "COMM:WIFI:STATus?", scpi_cmd_comm_wifi_status_q },
+
+    // External bus gateway commands
+    { "BUS:UART:OPEN", scpi_cmd_bus_uart_open },
+    { "BUS:UART:OPEN?", scpi_cmd_bus_uart_open_q },
+    { "BUS:UART:CLOSe", scpi_cmd_bus_uart_close },
+    { "BUS:UART:CONFigure:BUS", scpi_cmd_bus_uart_configure_bus },
+    { "BUS:UART:CONFigure:BUS?", scpi_cmd_bus_uart_configure_bus_q },
+    { "BUS:UART:CONFigure:BAUD", scpi_cmd_bus_uart_configure_baud },
+    { "BUS:UART:CONFigure:BAUD?", scpi_cmd_bus_uart_configure_baud_q },
+    { "BUS:UART:CONFigure:TIMEout", scpi_cmd_bus_uart_configure_timeout },
+    { "BUS:UART:CONFigure:TIMEout?", scpi_cmd_bus_uart_configure_timeout_q },
+    { "BUS:UART:WRITe", scpi_cmd_bus_uart_write },
+    { "BUS:UART:READ?", scpi_cmd_bus_uart_read_q },
+    { "BUS:UART:AVAILable?", scpi_cmd_bus_uart_available_q },
+    { "BUS:UART:CLEar", scpi_cmd_bus_uart_clear },
+    { "BUS:UART:FLUSh", scpi_cmd_bus_uart_flush },
+    { "BUS:UART:TRANsact?", scpi_cmd_bus_uart_transact_q },
 
     // Logic analyser commands
     { "LA:CONFigure:PINBase", scpi_cmd_configure_logic_analyser_pinbase },

--- a/src/platform/uart_ll.c
+++ b/src/platform/uart_ll.c
@@ -130,13 +130,18 @@ static void uart1_irq_handler(void) { uart_irq_handler(UART_BUS_1); }
  * This function configures the UART hardware, including baud rate, data bits,
  * stop bits, and parity, to prepare it for serial communication.
  */
-void UART_LL_init(UART_Bus bus, uint8_t *rx_buf, uint32_t sz)
+void UART_LL_init_baud(
+    UART_Bus bus,
+    uint8_t *rx_buf,
+    uint32_t sz,
+    uint32_t baudrate
+)
 {
     if (bus >= UART_BUS_COUNT) {
         THROW(ERROR_INVALID_ARGUMENT);
     }
 
-    if (!rx_buf || sz == 0) {
+    if (!rx_buf || sz == 0 || baudrate == 0) {
         THROW(ERROR_INVALID_ARGUMENT);
     }
 
@@ -146,7 +151,7 @@ void UART_LL_init(UART_Bus bus, uint8_t *rx_buf, uint32_t sz)
 
     UARTInstance *instance = &g_uart_instances[bus];
 
-    uart_init(instance->uart, UART_DEFAULT_BAUDRATE);
+    uart_init(instance->uart, baudrate);
     gpio_set_function(instance->tx_gpio, GPIO_FUNC_UART);
     gpio_set_function(instance->rx_gpio, GPIO_FUNC_UART);
     uart_set_format(instance->uart, 8, 1, UART_PARITY_NONE);
@@ -167,6 +172,11 @@ void UART_LL_init(UART_Bus bus, uint8_t *rx_buf, uint32_t sz)
     );
     irq_set_enabled(instance->irq, true);
     uart_set_irq_enables(instance->uart, true, false);
+}
+
+void UART_LL_init(UART_Bus bus, uint8_t *rx_buf, uint32_t sz)
+{
+    UART_LL_init_baud(bus, rx_buf, sz, UART_DEFAULT_BAUDRATE);
 }
 
 /**

--- a/src/platform/uart_ll.h
+++ b/src/platform/uart_ll.h
@@ -38,6 +38,24 @@ enum { UART_DEFAULT_BAUDRATE = 115200 };
 void UART_LL_init(UART_Bus bus, uint8_t *rx_buf, uint32_t sz);
 
 /**
+ * @brief Initialize the UART peripheral with an explicit baud rate.
+ *
+ * The first gateway milestone keeps the existing 8N1 format and default pins
+ * while allowing SCPI to choose the baud rate.
+ *
+ * @param bus UART bus instance to initialize
+ * @param rx_buf Pointer to the reception buffer
+ * @param sz Size of the reception buffer in bytes
+ * @param baudrate UART baud rate in bits per second
+ */
+void UART_LL_init_baud(
+    UART_Bus bus,
+    uint8_t *rx_buf,
+    uint32_t sz,
+    uint32_t baudrate
+);
+
+/**
  * @brief Deinitialize the UART peripheral.
  *
  * @param bus UART bus instance to deinitialize

--- a/src/system/bus/uart.c
+++ b/src/system/bus/uart.c
@@ -241,7 +241,22 @@ UART_Handle *UART_init(
     CircularBuffer *tx_buffer
 )
 {
-    if (!rx_buffer || !tx_buffer || bus >= UART_BUS_COUNT) {
+    return UART_init_with_baud(
+        bus,
+        rx_buffer,
+        tx_buffer,
+        UART_DEFAULT_BAUDRATE
+    );
+}
+
+UART_Handle *UART_init_with_baud(
+    size_t bus,
+    CircularBuffer *rx_buffer,
+    CircularBuffer *tx_buffer,
+    uint32_t baudrate
+)
+{
+    if (!rx_buffer || !tx_buffer || bus >= UART_BUS_COUNT || baudrate == 0) {
         THROW(ERROR_INVALID_ARGUMENT);
     }
 
@@ -270,7 +285,7 @@ UART_Handle *UART_init(
     handle->passthrough_target = NULL;
 
     /* Initialize hardware layer */
-    UART_LL_init(bus_id, rx_buffer->buffer, rx_buffer->size);
+    UART_LL_init_baud(bus_id, rx_buffer->buffer, rx_buffer->size, baudrate);
     UART_LL_set_idle_callback(bus_id, idle_callback);
     UART_LL_set_rx_complete_callback(bus_id, rx_complete_callback);
     UART_LL_set_tx_complete_callback(bus_id, tx_complete_callback);

--- a/src/system/bus/uart.h
+++ b/src/system/bus/uart.h
@@ -100,6 +100,24 @@ UART_Handle *UART_init(
 );
 
 /**
+ * @brief Initialize the UART peripheral with an explicit baud rate.
+ *
+ * This keeps the current 8N1 format and platform default pins.
+ *
+ * @param bus UART bus instance to initialize (0-based index)
+ * @param rx_buffer Pointer to pre-allocated RX circular buffer
+ * @param tx_buffer Pointer to pre-allocated TX circular buffer
+ * @param baudrate UART baud rate in bits per second
+ * @return Pointer to UART handle on success
+ */
+UART_Handle *UART_init_with_baud(
+    size_t bus,
+    CircularBuffer *rx_buffer,
+    CircularBuffer *tx_buffer,
+    uint32_t baudrate
+);
+
+/**
  * @brief Deinitialize the UART peripheral.
  *
  * @note Bus cannot be deinitialized while passthrough mode is active.


### PR DESCRIPTION
Working on Issue #194.

This PR adds a UART bus gateway through SCPI communication. This allows PSLab users to communicate with other peripherals using the onboard UART bus through regular SCPI commands. (eg sensors)

- UART gateway commands:
  - `src/application/gateway/uart_commands.c`
  - `src/application/gateway/uart_commands.h`
- SCPI command handlers:
  - `src/application/protocol/bus/uart.c`
  - `src/application/protocol/bus/uart.h`
- UART baud rate init support:
  - `UART_init_with_baud(...)`
  - `UART_LL_init_baud(...)`
- SCPI command registration for `BUS:UART:*`
- Increased SCPI input buffer to support binary block writes

Supported Commands:

```
BUS:UART:CONFigure:BUS <1>
BUS:UART:CONFigure:BUS?
BUS:UART:CONFigure:BAUD <baud>
BUS:UART:CONFigure:BAUD?
BUS:UART:CONFigure:TIMEout <ms>
BUS:UART:CONFigure:TIMEout?
BUS:UART:OPEN
BUS:UART:OPEN?
BUS:UART:CLOSe
BUS:UART:WRITe <binary_block>
BUS:UART:READ? [max_bytes]
BUS:UART:AVAILable?
BUS:UART:CLEar
BUS:UART:FLUSh
BUS:UART:TRANsact? <binary_block>
```

Large Diff due to previous PRs. Will mark as draft for now until previous PRs are merged and will rebase as required so it's easier to review.