### PR TITLE
 feat: added application layer for spi bus gateway 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,12 +15,14 @@ target_sources(pslab_pico PRIVATE
         src/application/main.c
         src/application/protocol/common.c
         src/application/protocol/bus/i2c.c
+        src/application/protocol/bus/spi.c
         src/application/protocol/bus/uart.c
         src/application/protocol/la.c
         src/application/protocol/dso.c
         src/application/protocol/mso.c
         src/application/communication_commands.c
         src/application/gateway/i2c_commands.c
+        src/application/gateway/spi_commands.c
         src/application/gateway/uart_commands.c
         src/application/logic_analyser_commands.c
         src/application/dso_commands.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ target_sources(pslab_pico PRIVATE
         src/platform/status_led.c
         src/platform/test_signal.c
         src/system/bus/i2c.c
+        src/system/bus/spi.c
         src/system/bus/uart.c
         src/system/logic_analyser.c
         src/system/transport.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ target_sources(pslab_pico PRIVATE
         src/platform/pattern_output_ll.c
         src/platform/platform.c
         src/platform/esp_spi_bridge.c
+        src/platform/spi_ll.c
         src/platform/uart_ll.c
         src/platform/usb_cdc.c
         src/platform/usb_descriptors.c

--- a/README.md
+++ b/README.md
@@ -230,6 +230,45 @@ Available commands:
 bytes per transfer. `TRANsact?` sends the write block followed by a repeated
 start read, which is the common register read pattern for I2C sensors.
 
+The SPI gateway exposes SPI1 as a SCPI master bus. SPI0 is reserved by the
+ESP/WiFi bridge and is not exposed through the generic gateway.
+
+SPI defaults:
+
+- SPI1 SCK: GPIO10
+- SPI1 MOSI/TX: GPIO11
+- SPI1 MISO/RX: GPIO12
+- SPI1 CS: GPIO13
+- Rate: 1 MHz
+- Mode: 0
+- Bit order: MSB first
+- CS polarity: active low
+- Dummy byte for reads: `0xff`
+
+Available commands:
+
+- `BUS:SPI:CONFigure:BUS <1>`
+- `BUS:SPI:CONFigure:BUS?`
+- `BUS:SPI:CONFigure:RATE <hz>`
+- `BUS:SPI:CONFigure:RATE?`
+- `BUS:SPI:CONFigure:MODE <0|1|2|3>`
+- `BUS:SPI:CONFigure:MODE?`
+- `BUS:SPI:CONFigure:DUMMY <byte>`
+- `BUS:SPI:CONFigure:DUMMY?`
+- `BUS:SPI:OPEN`
+- `BUS:SPI:OPEN?`
+- `BUS:SPI:CLOSe`
+- `BUS:SPI:WRITe <arbitrary_block>`
+- `BUS:SPI:READ? <byte_count>`
+- `BUS:SPI:EXCHange? <arbitrary_block>`
+- `BUS:SPI:TRANsact? <arbitrary_block>,<read_byte_count>`
+
+`WRITe`, `READ?`, `EXCHange?`, and `TRANsact?` use SCPI arbitrary blocks and
+are capped at 512 bytes per transfer. `EXCHange?` performs a full duplex SPI
+transfer and returns the bytes received while the command block is clocked out.
+`TRANsact?` writes a command block and then reads a response while keeping CS
+asserted, which is the common register read pattern for SPI sensors.
+
 ## Build
 
 Configure from the project root:

--- a/src/application/gateway/spi_commands.c
+++ b/src/application/gateway/spi_commands.c
@@ -1,0 +1,160 @@
+#include "application/gateway/spi_commands.h"
+
+#include "system/bus/spi.h"
+
+enum {
+    SPI_GATEWAY_MIN_RATE_HZ = 1000,
+    SPI_GATEWAY_MAX_RATE_HZ = 50000000,
+};
+
+static SPI_Handle *gateway_spi;
+
+static struct {
+    uint32_t bus;
+    uint32_t rate_hz;
+    uint32_t mode;
+    uint32_t dummy_byte;
+} state = {
+    .bus = SPI_GATEWAY_DEFAULT_BUS,
+    .rate_hz = SPI_GATEWAY_DEFAULT_RATE_HZ,
+    .mode = SPI_GATEWAY_DEFAULT_MODE,
+    .dummy_byte = SPI_GATEWAY_DEFAULT_DUMMY_BYTE,
+};
+
+bool spi_gateway_set_bus(uint32_t bus)
+{
+    if (gateway_spi || bus != SPI_GATEWAY_DEFAULT_BUS) {
+        return false;
+    }
+
+    state.bus = bus;
+    return true;
+}
+
+uint32_t spi_gateway_get_bus(void) { return state.bus; }
+
+bool spi_gateway_set_rate(uint32_t rate_hz)
+{
+    if (gateway_spi || rate_hz < SPI_GATEWAY_MIN_RATE_HZ ||
+        rate_hz > SPI_GATEWAY_MAX_RATE_HZ) {
+        return false;
+    }
+
+    state.rate_hz = rate_hz;
+    return true;
+}
+
+uint32_t spi_gateway_get_rate(void)
+{
+    return gateway_spi ? SPI_get_rate(gateway_spi) : state.rate_hz;
+}
+
+bool spi_gateway_set_mode(uint32_t mode)
+{
+    if (gateway_spi || mode > SPI_GATEWAY_DEFAULT_MODE + 3u) {
+        return false;
+    }
+
+    state.mode = mode;
+    return true;
+}
+
+uint32_t spi_gateway_get_mode(void)
+{
+    return gateway_spi ? (uint32_t)SPI_get_mode(gateway_spi) : state.mode;
+}
+
+bool spi_gateway_set_dummy_byte(uint32_t dummy_byte)
+{
+    if (gateway_spi || dummy_byte > 0xff) {
+        return false;
+    }
+
+    state.dummy_byte = dummy_byte;
+    return true;
+}
+
+uint32_t spi_gateway_get_dummy_byte(void)
+{
+    return gateway_spi ? SPI_get_dummy_byte(gateway_spi) : state.dummy_byte;
+}
+
+bool spi_gateway_open(void)
+{
+    if (gateway_spi) {
+        return true;
+    }
+
+    SPI_Config config;
+    if (!SPI_default_config(state.bus, &config)) {
+        return false;
+    }
+
+    config.rate_hz = state.rate_hz;
+    config.mode = (SPI_Mode)state.mode;
+    config.dummy_byte = (uint8_t)state.dummy_byte;
+
+    gateway_spi = SPI_init(&config);
+    return gateway_spi != NULL;
+}
+
+void spi_gateway_close(void)
+{
+    if (!gateway_spi) {
+        return;
+    }
+
+    SPI_Handle *handle = gateway_spi;
+    gateway_spi = NULL;
+    SPI_deinit(handle);
+}
+
+bool spi_gateway_is_open(void) { return gateway_spi != NULL; }
+
+int32_t spi_gateway_write(uint8_t const *data, size_t len)
+{
+    if (!gateway_spi || !data || len == 0 || len > SPI_GATEWAY_MAX_TRANSFER) {
+        return -1;
+    }
+
+    return SPI_write(gateway_spi, data, len);
+}
+
+int32_t spi_gateway_read(uint8_t *data, size_t len)
+{
+    if (!gateway_spi || !data || len == 0 || len > SPI_GATEWAY_MAX_TRANSFER) {
+        return -1;
+    }
+
+    return SPI_read(gateway_spi, data, len);
+}
+
+int32_t spi_gateway_exchange(
+    uint8_t const *tx_data,
+    uint8_t *rx_data,
+    size_t len
+)
+{
+    if (!gateway_spi || !tx_data || !rx_data || len == 0 ||
+        len > SPI_GATEWAY_MAX_TRANSFER) {
+        return -1;
+    }
+
+    return SPI_exchange(gateway_spi, tx_data, rx_data, len);
+}
+
+int32_t spi_gateway_transact(
+    uint8_t const *tx_data,
+    size_t tx_len,
+    uint8_t *rx_data,
+    size_t rx_len
+)
+{
+    if (!gateway_spi || !tx_data || tx_len == 0 || !rx_data ||
+        rx_len == 0 || tx_len > SPI_GATEWAY_MAX_TRANSFER ||
+        rx_len > SPI_GATEWAY_MAX_TRANSFER) {
+        return -1;
+    }
+
+    return SPI_transact(gateway_spi, tx_data, tx_len, rx_data, rx_len);
+}

--- a/src/application/gateway/spi_commands.h
+++ b/src/application/gateway/spi_commands.h
@@ -1,0 +1,54 @@
+#ifndef PSLAB_APPLICATION_GATEWAY_SPI_COMMANDS_H
+#define PSLAB_APPLICATION_GATEWAY_SPI_COMMANDS_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum {
+    SPI_GATEWAY_DEFAULT_BUS = 1,
+    SPI_GATEWAY_DEFAULT_RATE_HZ = 1000000,
+    SPI_GATEWAY_DEFAULT_MODE = 0,
+    SPI_GATEWAY_DEFAULT_DUMMY_BYTE = 0xff,
+    SPI_GATEWAY_MAX_TRANSFER = 512,
+};
+
+bool spi_gateway_set_bus(uint32_t bus);
+uint32_t spi_gateway_get_bus(void);
+
+bool spi_gateway_set_rate(uint32_t rate_hz);
+uint32_t spi_gateway_get_rate(void);
+
+bool spi_gateway_set_mode(uint32_t mode);
+uint32_t spi_gateway_get_mode(void);
+
+bool spi_gateway_set_dummy_byte(uint32_t dummy_byte);
+uint32_t spi_gateway_get_dummy_byte(void);
+
+bool spi_gateway_open(void);
+void spi_gateway_close(void);
+bool spi_gateway_is_open(void);
+
+int32_t spi_gateway_write(uint8_t const *data, size_t len);
+int32_t spi_gateway_read(uint8_t *data, size_t len);
+int32_t spi_gateway_exchange(
+    uint8_t const *tx_data,
+    uint8_t *rx_data,
+    size_t len
+);
+int32_t spi_gateway_transact(
+    uint8_t const *tx_data,
+    size_t tx_len,
+    uint8_t *rx_data,
+    size_t rx_len
+);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/application/protocol/bus/spi.c
+++ b/src/application/protocol/bus/spi.c
@@ -1,0 +1,212 @@
+#include "application/protocol/bus/spi.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "scpi/error.h"
+#include "scpi/scpi.h"
+
+#include "application/gateway/spi_commands.h"
+
+static uint8_t response_buffer[SPI_GATEWAY_MAX_TRANSFER];
+
+static scpi_result_t result_ok(void) { return SCPI_RES_OK; }
+
+static scpi_result_t result_missing_parameter(scpi_t *context)
+{
+    SCPI_ErrorPush(context, SCPI_ERROR_MISSING_PARAMETER);
+    return SCPI_RES_ERR;
+}
+
+static scpi_result_t result_illegal_parameter(scpi_t *context)
+{
+    SCPI_ErrorPush(context, SCPI_ERROR_ILLEGAL_PARAMETER_VALUE);
+    return SCPI_RES_ERR;
+}
+
+static scpi_result_t result_execution_error(scpi_t *context)
+{
+    SCPI_ErrorPush(context, SCPI_ERROR_EXECUTION_ERROR);
+    return SCPI_RES_ERR;
+}
+
+static scpi_result_t configure_uint32(
+    scpi_t *context,
+    bool (*setter)(uint32_t)
+)
+{
+    uint32_t value = 0;
+    if (!SCPI_ParamUInt32(context, &value, TRUE)) {
+        return result_missing_parameter(context);
+    }
+
+    return setter(value) ? result_ok() : result_illegal_parameter(context);
+}
+
+scpi_result_t scpi_cmd_bus_spi_open(scpi_t *context)
+{
+    return spi_gateway_open() ? result_ok() : result_execution_error(context);
+}
+
+scpi_result_t scpi_cmd_bus_spi_close(scpi_t *context)
+{
+    (void)context;
+    spi_gateway_close();
+    return SCPI_RES_OK;
+}
+
+scpi_result_t scpi_cmd_bus_spi_open_q(scpi_t *context)
+{
+    SCPI_ResultBool(context, spi_gateway_is_open() ? TRUE : FALSE);
+    return SCPI_RES_OK;
+}
+
+scpi_result_t scpi_cmd_bus_spi_configure_bus(scpi_t *context)
+{
+    return configure_uint32(context, spi_gateway_set_bus);
+}
+
+scpi_result_t scpi_cmd_bus_spi_configure_bus_q(scpi_t *context)
+{
+    SCPI_ResultUInt32(context, spi_gateway_get_bus());
+    return SCPI_RES_OK;
+}
+
+scpi_result_t scpi_cmd_bus_spi_configure_rate(scpi_t *context)
+{
+    return configure_uint32(context, spi_gateway_set_rate);
+}
+
+scpi_result_t scpi_cmd_bus_spi_configure_rate_q(scpi_t *context)
+{
+    SCPI_ResultUInt32(context, spi_gateway_get_rate());
+    return SCPI_RES_OK;
+}
+
+scpi_result_t scpi_cmd_bus_spi_configure_mode(scpi_t *context)
+{
+    return configure_uint32(context, spi_gateway_set_mode);
+}
+
+scpi_result_t scpi_cmd_bus_spi_configure_mode_q(scpi_t *context)
+{
+    SCPI_ResultUInt32(context, spi_gateway_get_mode());
+    return SCPI_RES_OK;
+}
+
+scpi_result_t scpi_cmd_bus_spi_configure_dummy(scpi_t *context)
+{
+    return configure_uint32(context, spi_gateway_set_dummy_byte);
+}
+
+scpi_result_t scpi_cmd_bus_spi_configure_dummy_q(scpi_t *context)
+{
+    SCPI_ResultUInt32(context, spi_gateway_get_dummy_byte());
+    return SCPI_RES_OK;
+}
+
+scpi_result_t scpi_cmd_bus_spi_write(scpi_t *context)
+{
+    char const *data = NULL;
+    size_t len = 0;
+
+    if (!SCPI_ParamArbitraryBlock(context, &data, &len, TRUE)) {
+        return result_missing_parameter(context);
+    }
+
+    if (!spi_gateway_is_open() || len > SPI_GATEWAY_MAX_TRANSFER) {
+        return result_execution_error(context);
+    }
+
+    int32_t written = spi_gateway_write((uint8_t const *)data, len);
+    if (written < 0) {
+        return result_execution_error(context);
+    }
+
+    SCPI_ResultUInt32(context, (uint32_t)written);
+    return SCPI_RES_OK;
+}
+
+scpi_result_t scpi_cmd_bus_spi_read_q(scpi_t *context)
+{
+    uint32_t len = 0;
+
+    if (!SCPI_ParamUInt32(context, &len, TRUE)) {
+        return result_missing_parameter(context);
+    }
+
+    if (!spi_gateway_is_open() || len == 0 ||
+        len > SPI_GATEWAY_MAX_TRANSFER) {
+        return result_execution_error(context);
+    }
+
+    int32_t bytes_read = spi_gateway_read(response_buffer, len);
+    if (bytes_read < 0) {
+        return result_execution_error(context);
+    }
+
+    SCPI_ResultArbitraryBlock(context, response_buffer, (size_t)bytes_read);
+    return SCPI_RES_OK;
+}
+
+scpi_result_t scpi_cmd_bus_spi_exchange_q(scpi_t *context)
+{
+    char const *data = NULL;
+    size_t len = 0;
+
+    if (!SCPI_ParamArbitraryBlock(context, &data, &len, TRUE)) {
+        return result_missing_parameter(context);
+    }
+
+    if (!spi_gateway_is_open() || len == 0 ||
+        len > SPI_GATEWAY_MAX_TRANSFER) {
+        return result_execution_error(context);
+    }
+
+    int32_t bytes_read = spi_gateway_exchange(
+        (uint8_t const *)data,
+        response_buffer,
+        len
+    );
+    if (bytes_read < 0) {
+        return result_execution_error(context);
+    }
+
+    SCPI_ResultArbitraryBlock(context, response_buffer, (size_t)bytes_read);
+    return SCPI_RES_OK;
+}
+
+scpi_result_t scpi_cmd_bus_spi_transact_q(scpi_t *context)
+{
+    char const *data = NULL;
+    size_t len = 0;
+    uint32_t read_len = 0;
+
+    if (!SCPI_ParamArbitraryBlock(context, &data, &len, TRUE)) {
+        return result_missing_parameter(context);
+    }
+
+    if (!SCPI_ParamUInt32(context, &read_len, TRUE)) {
+        return result_missing_parameter(context);
+    }
+
+    if (!spi_gateway_is_open() || len == 0 ||
+        len > SPI_GATEWAY_MAX_TRANSFER || read_len == 0 ||
+        read_len > SPI_GATEWAY_MAX_TRANSFER) {
+        return result_execution_error(context);
+    }
+
+    int32_t bytes_read = spi_gateway_transact(
+        (uint8_t const *)data,
+        len,
+        response_buffer,
+        read_len
+    );
+    if (bytes_read < 0) {
+        return result_execution_error(context);
+    }
+
+    SCPI_ResultArbitraryBlock(context, response_buffer, (size_t)bytes_read);
+    return SCPI_RES_OK;
+}

--- a/src/application/protocol/bus/spi.h
+++ b/src/application/protocol/bus/spi.h
@@ -1,0 +1,30 @@
+#ifndef PSLAB_APPLICATION_PROTOCOL_BUS_SPI_H
+#define PSLAB_APPLICATION_PROTOCOL_BUS_SPI_H
+
+#include "scpi/types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+scpi_result_t scpi_cmd_bus_spi_open(scpi_t *context);
+scpi_result_t scpi_cmd_bus_spi_close(scpi_t *context);
+scpi_result_t scpi_cmd_bus_spi_open_q(scpi_t *context);
+scpi_result_t scpi_cmd_bus_spi_configure_bus(scpi_t *context);
+scpi_result_t scpi_cmd_bus_spi_configure_bus_q(scpi_t *context);
+scpi_result_t scpi_cmd_bus_spi_configure_rate(scpi_t *context);
+scpi_result_t scpi_cmd_bus_spi_configure_rate_q(scpi_t *context);
+scpi_result_t scpi_cmd_bus_spi_configure_mode(scpi_t *context);
+scpi_result_t scpi_cmd_bus_spi_configure_mode_q(scpi_t *context);
+scpi_result_t scpi_cmd_bus_spi_configure_dummy(scpi_t *context);
+scpi_result_t scpi_cmd_bus_spi_configure_dummy_q(scpi_t *context);
+scpi_result_t scpi_cmd_bus_spi_write(scpi_t *context);
+scpi_result_t scpi_cmd_bus_spi_read_q(scpi_t *context);
+scpi_result_t scpi_cmd_bus_spi_exchange_q(scpi_t *context);
+scpi_result_t scpi_cmd_bus_spi_transact_q(scpi_t *context);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/application/protocol/common.c
+++ b/src/application/protocol/common.c
@@ -21,6 +21,7 @@
 #include "application/logic_analyser_commands.h"
 #include "application/mixed_signal_commands.h"
 #include "application/protocol/bus/i2c.h"
+#include "application/protocol/bus/spi.h"
 #include "application/protocol/bus/uart.h"
 #include "platform/platform.h"
 #include "platform/status_led.h"
@@ -280,6 +281,21 @@ static scpi_command_t const g_SCPI_COMMANDS[] = {
     { "BUS:I2C:WRITe", scpi_cmd_bus_i2c_write },
     { "BUS:I2C:READ?", scpi_cmd_bus_i2c_read_q },
     { "BUS:I2C:TRANsact?", scpi_cmd_bus_i2c_transact_q },
+    { "BUS:SPI:OPEN", scpi_cmd_bus_spi_open },
+    { "BUS:SPI:OPEN?", scpi_cmd_bus_spi_open_q },
+    { "BUS:SPI:CLOSe", scpi_cmd_bus_spi_close },
+    { "BUS:SPI:CONFigure:BUS", scpi_cmd_bus_spi_configure_bus },
+    { "BUS:SPI:CONFigure:BUS?", scpi_cmd_bus_spi_configure_bus_q },
+    { "BUS:SPI:CONFigure:RATE", scpi_cmd_bus_spi_configure_rate },
+    { "BUS:SPI:CONFigure:RATE?", scpi_cmd_bus_spi_configure_rate_q },
+    { "BUS:SPI:CONFigure:MODE", scpi_cmd_bus_spi_configure_mode },
+    { "BUS:SPI:CONFigure:MODE?", scpi_cmd_bus_spi_configure_mode_q },
+    { "BUS:SPI:CONFigure:DUMMY", scpi_cmd_bus_spi_configure_dummy },
+    { "BUS:SPI:CONFigure:DUMMY?", scpi_cmd_bus_spi_configure_dummy_q },
+    { "BUS:SPI:WRITe", scpi_cmd_bus_spi_write },
+    { "BUS:SPI:READ?", scpi_cmd_bus_spi_read_q },
+    { "BUS:SPI:EXCHange?", scpi_cmd_bus_spi_exchange_q },
+    { "BUS:SPI:TRANsact?", scpi_cmd_bus_spi_transact_q },
 
     // Logic analyser commands
     { "LA:CONFigure:PINBase", scpi_cmd_configure_logic_analyser_pinbase },

--- a/src/platform/spi_ll.c
+++ b/src/platform/spi_ll.c
@@ -1,0 +1,282 @@
+/**
+ * @file spi_ll.c
+ * @brief Low-level SPI hardware implementation.
+ */
+
+#include "platform/spi_ll.h"
+
+#include "hardware/gpio.h"
+#include "hardware/spi.h"
+#include "pico/error.h"
+
+typedef struct {
+    spi_inst_t *instance;
+    uint32_t sck_gpio;
+    uint32_t tx_gpio;
+    uint32_t rx_gpio;
+    uint32_t cs_gpio;
+    uint32_t rate_hz;
+    SPI_LL_Mode mode;
+    SPI_LL_BitOrder bit_order;
+    bool cs_active_low;
+    bool selected;
+    bool initialized;
+} SPI_LL_Instance;
+
+static SPI_LL_Instance instances[SPI_LL_BUS_COUNT] = {
+    [SPI_LL_BUS_1] = {
+        .instance = spi1,
+    },
+};
+
+static bool valid_bus(SPI_LL_Bus bus) { return bus == SPI_LL_BUS_1; }
+
+static bool valid_gpio(uint32_t gpio) { return gpio <= 29; }
+
+static bool valid_mode(SPI_LL_Mode mode) { return mode <= SPI_LL_MODE_3; }
+
+static bool valid_bit_order(SPI_LL_BitOrder bit_order)
+{
+    return bit_order <= SPI_LL_BIT_ORDER_LSB_FIRST;
+}
+
+static bool valid_spi1_rx_gpio(uint32_t gpio)
+{
+    return gpio == 8 || gpio == 12 || gpio == 24 || gpio == 28;
+}
+
+static bool valid_spi1_cs_gpio(uint32_t gpio)
+{
+    return gpio == 9 || gpio == 13 || gpio == 25 || gpio == 29;
+}
+
+static bool valid_spi1_sck_gpio(uint32_t gpio)
+{
+    return gpio == 10 || gpio == 14 || gpio == 26;
+}
+
+static bool valid_spi1_tx_gpio(uint32_t gpio)
+{
+    return gpio == 11 || gpio == 15 || gpio == 27;
+}
+
+static bool pins_match_bus(SPI_LL_Bus bus, SPI_LL_Config const *config)
+{
+    return bus == SPI_LL_BUS_1 && valid_spi1_sck_gpio(config->sck_gpio) &&
+           valid_spi1_tx_gpio(config->tx_gpio) &&
+           valid_spi1_rx_gpio(config->rx_gpio) &&
+           valid_spi1_cs_gpio(config->cs_gpio);
+}
+
+static bool pins_are_distinct(SPI_LL_Config const *config)
+{
+    return config->sck_gpio != config->tx_gpio &&
+           config->sck_gpio != config->rx_gpio &&
+           config->sck_gpio != config->cs_gpio &&
+           config->tx_gpio != config->rx_gpio &&
+           config->tx_gpio != config->cs_gpio &&
+           config->rx_gpio != config->cs_gpio;
+}
+
+static spi_cpol_t pico_cpol(SPI_LL_Mode mode)
+{
+    return mode == SPI_LL_MODE_2 || mode == SPI_LL_MODE_3 ? SPI_CPOL_1
+                                                          : SPI_CPOL_0;
+}
+
+static spi_cpha_t pico_cpha(SPI_LL_Mode mode)
+{
+    return mode == SPI_LL_MODE_1 || mode == SPI_LL_MODE_3 ? SPI_CPHA_1
+                                                          : SPI_CPHA_0;
+}
+
+static spi_order_t pico_bit_order(SPI_LL_BitOrder bit_order)
+{
+    return bit_order == SPI_LL_BIT_ORDER_LSB_FIRST ? SPI_LSB_FIRST
+                                                   : SPI_MSB_FIRST;
+}
+
+static void set_cs_inactive(SPI_LL_Instance const *instance)
+{
+    gpio_put(instance->cs_gpio, instance->cs_active_low ? 1 : 0);
+}
+
+static void set_cs_active(SPI_LL_Instance const *instance)
+{
+    gpio_put(instance->cs_gpio, instance->cs_active_low ? 0 : 1);
+}
+
+static bool config_is_valid(SPI_LL_Bus bus, SPI_LL_Config const *config)
+{
+    return config && config->rate_hz > 0 && valid_gpio(config->sck_gpio) &&
+           valid_gpio(config->tx_gpio) && valid_gpio(config->rx_gpio) &&
+           valid_gpio(config->cs_gpio) && pins_match_bus(bus, config) &&
+           pins_are_distinct(config) && valid_mode(config->mode) &&
+           valid_bit_order(config->bit_order);
+}
+
+bool SPI_LL_default_config(SPI_LL_Bus bus, SPI_LL_Config *config)
+{
+    if (!valid_bus(bus) || !config) {
+        return false;
+    }
+
+    *config = (SPI_LL_Config){
+        .sck_gpio = 10u,
+        .tx_gpio = 11u,
+        .rx_gpio = 12u,
+        .cs_gpio = 13u,
+        .rate_hz = SPI_LL_DEFAULT_RATE_HZ,
+        .mode = SPI_LL_MODE_0,
+        .bit_order = SPI_LL_BIT_ORDER_MSB_FIRST,
+        .cs_active_low = true,
+    };
+    return true;
+}
+
+bool SPI_LL_init(SPI_LL_Bus bus, SPI_LL_Config const *config)
+{
+    if (!valid_bus(bus) || !config_is_valid(bus, config) ||
+        instances[bus].initialized) {
+        return false;
+    }
+
+    SPI_LL_Instance *instance = &instances[bus];
+    uint32_t actual_rate = spi_init(instance->instance, config->rate_hz);
+    spi_set_format(
+        instance->instance,
+        8,
+        pico_cpol(config->mode),
+        pico_cpha(config->mode),
+        pico_bit_order(config->bit_order)
+    );
+
+    gpio_set_function(config->rx_gpio, GPIO_FUNC_SPI);
+    gpio_set_function(config->sck_gpio, GPIO_FUNC_SPI);
+    gpio_set_function(config->tx_gpio, GPIO_FUNC_SPI);
+
+    gpio_init(config->cs_gpio);
+    gpio_set_dir(config->cs_gpio, GPIO_OUT);
+
+    instance->sck_gpio = config->sck_gpio;
+    instance->tx_gpio = config->tx_gpio;
+    instance->rx_gpio = config->rx_gpio;
+    instance->cs_gpio = config->cs_gpio;
+    instance->rate_hz = actual_rate;
+    instance->mode = config->mode;
+    instance->bit_order = config->bit_order;
+    instance->cs_active_low = config->cs_active_low;
+    instance->selected = false;
+    instance->initialized = true;
+
+    set_cs_inactive(instance);
+    return true;
+}
+
+void SPI_LL_deinit(SPI_LL_Bus bus)
+{
+    if (!valid_bus(bus) || !instances[bus].initialized) {
+        return;
+    }
+
+    SPI_LL_Instance *instance = &instances[bus];
+    set_cs_inactive(instance);
+    spi_deinit(instance->instance);
+
+    gpio_set_function(instance->sck_gpio, GPIO_FUNC_NULL);
+    gpio_set_function(instance->tx_gpio, GPIO_FUNC_NULL);
+    gpio_set_function(instance->rx_gpio, GPIO_FUNC_NULL);
+    gpio_set_function(instance->cs_gpio, GPIO_FUNC_NULL);
+    gpio_disable_pulls(instance->sck_gpio);
+    gpio_disable_pulls(instance->tx_gpio);
+    gpio_disable_pulls(instance->rx_gpio);
+    gpio_disable_pulls(instance->cs_gpio);
+
+    instance->sck_gpio = 0;
+    instance->tx_gpio = 0;
+    instance->rx_gpio = 0;
+    instance->cs_gpio = 0;
+    instance->rate_hz = 0;
+    instance->mode = SPI_LL_MODE_0;
+    instance->bit_order = SPI_LL_BIT_ORDER_MSB_FIRST;
+    instance->cs_active_low = true;
+    instance->selected = false;
+    instance->initialized = false;
+}
+
+bool SPI_LL_is_initialized(SPI_LL_Bus bus)
+{
+    return valid_bus(bus) && instances[bus].initialized;
+}
+
+uint32_t SPI_LL_get_rate(SPI_LL_Bus bus)
+{
+    return SPI_LL_is_initialized(bus) ? instances[bus].rate_hz : 0;
+}
+
+SPI_LL_Mode SPI_LL_get_mode(SPI_LL_Bus bus)
+{
+    return SPI_LL_is_initialized(bus) ? instances[bus].mode : SPI_LL_MODE_0;
+}
+
+SPI_LL_BitOrder SPI_LL_get_bit_order(SPI_LL_Bus bus)
+{
+    return SPI_LL_is_initialized(bus) ? instances[bus].bit_order
+                                      : SPI_LL_BIT_ORDER_MSB_FIRST;
+}
+
+bool SPI_LL_select(SPI_LL_Bus bus)
+{
+    if (!SPI_LL_is_initialized(bus)) {
+        return false;
+    }
+
+    SPI_LL_Instance *instance = &instances[bus];
+    set_cs_active(instance);
+    instance->selected = true;
+    return true;
+}
+
+void SPI_LL_deselect(SPI_LL_Bus bus)
+{
+    if (!SPI_LL_is_initialized(bus)) {
+        return;
+    }
+
+    SPI_LL_Instance *instance = &instances[bus];
+    set_cs_inactive(instance);
+    instance->selected = false;
+}
+
+bool SPI_LL_is_selected(SPI_LL_Bus bus)
+{
+    return SPI_LL_is_initialized(bus) && instances[bus].selected;
+}
+
+int32_t SPI_LL_transfer(
+    SPI_LL_Bus bus,
+    uint8_t const *tx_data,
+    uint8_t *rx_data,
+    size_t len
+)
+{
+    if (!SPI_LL_is_initialized(bus) || len == 0 ||
+        (!tx_data && !rx_data)) {
+        return PICO_ERROR_GENERIC;
+    }
+
+    if (tx_data && rx_data) {
+        return spi_write_read_blocking(
+            instances[bus].instance,
+            tx_data,
+            rx_data,
+            len
+        );
+    }
+
+    if (tx_data) {
+        return spi_write_blocking(instances[bus].instance, tx_data, len);
+    }
+
+    return spi_read_blocking(instances[bus].instance, 0xff, rx_data, len);
+}

--- a/src/platform/spi_ll.c
+++ b/src/platform/spi_ll.c
@@ -257,7 +257,8 @@ int32_t SPI_LL_transfer(
     SPI_LL_Bus bus,
     uint8_t const *tx_data,
     uint8_t *rx_data,
-    size_t len
+    size_t len,
+    uint8_t dummy_byte
 )
 {
     if (!SPI_LL_is_initialized(bus) || len == 0 ||
@@ -278,5 +279,5 @@ int32_t SPI_LL_transfer(
         return spi_write_blocking(instances[bus].instance, tx_data, len);
     }
 
-    return spi_read_blocking(instances[bus].instance, 0xff, rx_data, len);
+    return spi_read_blocking(instances[bus].instance, dummy_byte, rx_data, len);
 }

--- a/src/platform/spi_ll.h
+++ b/src/platform/spi_ll.h
@@ -76,7 +76,8 @@ int32_t SPI_LL_transfer(
     SPI_LL_Bus bus,
     uint8_t const *tx_data,
     uint8_t *rx_data,
-    size_t len
+    size_t len,
+    uint8_t dummy_byte
 );
 
 #ifdef __cplusplus

--- a/src/platform/spi_ll.h
+++ b/src/platform/spi_ll.h
@@ -1,0 +1,86 @@
+/**
+ * @file spi_ll.h
+ * @brief Low-level SPI hardware interface.
+ *
+ * This module is the only layer that should call Pico SDK SPI functions
+ * directly. System and application code should build on this interface.
+ */
+
+#ifndef PSLAB_SPI_LL_H
+#define PSLAB_SPI_LL_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    SPI_LL_BUS_1 = 1,
+    SPI_LL_BUS_COUNT = 2,
+} SPI_LL_Bus;
+
+typedef enum {
+    SPI_LL_MODE_0 = 0,
+    SPI_LL_MODE_1 = 1,
+    SPI_LL_MODE_2 = 2,
+    SPI_LL_MODE_3 = 3,
+} SPI_LL_Mode;
+
+typedef enum {
+    SPI_LL_BIT_ORDER_MSB_FIRST = 0,
+    SPI_LL_BIT_ORDER_LSB_FIRST = 1,
+} SPI_LL_BitOrder;
+
+enum {
+    SPI_LL_DEFAULT_RATE_HZ = 1000000,
+};
+
+typedef struct {
+    uint32_t sck_gpio;
+    uint32_t tx_gpio;
+    uint32_t rx_gpio;
+    uint32_t cs_gpio;
+    uint32_t rate_hz;
+    SPI_LL_Mode mode;
+    SPI_LL_BitOrder bit_order;
+    bool cs_active_low;
+} SPI_LL_Config;
+
+/**
+ * @brief Fill an SPI configuration with board defaults for a bus.
+ *
+ * Defaults:
+ * - SPI1: SCK GPIO10, TX/MOSI GPIO11, RX/MISO GPIO12, CS GPIO13
+ * - 1 MHz, mode 0, MSB first, active-low CS
+ *
+ * SPI0 is intentionally not exposed by this platform interface as
+ * it is currently being used by the ESP/WiFi bridge.
+ */
+bool SPI_LL_default_config(SPI_LL_Bus bus, SPI_LL_Config *config);
+
+bool SPI_LL_init(SPI_LL_Bus bus, SPI_LL_Config const *config);
+void SPI_LL_deinit(SPI_LL_Bus bus);
+bool SPI_LL_is_initialized(SPI_LL_Bus bus);
+uint32_t SPI_LL_get_rate(SPI_LL_Bus bus);
+SPI_LL_Mode SPI_LL_get_mode(SPI_LL_Bus bus);
+SPI_LL_BitOrder SPI_LL_get_bit_order(SPI_LL_Bus bus);
+
+bool SPI_LL_select(SPI_LL_Bus bus);
+void SPI_LL_deselect(SPI_LL_Bus bus);
+bool SPI_LL_is_selected(SPI_LL_Bus bus);
+
+int32_t SPI_LL_transfer(
+    SPI_LL_Bus bus,
+    uint8_t const *tx_data,
+    uint8_t *rx_data,
+    size_t len
+);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/system/bus/spi.c
+++ b/src/system/bus/spi.c
@@ -1,0 +1,265 @@
+/**
+ * @file spi.c
+ * @brief Hardware-independent SPI bus implementation.
+ */
+
+#include "system/bus/spi.h"
+
+#include <stdlib.h>
+
+#include "platform/spi_ll.h"
+
+struct SPI_Handle {
+    SPI_LL_Bus bus;
+    uint8_t dummy_byte;
+    bool initialized;
+};
+
+static SPI_Handle *active_handles[SPI_LL_BUS_COUNT];
+
+static bool valid_bus(uint32_t bus) { return bus == SPI_DEFAULT_BUS; }
+
+static bool valid_mode(SPI_Mode mode) { return mode <= SPI_MODE_3; }
+
+static bool valid_bit_order(SPI_BitOrder bit_order)
+{
+    return bit_order <= SPI_BIT_ORDER_LSB_FIRST;
+}
+
+static SPI_LL_Mode to_ll_mode(SPI_Mode mode) { return (SPI_LL_Mode)mode; }
+
+static SPI_Mode from_ll_mode(SPI_LL_Mode mode) { return (SPI_Mode)mode; }
+
+static SPI_LL_BitOrder to_ll_bit_order(SPI_BitOrder bit_order)
+{
+    return (SPI_LL_BitOrder)bit_order;
+}
+
+static SPI_BitOrder from_ll_bit_order(SPI_LL_BitOrder bit_order)
+{
+    return (SPI_BitOrder)bit_order;
+}
+
+size_t SPI_get_bus_count(void) { return SPI_LL_BUS_COUNT; }
+
+bool SPI_default_config(uint32_t bus, SPI_Config *config)
+{
+    if (!valid_bus(bus) || !config) {
+        return false;
+    }
+
+    SPI_LL_Config ll_config;
+    if (!SPI_LL_default_config((SPI_LL_Bus)bus, &ll_config)) {
+        return false;
+    }
+
+    *config = (SPI_Config){
+        .bus = bus,
+        .sck_gpio = ll_config.sck_gpio,
+        .tx_gpio = ll_config.tx_gpio,
+        .rx_gpio = ll_config.rx_gpio,
+        .cs_gpio = ll_config.cs_gpio,
+        .rate_hz = ll_config.rate_hz,
+        .mode = from_ll_mode(ll_config.mode),
+        .bit_order = from_ll_bit_order(ll_config.bit_order),
+        .dummy_byte = SPI_DEFAULT_DUMMY_BYTE,
+        .cs_active_low = ll_config.cs_active_low,
+    };
+    return true;
+}
+
+SPI_Handle *SPI_init(SPI_Config const *config)
+{
+    if (!config || !valid_bus(config->bus) || config->rate_hz == 0 ||
+        !valid_mode(config->mode) || !valid_bit_order(config->bit_order) ||
+        active_handles[config->bus]) {
+        return NULL;
+    }
+
+    SPI_Handle *handle = malloc(sizeof(*handle));
+    if (!handle) {
+        return NULL;
+    }
+
+    SPI_LL_Config ll_config = {
+        .sck_gpio = config->sck_gpio,
+        .tx_gpio = config->tx_gpio,
+        .rx_gpio = config->rx_gpio,
+        .cs_gpio = config->cs_gpio,
+        .rate_hz = config->rate_hz,
+        .mode = to_ll_mode(config->mode),
+        .bit_order = to_ll_bit_order(config->bit_order),
+        .cs_active_low = config->cs_active_low,
+    };
+
+    if (!SPI_LL_init((SPI_LL_Bus)config->bus, &ll_config)) {
+        free(handle);
+        return NULL;
+    }
+
+    *handle = (SPI_Handle){
+        .bus = (SPI_LL_Bus)config->bus,
+        .dummy_byte = config->dummy_byte,
+        .initialized = true,
+    };
+    active_handles[config->bus] = handle;
+    return handle;
+}
+
+void SPI_deinit(SPI_Handle *handle)
+{
+    if (!handle || !handle->initialized) {
+        return;
+    }
+
+    SPI_LL_Bus bus = handle->bus;
+    SPI_LL_deinit(bus);
+    if (valid_bus(bus) && active_handles[bus] == handle) {
+        active_handles[bus] = NULL;
+    }
+
+    handle->initialized = false;
+    free(handle);
+}
+
+bool SPI_is_ready(SPI_Handle const *handle)
+{
+    return handle && handle->initialized &&
+           SPI_LL_is_initialized(handle->bus);
+}
+
+uint32_t SPI_get_bus(SPI_Handle const *handle)
+{
+    return SPI_is_ready(handle) ? (uint32_t)handle->bus : SPI_LL_BUS_COUNT;
+}
+
+uint32_t SPI_get_rate(SPI_Handle const *handle)
+{
+    return SPI_is_ready(handle) ? SPI_LL_get_rate(handle->bus) : 0;
+}
+
+SPI_Mode SPI_get_mode(SPI_Handle const *handle)
+{
+    return SPI_is_ready(handle) ? from_ll_mode(SPI_LL_get_mode(handle->bus))
+                                : SPI_MODE_0;
+}
+
+SPI_BitOrder SPI_get_bit_order(SPI_Handle const *handle)
+{
+    return SPI_is_ready(handle)
+               ? from_ll_bit_order(SPI_LL_get_bit_order(handle->bus))
+               : SPI_BIT_ORDER_MSB_FIRST;
+}
+
+uint8_t SPI_get_dummy_byte(SPI_Handle const *handle)
+{
+    return SPI_is_ready(handle) ? handle->dummy_byte : SPI_DEFAULT_DUMMY_BYTE;
+}
+
+int32_t SPI_exchange(
+    SPI_Handle *handle,
+    uint8_t const *tx_data,
+    uint8_t *rx_data,
+    size_t len
+)
+{
+    if (!SPI_is_ready(handle) || !tx_data || !rx_data || len == 0) {
+        return -1;
+    }
+
+    if (!SPI_LL_select(handle->bus)) {
+        return -1;
+    }
+
+    int32_t result = SPI_LL_transfer(
+        handle->bus,
+        tx_data,
+        rx_data,
+        len,
+        handle->dummy_byte
+    );
+    SPI_LL_deselect(handle->bus);
+    return result;
+}
+
+int32_t SPI_write(SPI_Handle *handle, uint8_t const *data, size_t len)
+{
+    if (!SPI_is_ready(handle) || !data || len == 0) {
+        return -1;
+    }
+
+    if (!SPI_LL_select(handle->bus)) {
+        return -1;
+    }
+
+    int32_t result = SPI_LL_transfer(
+        handle->bus,
+        data,
+        NULL,
+        len,
+        handle->dummy_byte
+    );
+    SPI_LL_deselect(handle->bus);
+    return result;
+}
+
+int32_t SPI_read(SPI_Handle *handle, uint8_t *data, size_t len)
+{
+    if (!SPI_is_ready(handle) || !data || len == 0) {
+        return -1;
+    }
+
+    if (!SPI_LL_select(handle->bus)) {
+        return -1;
+    }
+
+    int32_t result = SPI_LL_transfer(
+        handle->bus,
+        NULL,
+        data,
+        len,
+        handle->dummy_byte
+    );
+    SPI_LL_deselect(handle->bus);
+    return result;
+}
+
+int32_t SPI_transact(
+    SPI_Handle *handle,
+    uint8_t const *tx_data,
+    size_t tx_len,
+    uint8_t *rx_data,
+    size_t rx_len
+)
+{
+    if (!SPI_is_ready(handle) || !tx_data || tx_len == 0 || !rx_data ||
+        rx_len == 0) {
+        return -1;
+    }
+
+    if (!SPI_LL_select(handle->bus)) {
+        return -1;
+    }
+
+    int32_t written = SPI_LL_transfer(
+        handle->bus,
+        tx_data,
+        NULL,
+        tx_len,
+        handle->dummy_byte
+    );
+    if (written < 0 || (size_t)written != tx_len) {
+        SPI_LL_deselect(handle->bus);
+        return -1;
+    }
+
+    int32_t read = SPI_LL_transfer(
+        handle->bus,
+        NULL,
+        rx_data,
+        rx_len,
+        handle->dummy_byte
+    );
+    SPI_LL_deselect(handle->bus);
+    return read;
+}

--- a/src/system/bus/spi.h
+++ b/src/system/bus/spi.h
@@ -1,0 +1,117 @@
+/**
+ * @file spi.h
+ * @brief Hardware-independent SPI bus interface.
+ *
+ * This layer owns SPI handles and bus lifetime. Application code should use
+ * this API rather than calling the platform SPI layer directly.
+ */
+
+#ifndef PSLAB_SYSTEM_BUS_SPI_H
+#define PSLAB_SYSTEM_BUS_SPI_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct SPI_Handle SPI_Handle;
+
+typedef enum {
+    SPI_MODE_0 = 0,
+    SPI_MODE_1 = 1,
+    SPI_MODE_2 = 2,
+    SPI_MODE_3 = 3,
+} SPI_Mode;
+
+typedef enum {
+    SPI_BIT_ORDER_MSB_FIRST = 0,
+    SPI_BIT_ORDER_LSB_FIRST = 1,
+} SPI_BitOrder;
+
+typedef struct {
+    uint32_t bus;
+    uint32_t sck_gpio;
+    uint32_t tx_gpio;
+    uint32_t rx_gpio;
+    uint32_t cs_gpio;
+    uint32_t rate_hz;
+    SPI_Mode mode;
+    SPI_BitOrder bit_order;
+    uint8_t dummy_byte;
+    bool cs_active_low;
+} SPI_Config;
+
+enum {
+    SPI_DEFAULT_BUS = 1,
+    SPI_DEFAULT_RATE_HZ = 1000000,
+    SPI_DEFAULT_DUMMY_BYTE = 0xff,
+};
+
+size_t SPI_get_bus_count(void);
+bool SPI_default_config(uint32_t bus, SPI_Config *config);
+
+SPI_Handle *SPI_init(SPI_Config const *config);
+void SPI_deinit(SPI_Handle *handle);
+
+bool SPI_is_ready(SPI_Handle const *handle);
+uint32_t SPI_get_bus(SPI_Handle const *handle);
+uint32_t SPI_get_rate(SPI_Handle const *handle);
+SPI_Mode SPI_get_mode(SPI_Handle const *handle);
+SPI_BitOrder SPI_get_bit_order(SPI_Handle const *handle);
+uint8_t SPI_get_dummy_byte(SPI_Handle const *handle);
+
+/**
+ * @brief Full-duplex SPI exchange.
+ *
+ * Keeps CS asserted for the entire transfer.
+ *
+ * @return Number of bytes exchanged on success, or a negative value on error.
+ */
+int32_t SPI_exchange(
+    SPI_Handle *handle,
+    uint8_t const *tx_data,
+    uint8_t *rx_data,
+    size_t len
+);
+
+/**
+ * @brief Write bytes while discarding received bytes.
+ *
+ * Keeps CS asserted for the entire transfer.
+ *
+ * @return Number of bytes written on success, or a negative value on error.
+ */
+int32_t SPI_write(SPI_Handle *handle, uint8_t const *data, size_t len);
+
+/**
+ * @brief Read bytes while sending the handle's configured dummy byte.
+ *
+ * Keeps CS asserted for the entire transfer.
+ *
+ * @return Number of bytes read on success, or a negative value on error.
+ */
+int32_t SPI_read(SPI_Handle *handle, uint8_t *data, size_t len);
+
+/**
+ * @brief Write a command/prefix and then read a response under one CS window.
+ *
+ * This is the common register-read pattern for SPI sensors.
+ *
+ * @return Number of bytes read on success, or a negative value on error.
+ */
+int32_t SPI_transact(
+    SPI_Handle *handle,
+    uint8_t const *tx_data,
+    size_t tx_len,
+    uint8_t *rx_data,
+    size_t rx_len
+);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
Adds the application layer for the SPI bus gateway. Follows up on #204 and working on #203.

Commands added:
```
BUS:SPI:OPEN
BUS:SPI:OPEN?
BUS:SPI:CLOSe
BUS:SPI:CONFigure:BUS
BUS:SPI:CONFigure:BUS?
BUS:SPI:CONFigure:RATE
BUS:SPI:CONFigure:RATE?
BUS:SPI:CONFigure:MODE
BUS:SPI:CONFigure:MODE?
BUS:SPI:CONFigure:DUMMY
BUS:SPI:CONFigure:DUMMY?
BUS:SPI:WRITe
BUS:SPI:READ?
BUS:SPI:EXCHange?
BUS:SPI:TRANsact?
```
Defaults:

- SPI1 only
- 1 MHz
- mode 0
- dummy byte 0xff
- max transfer 512 bytes

PR is stacked on #204. Actual PR size is about 500 lines. Will rebase as previous prs are merged.