### PR TITLE
feat: add I2C SCPI gateway

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,11 +14,13 @@ add_executable(pslab_pico)
 target_sources(pslab_pico PRIVATE
         src/application/main.c
         src/application/protocol/common.c
+        src/application/protocol/bus/i2c.c
         src/application/protocol/bus/uart.c
         src/application/protocol/la.c
         src/application/protocol/dso.c
         src/application/protocol/mso.c
         src/application/communication_commands.c
+        src/application/gateway/i2c_commands.c
         src/application/gateway/uart_commands.c
         src/application/logic_analyser_commands.c
         src/application/dso_commands.c

--- a/README.md
+++ b/README.md
@@ -195,6 +195,41 @@ Available commands:
 `WRITe`, `READ?`, and `TRANsact?` use SCPI arbitrary blocks so binary payloads
 are safe. The current implementation caps each transfer at 512 bytes.
 
+The I2C gateway exposes the Pico I2C controller as a SCPI master bus for
+external sensors and peripherals. It defaults to I2C0 on GPIO0/GPIO1 at
+100 kHz.
+
+I2C defaults:
+
+- I2C0 SDA: GPIO0
+- I2C0 SCL: GPIO1
+- I2C1 SDA: GPIO6
+- I2C1 SCL: GPIO7
+- Addressing: 7 bit master mode
+
+Available commands:
+
+- `BUS:I2C:CONFigure:BUS <0|1>`
+- `BUS:I2C:CONFigure:BUS?`
+- `BUS:I2C:CONFigure:RATE <hz>`
+- `BUS:I2C:CONFigure:RATE?`
+- `BUS:I2C:CONFigure:ADDRess <address>`
+- `BUS:I2C:CONFigure:ADDRess?`
+- `BUS:I2C:CONFigure:TIMEout <ms>`
+- `BUS:I2C:CONFigure:TIMEout?`
+- `BUS:I2C:OPEN`
+- `BUS:I2C:OPEN?`
+- `BUS:I2C:CLOSe`
+- `BUS:I2C:SCAN?`
+- `BUS:I2C:WRITe <arbitrary_block>`
+- `BUS:I2C:READ? <byte_count>`
+- `BUS:I2C:TRANsact? <arbitrary_block>,<read_byte_count>`
+
+`SCAN?` returns comma separated hexadecimal 7 bit addresses. `WRITe`,
+`READ?`, and `TRANsact?` use SCPI arbitrary blocks and are capped at 512
+bytes per transfer. `TRANsact?` sends the write block followed by a repeated
+start read, which is the common register read pattern for I2C sensors.
+
 ## Build
 
 Configure from the project root:

--- a/src/application/gateway/i2c_commands.c
+++ b/src/application/gateway/i2c_commands.c
@@ -1,0 +1,175 @@
+#include "application/gateway/i2c_commands.h"
+
+#include "system/bus/i2c.h"
+
+enum {
+    I2C_GATEWAY_MIN_RATE_HZ = 1000,
+    I2C_GATEWAY_MAX_RATE_HZ = 1000000,
+    I2C_GATEWAY_MAX_TIMEOUT_MS = 60000,
+};
+
+static I2C_Handle *gateway_i2c;
+
+static struct {
+    uint32_t bus;
+    uint32_t address;
+    uint32_t rate_hz;
+    uint32_t timeout_ms;
+} state = {
+    .bus = I2C_GATEWAY_DEFAULT_BUS,
+    .address = I2C_GATEWAY_DEFAULT_ADDRESS,
+    .rate_hz = I2C_GATEWAY_DEFAULT_RATE_HZ,
+    .timeout_ms = I2C_GATEWAY_DEFAULT_TIMEOUT_MS,
+};
+
+static bool address_is_allowed(uint32_t address)
+{
+    return address >= 0x08 && address < 0x78;
+}
+
+bool i2c_gateway_set_bus(uint32_t bus)
+{
+    if (gateway_i2c || bus >= I2C_get_bus_count()) {
+        return false;
+    }
+
+    state.bus = bus;
+    return true;
+}
+
+uint32_t i2c_gateway_get_bus(void) { return state.bus; }
+
+bool i2c_gateway_set_rate(uint32_t rate_hz)
+{
+    if (gateway_i2c || rate_hz < I2C_GATEWAY_MIN_RATE_HZ ||
+        rate_hz > I2C_GATEWAY_MAX_RATE_HZ) {
+        return false;
+    }
+
+    state.rate_hz = rate_hz;
+    return true;
+}
+
+uint32_t i2c_gateway_get_rate(void)
+{
+    return gateway_i2c ? I2C_get_rate(gateway_i2c) : state.rate_hz;
+}
+
+bool i2c_gateway_set_address(uint32_t address)
+{
+    if (!address_is_allowed(address)) {
+        return false;
+    }
+
+    state.address = address;
+    return true;
+}
+
+uint32_t i2c_gateway_get_address(void) { return state.address; }
+
+bool i2c_gateway_set_timeout(uint32_t timeout_ms)
+{
+    if (timeout_ms == 0 || timeout_ms > I2C_GATEWAY_MAX_TIMEOUT_MS) {
+        return false;
+    }
+
+    state.timeout_ms = timeout_ms;
+    return true;
+}
+
+uint32_t i2c_gateway_get_timeout(void) { return state.timeout_ms; }
+
+bool i2c_gateway_open(void)
+{
+    if (gateway_i2c) {
+        return true;
+    }
+
+    if (state.bus >= I2C_get_bus_count()) {
+        return false;
+    }
+
+    I2C_Config config;
+    if (!I2C_default_config(state.bus, &config)) {
+        return false;
+    }
+
+    config.rate_hz = state.rate_hz;
+    config.timeout_us = state.timeout_ms * 1000u;
+
+    gateway_i2c = I2C_init(&config);
+    return gateway_i2c != NULL;
+}
+
+void i2c_gateway_close(void)
+{
+    if (!gateway_i2c) {
+        return;
+    }
+
+    I2C_Handle *handle = gateway_i2c;
+    gateway_i2c = NULL;
+    I2C_deinit(handle);
+}
+
+bool i2c_gateway_is_open(void) { return gateway_i2c != NULL; }
+
+uint32_t i2c_gateway_scan(uint8_t *addresses, size_t max_count)
+{
+    if (!gateway_i2c || !addresses || max_count == 0) {
+        return 0;
+    }
+
+    if (max_count > I2C_GATEWAY_MAX_SCAN_RESULTS) {
+        max_count = I2C_GATEWAY_MAX_SCAN_RESULTS;
+    }
+
+    return I2C_scan(gateway_i2c, addresses, max_count);
+}
+
+int32_t i2c_gateway_write(uint8_t const *data, size_t len)
+{
+    if (!gateway_i2c || (!data && len > 0) ||
+        len > I2C_GATEWAY_MAX_TRANSFER) {
+        return -1;
+    }
+
+    return I2C_write(gateway_i2c, (uint8_t)state.address, data, len, false);
+}
+
+int32_t i2c_gateway_read(uint8_t *data, size_t len)
+{
+    if (!gateway_i2c || !data || len == 0 ||
+        len > I2C_GATEWAY_MAX_TRANSFER) {
+        return -1;
+    }
+
+    return I2C_read(gateway_i2c, (uint8_t)state.address, data, len, false);
+}
+
+int32_t i2c_gateway_transact(
+    uint8_t const *tx_data,
+    size_t tx_len,
+    uint8_t *rx_data,
+    size_t rx_len
+)
+{
+    if (!gateway_i2c || (!tx_data && tx_len > 0) || !rx_data ||
+        rx_len == 0 || tx_len > I2C_GATEWAY_MAX_TRANSFER ||
+        rx_len > I2C_GATEWAY_MAX_TRANSFER) {
+        return -1;
+    }
+
+    int32_t written = I2C_write(
+        gateway_i2c,
+        (uint8_t)state.address,
+        tx_data,
+        tx_len,
+        true
+    );
+    if (written < 0 || (size_t)written != tx_len) {
+        return -1;
+    }
+
+    return I2C_read(gateway_i2c, (uint8_t)state.address, rx_data, rx_len, false);
+}

--- a/src/application/gateway/i2c_commands.h
+++ b/src/application/gateway/i2c_commands.h
@@ -1,0 +1,51 @@
+#ifndef PSLAB_APPLICATION_GATEWAY_I2C_COMMANDS_H
+#define PSLAB_APPLICATION_GATEWAY_I2C_COMMANDS_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum {
+    I2C_GATEWAY_DEFAULT_BUS = 0,
+    I2C_GATEWAY_DEFAULT_ADDRESS = 0x3c,
+    I2C_GATEWAY_DEFAULT_RATE_HZ = 100000,
+    I2C_GATEWAY_DEFAULT_TIMEOUT_MS = 100,
+    I2C_GATEWAY_MAX_TRANSFER = 512,
+    I2C_GATEWAY_MAX_SCAN_RESULTS = 112,
+};
+
+bool i2c_gateway_set_bus(uint32_t bus);
+uint32_t i2c_gateway_get_bus(void);
+
+bool i2c_gateway_set_rate(uint32_t rate_hz);
+uint32_t i2c_gateway_get_rate(void);
+
+bool i2c_gateway_set_address(uint32_t address);
+uint32_t i2c_gateway_get_address(void);
+
+bool i2c_gateway_set_timeout(uint32_t timeout_ms);
+uint32_t i2c_gateway_get_timeout(void);
+
+bool i2c_gateway_open(void);
+void i2c_gateway_close(void);
+bool i2c_gateway_is_open(void);
+
+uint32_t i2c_gateway_scan(uint8_t *addresses, size_t max_count);
+int32_t i2c_gateway_write(uint8_t const *data, size_t len);
+int32_t i2c_gateway_read(uint8_t *data, size_t len);
+int32_t i2c_gateway_transact(
+    uint8_t const *tx_data,
+    size_t tx_len,
+    uint8_t *rx_data,
+    size_t rx_len
+);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/application/protocol/bus/i2c.c
+++ b/src/application/protocol/bus/i2c.c
@@ -1,0 +1,215 @@
+#include "application/protocol/bus/i2c.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include "scpi/error.h"
+#include "scpi/scpi.h"
+
+#include "application/gateway/i2c_commands.h"
+
+static uint8_t response_buffer[I2C_GATEWAY_MAX_TRANSFER];
+static uint8_t scan_addresses[I2C_GATEWAY_MAX_SCAN_RESULTS];
+static char scan_text[I2C_GATEWAY_MAX_SCAN_RESULTS * 3];
+
+static scpi_result_t result_ok(void) { return SCPI_RES_OK; }
+
+static scpi_result_t result_missing_parameter(scpi_t *context)
+{
+    SCPI_ErrorPush(context, SCPI_ERROR_MISSING_PARAMETER);
+    return SCPI_RES_ERR;
+}
+
+static scpi_result_t result_illegal_parameter(scpi_t *context)
+{
+    SCPI_ErrorPush(context, SCPI_ERROR_ILLEGAL_PARAMETER_VALUE);
+    return SCPI_RES_ERR;
+}
+
+static scpi_result_t result_execution_error(scpi_t *context)
+{
+    SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+    return SCPI_RES_ERR;
+}
+
+static scpi_result_t configure_uint32(
+    scpi_t *context,
+    bool (*setter)(uint32_t)
+)
+{
+    uint32_t value = 0;
+    if (!SCPI_ParamUInt32(context, &value, TRUE)) {
+        return result_missing_parameter(context);
+    }
+
+    return setter(value) ? result_ok() : result_illegal_parameter(context);
+}
+
+scpi_result_t scpi_cmd_bus_i2c_open(scpi_t *context)
+{
+    return i2c_gateway_open() ? result_ok() : result_execution_error(context);
+}
+
+scpi_result_t scpi_cmd_bus_i2c_close(scpi_t *context)
+{
+    (void)context;
+    i2c_gateway_close();
+    return SCPI_RES_OK;
+}
+
+scpi_result_t scpi_cmd_bus_i2c_open_q(scpi_t *context)
+{
+    SCPI_ResultBool(context, i2c_gateway_is_open() ? TRUE : FALSE);
+    return SCPI_RES_OK;
+}
+
+scpi_result_t scpi_cmd_bus_i2c_configure_bus(scpi_t *context)
+{
+    return configure_uint32(context, i2c_gateway_set_bus);
+}
+
+scpi_result_t scpi_cmd_bus_i2c_configure_bus_q(scpi_t *context)
+{
+    SCPI_ResultUInt32(context, i2c_gateway_get_bus());
+    return SCPI_RES_OK;
+}
+
+scpi_result_t scpi_cmd_bus_i2c_configure_rate(scpi_t *context)
+{
+    return configure_uint32(context, i2c_gateway_set_rate);
+}
+
+scpi_result_t scpi_cmd_bus_i2c_configure_rate_q(scpi_t *context)
+{
+    SCPI_ResultUInt32(context, i2c_gateway_get_rate());
+    return SCPI_RES_OK;
+}
+
+scpi_result_t scpi_cmd_bus_i2c_configure_address(scpi_t *context)
+{
+    return configure_uint32(context, i2c_gateway_set_address);
+}
+
+scpi_result_t scpi_cmd_bus_i2c_configure_address_q(scpi_t *context)
+{
+    SCPI_ResultUInt32(context, i2c_gateway_get_address());
+    return SCPI_RES_OK;
+}
+
+scpi_result_t scpi_cmd_bus_i2c_configure_timeout(scpi_t *context)
+{
+    return configure_uint32(context, i2c_gateway_set_timeout);
+}
+
+scpi_result_t scpi_cmd_bus_i2c_configure_timeout_q(scpi_t *context)
+{
+    SCPI_ResultUInt32(context, i2c_gateway_get_timeout());
+    return SCPI_RES_OK;
+}
+
+scpi_result_t scpi_cmd_bus_i2c_scan_q(scpi_t *context)
+{
+    if (!i2c_gateway_is_open()) {
+        return result_execution_error(context);
+    }
+
+    uint32_t count = i2c_gateway_scan(scan_addresses, sizeof(scan_addresses));
+    size_t used = 0;
+    scan_text[0] = '\0';
+
+    for (uint32_t i = 0; i < count; ++i) {
+        int written = snprintf(
+            &scan_text[used],
+            sizeof(scan_text) - used,
+            "%s%02X",
+            i == 0 ? "" : ",",
+            scan_addresses[i]
+        );
+        if (written < 0 || (size_t)written >= sizeof(scan_text) - used) {
+            return result_execution_error(context);
+        }
+        used += (size_t)written;
+    }
+
+    SCPI_ResultText(context, scan_text);
+    return SCPI_RES_OK;
+}
+
+scpi_result_t scpi_cmd_bus_i2c_write(scpi_t *context)
+{
+    char const *data = NULL;
+    size_t len = 0;
+
+    if (!SCPI_ParamArbitraryBlock(context, &data, &len, TRUE)) {
+        return result_missing_parameter(context);
+    }
+
+    if (!i2c_gateway_is_open() || len > I2C_GATEWAY_MAX_TRANSFER) {
+        return result_execution_error(context);
+    }
+
+    int32_t written = i2c_gateway_write((uint8_t const *)data, len);
+    if (written < 0) {
+        return result_execution_error(context);
+    }
+
+    SCPI_ResultUInt32(context, (uint32_t)written);
+    return SCPI_RES_OK;
+}
+
+scpi_result_t scpi_cmd_bus_i2c_read_q(scpi_t *context)
+{
+    uint32_t len = 0;
+
+    if (!SCPI_ParamUInt32(context, &len, TRUE)) {
+        return result_missing_parameter(context);
+    }
+
+    if (!i2c_gateway_is_open() || len == 0 ||
+        len > I2C_GATEWAY_MAX_TRANSFER) {
+        return result_execution_error(context);
+    }
+
+    int32_t bytes_read = i2c_gateway_read(response_buffer, len);
+    if (bytes_read < 0) {
+        return result_execution_error(context);
+    }
+
+    SCPI_ResultArbitraryBlock(context, response_buffer, (size_t)bytes_read);
+    return SCPI_RES_OK;
+}
+
+scpi_result_t scpi_cmd_bus_i2c_transact_q(scpi_t *context)
+{
+    char const *data = NULL;
+    size_t len = 0;
+    uint32_t read_len = 0;
+
+    if (!SCPI_ParamArbitraryBlock(context, &data, &len, TRUE)) {
+        return result_missing_parameter(context);
+    }
+
+    if (!SCPI_ParamUInt32(context, &read_len, TRUE)) {
+        return result_missing_parameter(context);
+    }
+
+    if (!i2c_gateway_is_open() || len > I2C_GATEWAY_MAX_TRANSFER ||
+        read_len == 0 || read_len > I2C_GATEWAY_MAX_TRANSFER) {
+        return result_execution_error(context);
+    }
+
+    int32_t bytes_read = i2c_gateway_transact(
+        (uint8_t const *)data,
+        len,
+        response_buffer,
+        read_len
+    );
+    if (bytes_read < 0) {
+        return result_execution_error(context);
+    }
+
+    SCPI_ResultArbitraryBlock(context, response_buffer, (size_t)bytes_read);
+    return SCPI_RES_OK;
+}

--- a/src/application/protocol/bus/i2c.h
+++ b/src/application/protocol/bus/i2c.h
@@ -1,0 +1,30 @@
+#ifndef PSLAB_APPLICATION_PROTOCOL_BUS_I2C_H
+#define PSLAB_APPLICATION_PROTOCOL_BUS_I2C_H
+
+#include "scpi/types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+scpi_result_t scpi_cmd_bus_i2c_open(scpi_t *context);
+scpi_result_t scpi_cmd_bus_i2c_close(scpi_t *context);
+scpi_result_t scpi_cmd_bus_i2c_open_q(scpi_t *context);
+scpi_result_t scpi_cmd_bus_i2c_configure_bus(scpi_t *context);
+scpi_result_t scpi_cmd_bus_i2c_configure_bus_q(scpi_t *context);
+scpi_result_t scpi_cmd_bus_i2c_configure_rate(scpi_t *context);
+scpi_result_t scpi_cmd_bus_i2c_configure_rate_q(scpi_t *context);
+scpi_result_t scpi_cmd_bus_i2c_configure_address(scpi_t *context);
+scpi_result_t scpi_cmd_bus_i2c_configure_address_q(scpi_t *context);
+scpi_result_t scpi_cmd_bus_i2c_configure_timeout(scpi_t *context);
+scpi_result_t scpi_cmd_bus_i2c_configure_timeout_q(scpi_t *context);
+scpi_result_t scpi_cmd_bus_i2c_scan_q(scpi_t *context);
+scpi_result_t scpi_cmd_bus_i2c_write(scpi_t *context);
+scpi_result_t scpi_cmd_bus_i2c_read_q(scpi_t *context);
+scpi_result_t scpi_cmd_bus_i2c_transact_q(scpi_t *context);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/application/protocol/common.c
+++ b/src/application/protocol/common.c
@@ -20,6 +20,7 @@
 #include "application/dso_commands.h"
 #include "application/logic_analyser_commands.h"
 #include "application/mixed_signal_commands.h"
+#include "application/protocol/bus/i2c.h"
 #include "application/protocol/bus/uart.h"
 #include "platform/platform.h"
 #include "platform/status_led.h"
@@ -264,6 +265,21 @@ static scpi_command_t const g_SCPI_COMMANDS[] = {
     { "BUS:UART:CLEar", scpi_cmd_bus_uart_clear },
     { "BUS:UART:FLUSh", scpi_cmd_bus_uart_flush },
     { "BUS:UART:TRANsact?", scpi_cmd_bus_uart_transact_q },
+    { "BUS:I2C:OPEN", scpi_cmd_bus_i2c_open },
+    { "BUS:I2C:OPEN?", scpi_cmd_bus_i2c_open_q },
+    { "BUS:I2C:CLOSe", scpi_cmd_bus_i2c_close },
+    { "BUS:I2C:CONFigure:BUS", scpi_cmd_bus_i2c_configure_bus },
+    { "BUS:I2C:CONFigure:BUS?", scpi_cmd_bus_i2c_configure_bus_q },
+    { "BUS:I2C:CONFigure:RATE", scpi_cmd_bus_i2c_configure_rate },
+    { "BUS:I2C:CONFigure:RATE?", scpi_cmd_bus_i2c_configure_rate_q },
+    { "BUS:I2C:CONFigure:ADDRess", scpi_cmd_bus_i2c_configure_address },
+    { "BUS:I2C:CONFigure:ADDRess?", scpi_cmd_bus_i2c_configure_address_q },
+    { "BUS:I2C:CONFigure:TIMEout", scpi_cmd_bus_i2c_configure_timeout },
+    { "BUS:I2C:CONFigure:TIMEout?", scpi_cmd_bus_i2c_configure_timeout_q },
+    { "BUS:I2C:SCAN?", scpi_cmd_bus_i2c_scan_q },
+    { "BUS:I2C:WRITe", scpi_cmd_bus_i2c_write },
+    { "BUS:I2C:READ?", scpi_cmd_bus_i2c_read_q },
+    { "BUS:I2C:TRANsact?", scpi_cmd_bus_i2c_transact_q },
 
     // Logic analyser commands
     { "LA:CONFigure:PINBase", scpi_cmd_configure_logic_analyser_pinbase },

--- a/src/platform/i2c_ll.c
+++ b/src/platform/i2c_ll.c
@@ -164,7 +164,19 @@ bool I2C_LL_probe_address(
         return false;
     }
 
-    int32_t result = I2C_LL_read(
+    int32_t result = I2C_LL_write(
+        bus,
+        address,
+        &data,
+        0,
+        false,
+        timeout_us
+    );
+    if (result == 0) {
+        return true;
+    }
+
+    result = I2C_LL_read(
         bus,
         address,
         &data,


### PR DESCRIPTION
Adds the SCPI facing I2C gateway layer on top of the LL I2C platform/system support from #196.

This PR includes:
- I2C gateway command wrappers
- SCPI protocol handlers for I2C bus operations
- command table integration


This PR is stacked on #196. Until #196 is merged, the diff might be large. Once 196 lands, this PR should shrink to the SCPI gateway half only.
