### PR TITLE
 feat: add digital pattern generator 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,9 +27,11 @@ target_sources(pslab_pico PRIVATE
         src/application/mixed_signal_commands.c
         src/system/instrument/dso.c
         src/system/instrument/mixed_signal.c
+        src/system/pattern_generator.c
         src/platform/adc_capture.c
         src/platform/i2c_ll.c
         src/platform/logic_analyser_ll.c
+        src/platform/pattern_output_ll.c
         src/platform/platform.c
         src/platform/esp_spi_bridge.c
         src/platform/uart_ll.c

--- a/src/platform/pattern_output_ll.c
+++ b/src/platform/pattern_output_ll.c
@@ -12,6 +12,8 @@ enum {
     PATTERN_OUTPUT_INSTRUCTIONS_PER_SAMPLE = 2,
 };
 
+static float const PATTERN_OUTPUT_MAX_CLKDIV = 65536.0f;
+
 static PIO config_pio(PatternOutputLLConfig const *config)
 {
     return config && config->pio ? (PIO)config->pio : pio0;
@@ -122,7 +124,7 @@ bool pattern_output_ll_configure(
     }
 
     float clk_div = rate_to_clkdiv(config->rate_hz);
-    if (clk_div < 1.0f) {
+    if (clk_div < 1.0f || clk_div > PATTERN_OUTPUT_MAX_CLKDIV) {
         return false;
     }
 
@@ -138,15 +140,15 @@ bool pattern_output_ll_configure(
 
     pg->config = *config;
     PIO pio = config_pio(&pg->config);
-    for (uint32_t pin = 0; pin < config->pin_count; ++pin) {
-        pio_gpio_init(pio, config->pin_base + pin);
-    }
-
     if (!load_program(pg)) {
         pg->initialized = false;
         pg->program_loaded = false;
         pg->loop_enabled = false;
         return false;
+    }
+
+    for (uint32_t pin = 0; pin < config->pin_count; ++pin) {
+        pio_gpio_init(pio, config->pin_base + pin);
     }
 
     pio_sm_config sm_config = pio_get_default_sm_config();

--- a/src/platform/pattern_output_ll.c
+++ b/src/platform/pattern_output_ll.c
@@ -1,0 +1,330 @@
+#include "platform/pattern_output_ll.h"
+
+#include "hardware/dma.h"
+#include "hardware/gpio.h"
+#include "hardware/pio.h"
+#include "hardware/structs/bus_ctrl.h"
+#include "pico/stdlib.h"
+
+#include "platform/platform.h"
+
+enum {
+    PATTERN_OUTPUT_INSTRUCTIONS_PER_SAMPLE = 2,
+};
+
+static PIO config_pio(PatternOutputLLConfig const *config)
+{
+    return config && config->pio ? (PIO)config->pio : pio0;
+}
+
+void pattern_output_ll_default_config(
+    PatternOutputLLConfig *config,
+    uint32_t pin_base,
+    uint32_t pin_count,
+    uint32_t rate_hz
+)
+{
+    if (!config) {
+        return;
+    }
+
+    *config = (PatternOutputLLConfig){
+        .pio = pio0,
+        .sm = 1,
+        .pin_base = pin_base,
+        .pin_count = pin_count,
+        .rate_hz = rate_hz,
+    };
+}
+
+static bool load_program(PatternOutputLL *pg)
+{
+    PIO pio = config_pio(&pg->config);
+    pg->program_instructions[0] = pio_encode_pull(false, true);
+    pg->program_instructions[1] = pio_encode_out(pio_pins, pg->config.pin_count);
+
+    struct pio_program program = {
+        .instructions = pg->program_instructions,
+        .length = 2,
+        .origin = -1,
+    };
+
+    if (!pio_can_add_program(pio, &program)) {
+        return false;
+    }
+
+    pg->program_offset = pio_add_program(pio, &program);
+    pg->program_loaded = true;
+    return true;
+}
+
+static void unload_program(PatternOutputLL *pg)
+{
+    if (!pg->program_loaded) {
+        return;
+    }
+
+    PIO pio = config_pio(&pg->config);
+    struct pio_program program = {
+        .instructions = pg->program_instructions,
+        .length = 2,
+        .origin = -1,
+    };
+    pio_remove_program(pio, &program, pg->program_offset);
+    pg->program_loaded = false;
+}
+
+static float rate_to_clkdiv(uint32_t rate_hz)
+{
+    if (rate_hz == 0) {
+        return 0.0f;
+    }
+
+    uint32_t sys_hz =
+        PLATFORM_get_peripheral_clock_speed(PLATFORM_CLOCK_SYS);
+    return (float)sys_hz /
+           ((float)rate_hz * (float)PATTERN_OUTPUT_INSTRUCTIONS_PER_SAMPLE);
+}
+
+static void save_and_apply_dma_priority(PatternOutputLL *pg)
+{
+    if (!pg || pg->bus_priority_saved) {
+        return;
+    }
+
+    pg->saved_bus_priority = bus_ctrl_hw->priority;
+    pg->bus_priority_saved = true;
+    bus_ctrl_hw->priority = pg->saved_bus_priority |
+                            BUSCTRL_BUS_PRIORITY_DMA_W_BITS |
+                            BUSCTRL_BUS_PRIORITY_DMA_R_BITS;
+}
+
+static void restore_bus_priority(PatternOutputLL *pg)
+{
+    if (!pg || !pg->bus_priority_saved) {
+        return;
+    }
+
+    bus_ctrl_hw->priority = pg->saved_bus_priority;
+    pg->bus_priority_saved = false;
+}
+
+bool pattern_output_ll_configure(
+    PatternOutputLL *pg,
+    PatternOutputLLConfig const *config
+)
+{
+    if (!pg || !config || config->pin_count == 0 ||
+        config->pin_count > PATTERN_OUTPUT_LL_MAX_PIN_COUNT ||
+        config->pin_base + config->pin_count > PATTERN_OUTPUT_LL_GPIO_COUNT ||
+        config->rate_hz == 0) {
+        return false;
+    }
+
+    float clk_div = rate_to_clkdiv(config->rate_hz);
+    if (clk_div < 1.0f) {
+        return false;
+    }
+
+    if (pg->initialized && pattern_output_ll_is_busy(pg)) {
+        return false;
+    }
+
+    PIO old_pio = config_pio(&pg->config);
+    if (pg->initialized) {
+        pio_sm_set_enabled(old_pio, pg->config.sm, false);
+        unload_program(pg);
+    }
+
+    pg->config = *config;
+    PIO pio = config_pio(&pg->config);
+    for (uint32_t pin = 0; pin < config->pin_count; ++pin) {
+        pio_gpio_init(pio, config->pin_base + pin);
+    }
+
+    if (!load_program(pg)) {
+        pg->initialized = false;
+        pg->program_loaded = false;
+        pg->loop_enabled = false;
+        return false;
+    }
+
+    pio_sm_config sm_config = pio_get_default_sm_config();
+    sm_config_set_out_pins(&sm_config, config->pin_base, config->pin_count);
+    sm_config_set_wrap(
+        &sm_config,
+        pg->program_offset,
+        pg->program_offset + 1
+    );
+    sm_config_set_clkdiv(&sm_config, clk_div);
+    sm_config_set_out_shift(&sm_config, true, false, 32);
+    sm_config_set_fifo_join(&sm_config, PIO_FIFO_JOIN_TX);
+    pio_sm_init(pio, config->sm, pg->program_offset, &sm_config);
+    pio_sm_set_consecutive_pindirs(
+        pio,
+        config->sm,
+        config->pin_base,
+        config->pin_count,
+        true
+    );
+
+    pg->initialized = true;
+    return true;
+}
+
+bool pattern_output_ll_init(
+    PatternOutputLL *pg,
+    PatternOutputLLConfig const *config
+)
+{
+    if (!pg) {
+        return false;
+    }
+
+    *pg = (PatternOutputLL){
+        .dma_chan = dma_claim_unused_channel(false),
+        .ctrl_dma_chan = -1,
+    };
+
+    if (pg->dma_chan < 0) {
+        return false;
+    }
+
+    pg->ctrl_dma_chan = dma_claim_unused_channel(false);
+    if (pg->ctrl_dma_chan < 0) {
+        dma_channel_unclaim((uint)pg->dma_chan);
+        pg->dma_chan = -1;
+        return false;
+    }
+
+    save_and_apply_dma_priority(pg);
+
+    if (!pattern_output_ll_configure(pg, config)) {
+        dma_channel_unclaim((uint)pg->dma_chan);
+        dma_channel_unclaim((uint)pg->ctrl_dma_chan);
+        pg->dma_chan = -1;
+        pg->ctrl_dma_chan = -1;
+        restore_bus_priority(pg);
+        return false;
+    }
+
+    return true;
+}
+
+void pattern_output_ll_deinit(PatternOutputLL *pg)
+{
+    if (!pg) {
+        return;
+    }
+
+    if (pg->initialized) {
+        pattern_output_ll_stop(pg);
+    }
+    unload_program(pg);
+    if (pg->dma_chan >= 0) {
+        dma_channel_unclaim((uint)pg->dma_chan);
+        pg->dma_chan = -1;
+    }
+    if (pg->ctrl_dma_chan >= 0) {
+        dma_channel_unclaim((uint)pg->ctrl_dma_chan);
+        pg->ctrl_dma_chan = -1;
+    }
+    restore_bus_priority(pg);
+    pg->initialized = false;
+}
+
+bool pattern_output_ll_start(
+    PatternOutputLL *pg,
+    uint32_t const *pattern,
+    uint32_t word_count,
+    bool loop
+)
+{
+    if (!pg || !pg->initialized || !pattern || word_count == 0 ||
+        pg->dma_chan < 0 || pg->ctrl_dma_chan < 0 ||
+        pattern_output_ll_is_busy(pg)) {
+        return false;
+    }
+
+    PIO pio = config_pio(&pg->config);
+    pio_sm_set_enabled(pio, pg->config.sm, false);
+    pio_sm_clear_fifos(pio, pg->config.sm);
+    pio_sm_restart(pio, pg->config.sm);
+    pg->loop_enabled = loop;
+
+    dma_channel_config dma_config =
+        dma_channel_get_default_config((uint)pg->dma_chan);
+    channel_config_set_transfer_data_size(&dma_config, DMA_SIZE_32);
+    channel_config_set_read_increment(&dma_config, true);
+    channel_config_set_write_increment(&dma_config, false);
+    channel_config_set_dreq(&dma_config, pio_get_dreq(pio, pg->config.sm, true));
+    if (loop) {
+        channel_config_set_chain_to(&dma_config, (uint)pg->ctrl_dma_chan);
+        channel_config_set_irq_quiet(&dma_config, true);
+    }
+
+    dma_channel_configure(
+        (uint)pg->dma_chan,
+        &dma_config,
+        &pio->txf[pg->config.sm],
+        pattern,
+        word_count,
+        false
+    );
+
+    if (loop) {
+        pg->restart_read_addr = (uintptr_t)pattern;
+
+        dma_channel_config ctrl_config =
+            dma_channel_get_default_config((uint)pg->ctrl_dma_chan);
+        channel_config_set_transfer_data_size(&ctrl_config, DMA_SIZE_32);
+        channel_config_set_read_increment(&ctrl_config, false);
+        channel_config_set_write_increment(&ctrl_config, false);
+
+        dma_channel_configure(
+            (uint)pg->ctrl_dma_chan,
+            &ctrl_config,
+            &dma_channel_hw_addr((uint)pg->dma_chan)->al3_read_addr_trig,
+            &pg->restart_read_addr,
+            1,
+            false
+        );
+    }
+
+    dma_channel_start((uint)pg->dma_chan);
+    pio_sm_set_enabled(pio, pg->config.sm, true);
+    return true;
+}
+
+void pattern_output_ll_stop(PatternOutputLL *pg)
+{
+    if (!pg || !pg->initialized) {
+        return;
+    }
+
+    pg->loop_enabled = false;
+
+    PIO pio = config_pio(&pg->config);
+    pio_sm_set_enabled(pio, pg->config.sm, false);
+    if (pg->dma_chan >= 0) {
+        dma_channel_abort((uint)pg->dma_chan);
+    }
+    if (pg->ctrl_dma_chan >= 0) {
+        dma_channel_abort((uint)pg->ctrl_dma_chan);
+    }
+    pio_sm_clear_fifos(pio, pg->config.sm);
+    pio_sm_restart(pio, pg->config.sm);
+}
+
+bool pattern_output_ll_is_busy(PatternOutputLL const *pg)
+{
+    if (!pg || !pg->initialized || pg->dma_chan < 0 ||
+        pg->ctrl_dma_chan < 0) {
+        return false;
+    }
+
+    PIO pio = config_pio(&pg->config);
+    return pg->loop_enabled || dma_channel_is_busy((uint)pg->dma_chan) ||
+           dma_channel_is_busy((uint)pg->ctrl_dma_chan) ||
+           !pio_sm_is_tx_fifo_empty(pio, pg->config.sm);
+}

--- a/src/platform/pattern_output_ll.h
+++ b/src/platform/pattern_output_ll.h
@@ -1,0 +1,58 @@
+#ifndef PATTERN_OUTPUT_LL_H
+#define PATTERN_OUTPUT_LL_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+enum {
+    PATTERN_OUTPUT_LL_MAX_PIN_COUNT = 8,
+    PATTERN_OUTPUT_LL_GPIO_COUNT = 30,
+};
+
+typedef struct {
+    void *pio;
+    uint32_t sm;
+    uint32_t pin_base;
+    uint32_t pin_count;
+    uint32_t rate_hz;
+} PatternOutputLLConfig;
+
+typedef struct {
+    PatternOutputLLConfig config;
+    int dma_chan;
+    int ctrl_dma_chan;
+    uint32_t program_offset;
+    uintptr_t restart_read_addr;
+    uint32_t saved_bus_priority;
+    uint16_t program_instructions[2];
+    bool program_loaded;
+    bool loop_enabled;
+    bool bus_priority_saved;
+    bool initialized;
+} PatternOutputLL;
+
+void pattern_output_ll_default_config(
+    PatternOutputLLConfig *config,
+    uint32_t pin_base,
+    uint32_t pin_count,
+    uint32_t rate_hz
+);
+bool pattern_output_ll_init(
+    PatternOutputLL *pg,
+    PatternOutputLLConfig const *config
+);
+void pattern_output_ll_deinit(PatternOutputLL *pg);
+bool pattern_output_ll_configure(
+    PatternOutputLL *pg,
+    PatternOutputLLConfig const *config
+);
+bool pattern_output_ll_start(
+    PatternOutputLL *pg,
+    uint32_t const *pattern,
+    uint32_t word_count,
+    bool loop
+);
+void pattern_output_ll_stop(PatternOutputLL *pg);
+bool pattern_output_ll_is_busy(PatternOutputLL const *pg);
+
+#endif

--- a/src/system/pattern_generator.c
+++ b/src/system/pattern_generator.c
@@ -1,0 +1,126 @@
+#include "system/pattern_generator.h"
+
+static bool config_is_valid(PatternGeneratorConfig const *config)
+{
+    return config && config->pin_count >= 1 &&
+           config->pin_count <= PATTERN_OUTPUT_LL_MAX_PIN_COUNT &&
+           config->pin_base + config->pin_count <=
+               PATTERN_OUTPUT_LL_GPIO_COUNT &&
+           config->rate_hz >= 1;
+}
+
+static bool configure_platform(
+    PatternGenerator *pg,
+    PatternGeneratorConfig const *config
+)
+{
+    PatternOutputLLConfig ll_config;
+    pattern_output_ll_default_config(
+        &ll_config,
+        config->pin_base,
+        config->pin_count,
+        config->rate_hz
+    );
+
+    if (pg->initialized) {
+        return pattern_output_ll_configure(&pg->platform, &ll_config);
+    }
+
+    pg->initialized = pattern_output_ll_init(&pg->platform, &ll_config);
+    return pg->initialized;
+}
+
+bool pattern_generator_init(
+    PatternGenerator *pg,
+    PatternGeneratorConfig const *config
+)
+{
+    if (!pg || !config_is_valid(config)) {
+        return false;
+    }
+
+    *pg = (PatternGenerator){0};
+    if (!configure_platform(pg, config)) {
+        return false;
+    }
+
+    pg->config = *config;
+    return true;
+}
+
+void pattern_generator_deinit(PatternGenerator *pg)
+{
+    if (!pg || !pg->initialized) {
+        return;
+    }
+
+    pattern_output_ll_deinit(&pg->platform);
+    pg->initialized = false;
+    pg->running = false;
+}
+
+bool pattern_generator_configure(
+    PatternGenerator *pg,
+    PatternGeneratorConfig const *config
+)
+{
+    if (!pg || !config_is_valid(config) || pattern_generator_is_running(pg)) {
+        return false;
+    }
+
+    if (!configure_platform(pg, config)) {
+        return false;
+    }
+
+    pg->config = *config;
+    return true;
+}
+
+bool pattern_generator_start(
+    PatternGenerator *pg,
+    uint32_t const *pattern,
+    uint32_t word_count,
+    PatternGeneratorMode mode
+)
+{
+    if (!pg || !pg->initialized || !pattern || word_count == 0 ||
+        pattern_generator_is_running(pg)) {
+        return false;
+    }
+
+    pg->pattern = pattern;
+    pg->word_count = word_count;
+    pg->mode = mode;
+    pg->running = pattern_output_ll_start(
+        &pg->platform,
+        pattern,
+        word_count,
+        mode == PATTERN_GENERATOR_MODE_LOOP
+    );
+    return pg->running;
+}
+
+void pattern_generator_stop(PatternGenerator *pg)
+{
+    if (!pg || !pg->initialized) {
+        return;
+    }
+
+    pattern_output_ll_stop(&pg->platform);
+    pg->running = false;
+}
+
+void pattern_generator_task(PatternGenerator *pg)
+{
+    if (!pg || !pg->initialized || !pg->running ||
+        pattern_output_ll_is_busy(&pg->platform)) {
+        return;
+    }
+
+    pattern_generator_stop(pg);
+}
+
+bool pattern_generator_is_running(PatternGenerator const *pg)
+{
+    return pg && pg->running && pattern_output_ll_is_busy(&pg->platform);
+}

--- a/src/system/pattern_generator.h
+++ b/src/system/pattern_generator.h
@@ -1,0 +1,59 @@
+#ifndef PATTERN_GENERATOR_H
+#define PATTERN_GENERATOR_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "platform/pattern_output_ll.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    PATTERN_GENERATOR_MODE_ONCE,
+    PATTERN_GENERATOR_MODE_LOOP,
+} PatternGeneratorMode;
+
+typedef struct {
+    uint32_t pin_base;
+    uint32_t pin_count;
+    uint32_t rate_hz;
+} PatternGeneratorConfig;
+
+typedef struct PatternGenerator PatternGenerator;
+
+bool pattern_generator_init(
+    PatternGenerator *pg,
+    PatternGeneratorConfig const *config
+);
+void pattern_generator_deinit(PatternGenerator *pg);
+bool pattern_generator_configure(
+    PatternGenerator *pg,
+    PatternGeneratorConfig const *config
+);
+bool pattern_generator_start(
+    PatternGenerator *pg,
+    uint32_t const *pattern,
+    uint32_t word_count,
+    PatternGeneratorMode mode
+);
+void pattern_generator_stop(PatternGenerator *pg);
+void pattern_generator_task(PatternGenerator *pg);
+bool pattern_generator_is_running(PatternGenerator const *pg);
+
+struct PatternGenerator {
+    PatternGeneratorConfig config;
+    PatternOutputLL platform;
+    uint32_t const *pattern;
+    uint32_t word_count;
+    PatternGeneratorMode mode;
+    bool initialized;
+    bool running;
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
Adds a digital pattern generator instrument. Fixes #198. 

- Adds a platform level PIO/DMA output driver:
  - `src/platform/pattern_output_ll.c`
  - `src/platform/pattern_output_ll.h`

- Adds a system level pattern generator instrument:
  - `src/system/pattern_generator.c`
  - `src/system/pattern_generator.h`

- Adds application level command state and validation:
  - `src/application/pattern_generator_commands.c`
  - `src/application/pattern_generator_commands.h`

- Adds SCPI protocol bindings:
  - `src/application/protocol/pg.c`

- Wires the feature into CMake and the SCPI command table.


SCPI Commands:
```
PG:CONF:PINS <base> <count>
PG:CONF:PINS?
PG:CONF:RATE <hz>
PG:CONF:RATE?
PG:CONF:MODE <ONCE|LOOP>
PG:CONF:MODE?
PG:DATA <binary block>
PG:START
PG:STOP
PG:STAT?
```

- Pattern data is uploaded as a SCPI arbitrary binary block.
- Each pattern word is a `uint32_t` where the low bits are output on the configured GPIO pins.
- ONCE mode plays the uploaded pattern once.
- LOOP mode repeats the uploaded pattern by restarting DMA after each pass.
- DMA chaining will be added later for a fully gapless loop.


Draft PR for now as this is being worked upon. Will rebase if previous PRs get merged.

## Summary by Sourcery

Introduce a configurable digital pattern generator instrument backed by a PIO/DMA-based pattern output driver and integrate it into the firmware build.

New Features:
- Add a platform-level PIO/DMA pattern output driver for streaming GPIO patterns at a configured rate.
- Add a system-level pattern generator abstraction supporting configurable pins, rate, and ONCE/LOOP playback modes.

Enhancements:
- Wire the pattern generator and pattern output driver into the main firmware CMake build so the feature is included in the image.