### PR TITLE
feat: add adc frontend interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,10 +25,12 @@ target_sources(pslab_pico PRIVATE
         src/application/logic_analyser_commands.c
         src/application/dso_commands.c
         src/application/mixed_signal_commands.c
+        src/system/instrument/adc_frontend.c
         src/system/instrument/dso.c
         src/system/instrument/mixed_signal.c
         src/system/pattern_generator.c
         src/platform/adc_capture.c
+        src/platform/internal_adc_frontend.c
         src/platform/i2c_ll.c
         src/platform/logic_analyser_ll.c
         src/platform/pattern_output_ll.c

--- a/src/platform/internal_adc_frontend.c
+++ b/src/platform/internal_adc_frontend.c
@@ -1,0 +1,123 @@
+#include "platform/internal_adc_frontend.h"
+
+#include "platform/adc_capture.h"
+#include "system/instrument/adc_frontend.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+enum {
+    INTERNAL_ADC_MAX_SAMPLE_COUNT = 4096,
+};
+
+static AdcCaptureConfig to_capture_config(AdcFrontendConfig const *config)
+{
+    return (AdcCaptureConfig){
+        .channel = config->channel,
+        .sample_rate_hz = config->sample_rate_hz,
+    };
+}
+
+static void to_frontend_info(
+    AdcCaptureInfo const *capture_info,
+    AdcFrontendCaptureInfo *frontend_info
+)
+{
+    if (!capture_info || !frontend_info) {
+        return;
+    }
+
+    *frontend_info = (AdcFrontendCaptureInfo){
+        .backend = ADC_FRONTEND_BACKEND_INTERNAL,
+        .channel = capture_info->channel,
+        .gpio = capture_info->gpio,
+        .sample_rate_hz = capture_info->sample_rate_hz,
+        .sample_count = capture_info->sample_count,
+        .sample_width_bits = 12,
+    };
+}
+
+static bool internal_init(AdcFrontendConfig const *config)
+{
+    if (!config || config->backend != ADC_FRONTEND_BACKEND_INTERNAL) {
+        return false;
+    }
+
+    AdcCaptureConfig capture_config = to_capture_config(config);
+    return adc_capture_init(&capture_config);
+}
+
+static void internal_deinit(void)
+{
+    adc_capture_deinit();
+}
+
+static bool internal_configure(AdcFrontendConfig const *config)
+{
+    if (!config || config->backend != ADC_FRONTEND_BACKEND_INTERNAL) {
+        return false;
+    }
+
+    AdcCaptureConfig capture_config = to_capture_config(config);
+    return adc_capture_configure(&capture_config);
+}
+
+static bool internal_run(
+    uint16_t *buffer,
+    uint32_t sample_count,
+    AdcFrontendCaptureInfo *info
+)
+{
+    AdcCaptureInfo capture_info;
+    if (!adc_capture_run(buffer, sample_count, &capture_info)) {
+        return false;
+    }
+
+    to_frontend_info(&capture_info, info);
+    return true;
+}
+
+static bool internal_arm(
+    uint16_t *buffer,
+    uint32_t sample_count,
+    AdcFrontendCaptureInfo *info
+)
+{
+    AdcCaptureInfo capture_info;
+    if (!adc_capture_arm(buffer, sample_count, &capture_info)) {
+        return false;
+    }
+
+    to_frontend_info(&capture_info, info);
+    return true;
+}
+
+static AdcFrontendDriver const internal_driver = {
+    .backend = ADC_FRONTEND_BACKEND_INTERNAL,
+    .name = "internal",
+    .capabilities = {
+        .backend = ADC_FRONTEND_BACKEND_INTERNAL,
+        .name = "internal",
+        .max_channel = ADC_CAPTURE_MAX_CHANNEL,
+        .min_sample_rate_hz = ADC_CAPTURE_MIN_SAMPLE_RATE_HZ,
+        .max_sample_rate_hz = ADC_CAPTURE_MAX_SAMPLE_RATE_HZ,
+        .max_sample_count = INTERNAL_ADC_MAX_SAMPLE_COUNT,
+        .sample_width_bits = 12,
+    },
+    .init = internal_init,
+    .deinit = internal_deinit,
+    .configure = internal_configure,
+    .run = internal_run,
+    .arm = internal_arm,
+    .start = adc_capture_start,
+    .wait = adc_capture_wait,
+    .abort = adc_capture_abort,
+    .read_once = adc_capture_read_once,
+    .is_busy = adc_capture_is_busy,
+    .channel_to_gpio = adc_capture_channel_to_gpio,
+};
+
+void internal_adc_frontend_register(void)
+{
+    (void)adc_frontend_register_driver(&internal_driver);
+}

--- a/src/platform/internal_adc_frontend.h
+++ b/src/platform/internal_adc_frontend.h
@@ -1,0 +1,6 @@
+#ifndef INTERNAL_ADC_FRONTEND_H
+#define INTERNAL_ADC_FRONTEND_H
+
+void internal_adc_frontend_register(void);
+
+#endif

--- a/src/platform/platform.c
+++ b/src/platform/platform.c
@@ -12,11 +12,13 @@
 #include "hardware/watchdog.h"
 #include "pico/stdlib.h"
 
+#include "platform/internal_adc_frontend.h"
 #include "platform.h"
 
 void PLATFORM_init(void)
 {
     /* Pico SDK runtime performs the core clock/runtime setup before main(). */
+    internal_adc_frontend_register();
 }
 
 uint32_t PLATFORM_get_tick(void)

--- a/src/system/instrument/adc_frontend.c
+++ b/src/system/instrument/adc_frontend.c
@@ -1,0 +1,235 @@
+#include "system/instrument/adc_frontend.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+enum {
+    ADC_FRONTEND_MAX_DRIVERS = 2,
+};
+
+static AdcFrontendDriver const *drivers[ADC_FRONTEND_MAX_DRIVERS];
+static AdcFrontendDriver const *active_driver;
+static bool initialized;
+static AdcFrontendCaptureInfo last_info;
+static AdcFrontendCompleteCallback complete_callback;
+static void *complete_user_data;
+
+static AdcFrontendDriver const *find_driver(AdcFrontendBackend backend)
+{
+    for (size_t i = 0; i < ADC_FRONTEND_MAX_DRIVERS; ++i) {
+        if (drivers[i] && drivers[i]->backend == backend) {
+            return drivers[i];
+        }
+    }
+
+    return NULL;
+}
+
+static bool driver_is_valid(AdcFrontendDriver const *driver)
+{
+    return driver && driver->backend != ADC_FRONTEND_BACKEND_NONE &&
+           driver->name && driver->init && driver->deinit &&
+           driver->configure && driver->run && driver->arm &&
+           driver->start && driver->wait && driver->abort &&
+           driver->read_once && driver->is_busy && driver->channel_to_gpio &&
+           driver->capabilities.max_sample_count > 0;
+}
+
+static void notify_complete(void)
+{
+    if (complete_callback) {
+        complete_callback(&last_info, complete_user_data);
+    }
+}
+
+static bool sample_count_is_valid(uint32_t sample_count)
+{
+    return sample_count > 0 &&
+           active_driver &&
+           sample_count <= active_driver->capabilities.max_sample_count;
+}
+
+bool adc_frontend_register_driver(AdcFrontendDriver const *driver)
+{
+    if (!driver_is_valid(driver) || find_driver(driver->backend)) {
+        return false;
+    }
+
+    for (size_t i = 0; i < ADC_FRONTEND_MAX_DRIVERS; ++i) {
+        if (!drivers[i]) {
+            drivers[i] = driver;
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool adc_frontend_select_backend(AdcFrontendBackend backend)
+{
+    AdcFrontendDriver const *driver = find_driver(backend);
+    if (!driver) {
+        return false;
+    }
+
+    if (active_driver == driver) {
+        return true;
+    }
+
+    if (initialized && active_driver) {
+        active_driver->deinit();
+    }
+
+    active_driver = driver;
+    initialized = false;
+    memset(&last_info, 0, sizeof(last_info));
+    return true;
+}
+
+AdcFrontendBackend adc_frontend_get_backend(void)
+{
+    return active_driver ? active_driver->backend : ADC_FRONTEND_BACKEND_NONE;
+}
+
+bool adc_frontend_get_capabilities(
+    AdcFrontendBackend backend,
+    AdcFrontendCapabilities *capabilities
+)
+{
+    AdcFrontendDriver const *driver = find_driver(backend);
+    if (!driver || !capabilities) {
+        return false;
+    }
+
+    *capabilities = driver->capabilities;
+    return true;
+}
+
+bool adc_frontend_init(AdcFrontendConfig const *config)
+{
+    if (!config || !adc_frontend_select_backend(config->backend)) {
+        return false;
+    }
+
+    initialized = active_driver->init(config);
+    return initialized;
+}
+
+void adc_frontend_deinit(void)
+{
+    if (initialized && active_driver) {
+        active_driver->deinit();
+    }
+
+    initialized = false;
+    memset(&last_info, 0, sizeof(last_info));
+}
+
+bool adc_frontend_configure(AdcFrontendConfig const *config)
+{
+    if (!config) {
+        return false;
+    }
+
+    if (!adc_frontend_select_backend(config->backend)) {
+        return false;
+    }
+
+    if (!initialized) {
+        return adc_frontend_init(config);
+    }
+
+    return active_driver->configure(config);
+}
+
+bool adc_frontend_run(
+    uint16_t *buffer,
+    uint32_t sample_count,
+    AdcFrontendCaptureInfo *info
+)
+{
+    if (!initialized || !active_driver || !sample_count_is_valid(sample_count)) {
+        return false;
+    }
+
+    bool complete = active_driver->run(buffer, sample_count, &last_info);
+    if (!complete) {
+        return false;
+    }
+
+    if (info) {
+        *info = last_info;
+    }
+    notify_complete();
+    return true;
+}
+
+bool adc_frontend_arm(
+    uint16_t *buffer,
+    uint32_t sample_count,
+    AdcFrontendCaptureInfo *info
+)
+{
+    if (!initialized || !active_driver || !sample_count_is_valid(sample_count)) {
+        return false;
+    }
+
+    bool armed = active_driver->arm(buffer, sample_count, &last_info);
+    if (armed && info) {
+        *info = last_info;
+    }
+
+    return armed;
+}
+
+bool adc_frontend_start(void)
+{
+    return initialized && active_driver && active_driver->start();
+}
+
+bool adc_frontend_wait(void)
+{
+    if (!initialized || !active_driver || !active_driver->wait()) {
+        return false;
+    }
+
+    notify_complete();
+    return true;
+}
+
+void adc_frontend_abort(void)
+{
+    if (initialized && active_driver) {
+        active_driver->abort();
+    }
+}
+
+bool adc_frontend_read_once(uint16_t *sample)
+{
+    return initialized && active_driver && active_driver->read_once(sample);
+}
+
+bool adc_frontend_is_busy(void)
+{
+    return initialized && active_driver && active_driver->is_busy();
+}
+
+uint32_t adc_frontend_channel_to_gpio(
+    AdcFrontendBackend backend,
+    uint32_t channel
+)
+{
+    AdcFrontendDriver const *driver = find_driver(backend);
+    return driver ? driver->channel_to_gpio(channel) : 0;
+}
+
+void adc_frontend_set_complete_callback(
+    AdcFrontendCompleteCallback callback,
+    void *user_data
+)
+{
+    complete_callback = callback;
+    complete_user_data = user_data;
+}

--- a/src/system/instrument/adc_frontend.h
+++ b/src/system/instrument/adc_frontend.h
@@ -1,0 +1,227 @@
+#ifndef ADC_FRONTEND_H
+#define ADC_FRONTEND_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    ADC_FRONTEND_BACKEND_NONE = 0,
+    ADC_FRONTEND_BACKEND_INTERNAL = 1,
+    ADC_FRONTEND_BACKEND_EXTERNAL_PARALLEL = 2,
+} AdcFrontendBackend;
+
+/**
+ * @brief Static capability description for an ADC frontend backend.
+ *
+ * The driver owns any string pointers stored here. Callers receive a copy from
+ * adc_frontend_get_capabilities() and must not modify pointed-to storage.
+ */
+typedef struct {
+    AdcFrontendBackend backend;
+    char const *name;
+    uint32_t max_channel;
+    uint32_t min_sample_rate_hz;
+    uint32_t max_sample_rate_hz;
+    uint32_t max_sample_count;
+    uint32_t sample_width_bits;
+} AdcFrontendCapabilities;
+
+/**
+ * @brief ADC frontend runtime configuration.
+ */
+typedef struct {
+    AdcFrontendBackend backend;
+    uint32_t channel;
+    uint32_t sample_rate_hz;
+} AdcFrontendConfig;
+
+/**
+ * @brief Metadata describing a completed or armed frontend capture.
+ */
+typedef struct {
+    AdcFrontendBackend backend;
+    uint32_t channel;
+    uint32_t gpio;
+    uint32_t sample_rate_hz;
+    uint32_t sample_count;
+    uint32_t sample_width_bits;
+} AdcFrontendCaptureInfo;
+
+/**
+ * @brief Optional callback called after a capture finishes successfully.
+ *
+ * The callback pointer and user data are borrowed; they must remain valid until
+ * changed by adc_frontend_set_complete_callback().
+ */
+typedef void (*AdcFrontendCompleteCallback)(
+    AdcFrontendCaptureInfo const *info,
+    void *user_data
+);
+
+/**
+ * @brief Driver operations for an ADC frontend backend.
+ *
+ * The driver object and all pointed-to functions/storage must have static
+ * lifetime after registration. Buffer ownership always remains with the caller.
+ */
+typedef struct {
+    AdcFrontendBackend backend;
+    char const *name;
+    AdcFrontendCapabilities capabilities;
+    bool (*init)(AdcFrontendConfig const *config);
+    void (*deinit)(void);
+    bool (*configure)(AdcFrontendConfig const *config);
+    bool (*run)(
+        uint16_t *buffer,
+        uint32_t sample_count,
+        AdcFrontendCaptureInfo *info
+    );
+    bool (*arm)(
+        uint16_t *buffer,
+        uint32_t sample_count,
+        AdcFrontendCaptureInfo *info
+    );
+    bool (*start)(void);
+    bool (*wait)(void);
+    void (*abort)(void);
+    bool (*read_once)(uint16_t *sample);
+    bool (*is_busy)(void);
+    uint32_t (*channel_to_gpio)(uint32_t channel);
+} AdcFrontendDriver;
+
+/**
+ * @brief Register an ADC frontend driver.
+ *
+ * @return true when the driver was accepted, false for invalid, duplicate, or
+ *         full registry conditions.
+ */
+bool adc_frontend_register_driver(AdcFrontendDriver const *driver);
+
+/**
+ * @brief Select the active backend, deinitializing the previous active backend.
+ *
+ * @return true if the requested backend is registered.
+ */
+bool adc_frontend_select_backend(AdcFrontendBackend backend);
+
+/**
+ * @brief Get the currently selected backend.
+ */
+AdcFrontendBackend adc_frontend_get_backend(void);
+
+/**
+ * @brief Copy backend capabilities into the caller-provided struct.
+ *
+ * @return true if the backend exists and capabilities is not NULL.
+ */
+bool adc_frontend_get_capabilities(
+    AdcFrontendBackend backend,
+    AdcFrontendCapabilities *capabilities
+);
+
+/**
+ * @brief Initialize the selected backend using config.
+ *
+ * @return true on success. The backend from config becomes active.
+ */
+bool adc_frontend_init(AdcFrontendConfig const *config);
+
+/**
+ * @brief Deinitialize the active backend.
+ */
+void adc_frontend_deinit(void);
+
+/**
+ * @brief Configure the requested backend, initializing it if needed.
+ *
+ * @return true on success. The backend from config becomes active.
+ */
+bool adc_frontend_configure(AdcFrontendConfig const *config);
+
+/**
+ * @brief Run a complete blocking burst capture.
+ *
+ * The caller owns buffer and it must hold sample_count uint16_t samples.
+ * Optional info receives capture metadata.
+ *
+ * @return true if the capture completed successfully.
+ */
+bool adc_frontend_run(
+    uint16_t *buffer,
+    uint32_t sample_count,
+    AdcFrontendCaptureInfo *info
+);
+
+/**
+ * @brief Arm a burst capture without starting it.
+ *
+ * The caller owns buffer and must keep it valid until wait/abort completes.
+ * Optional info receives armed capture metadata.
+ *
+ * @return true when the backend is armed.
+ */
+bool adc_frontend_arm(
+    uint16_t *buffer,
+    uint32_t sample_count,
+    AdcFrontendCaptureInfo *info
+);
+
+/**
+ * @brief Start a previously armed capture.
+ *
+ * @return true if the backend started.
+ */
+bool adc_frontend_start(void);
+
+/**
+ * @brief Wait for the active capture to complete.
+ *
+ * @return true if the capture completed successfully.
+ */
+bool adc_frontend_wait(void);
+
+/**
+ * @brief Abort an active or armed capture.
+ */
+void adc_frontend_abort(void);
+
+/**
+ * @brief Read one immediate sample from the active backend.
+ *
+ * @return true if sample was written.
+ */
+bool adc_frontend_read_once(uint16_t *sample);
+
+/**
+ * @brief Query whether the active backend is busy.
+ */
+bool adc_frontend_is_busy(void);
+
+/**
+ * @brief Convert a backend channel index to a physical GPIO when applicable.
+ *
+ * @return GPIO number, or 0 if the backend is unknown.
+ */
+uint32_t adc_frontend_channel_to_gpio(
+    AdcFrontendBackend backend,
+    uint32_t channel
+);
+
+/**
+ * @brief Set the optional successful-capture callback.
+ */
+void adc_frontend_set_complete_callback(
+    AdcFrontendCompleteCallback callback,
+    void *user_data
+);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/system/instrument/dso.c
+++ b/src/system/instrument/dso.c
@@ -5,7 +5,7 @@
  * This file ports the PSLab DSO instrument layer to RP2350. The STM32 firmware
  * used ADC_LL and TIM_LL for timer-triggered acquisition; this Pico port keeps
  * the instrument-level DSO responsibility and delegates low-level ADC capture
- * to platform/adc_capture.
+ * to the ADC frontend interface.
  *
  * @author PSLab Team
  * @date 2025-09-29
@@ -16,9 +16,9 @@
 #include <stdbool.h>
 #include <string.h>
 
-#include "platform/adc_capture.h"
 #include "platform/platform.h"
 #include "platform/status_led.h"
+#include "system/instrument/adc_frontend.h"
 
 enum {
     DSO_DEFAULT_CHANNEL = 0,
@@ -54,9 +54,14 @@ static struct {
 
 static bool config_is_valid(void)
 {
-    return state.channel <= ADC_CAPTURE_MAX_CHANNEL &&
-           state.sample_rate_hz >= ADC_CAPTURE_MIN_SAMPLE_RATE_HZ &&
-           state.sample_rate_hz <= ADC_CAPTURE_MAX_SAMPLE_RATE_HZ &&
+    AdcFrontendCapabilities capabilities;
+    return adc_frontend_get_capabilities(
+               ADC_FRONTEND_BACKEND_INTERNAL,
+               &capabilities
+           ) &&
+           state.channel <= capabilities.max_channel &&
+           state.sample_rate_hz >= capabilities.min_sample_rate_hz &&
+           state.sample_rate_hz <= capabilities.max_sample_rate_hz &&
            state.samples >= 1 && state.samples <= DSO_MAX_SAMPLES;
 }
 
@@ -66,17 +71,26 @@ static bool apply_config(void)
         return false;
     }
 
-    AdcCaptureConfig config = {
+    AdcFrontendConfig config = {
+        .backend = ADC_FRONTEND_BACKEND_INTERNAL,
         .channel = state.channel,
         .sample_rate_hz = state.sample_rate_hz,
     };
 
     if (adc_initialized) {
-        return adc_capture_configure(&config);
+        return adc_frontend_configure(&config);
     }
 
-    adc_initialized = adc_capture_init(&config);
+    adc_initialized = adc_frontend_init(&config);
     return adc_initialized;
+}
+
+static bool internal_adc_capabilities(AdcFrontendCapabilities *capabilities)
+{
+    return adc_frontend_get_capabilities(
+        ADC_FRONTEND_BACKEND_INTERNAL,
+        capabilities
+    );
 }
 
 static bool set_and_maybe_reconfigure(
@@ -109,7 +123,7 @@ void dso_reset_state(void)
     dso_stream_stop();
 
     if (adc_initialized) {
-        adc_capture_deinit();
+        adc_frontend_deinit();
     }
 
     adc_initialized = false;
@@ -126,18 +140,32 @@ void dso_reset_state(void)
 
 bool dso_set_channel(uint32_t value)
 {
+    AdcFrontendCapabilities capabilities;
+    if (!internal_adc_capabilities(&capabilities)) {
+        return false;
+    }
+
     return set_and_maybe_reconfigure(
-        &state.channel, value, 0, ADC_CAPTURE_MAX_CHANNEL, true
+        &state.channel,
+        value,
+        0,
+        capabilities.max_channel,
+        true
     );
 }
 
 bool dso_set_sample_rate(uint32_t value)
 {
+    AdcFrontendCapabilities capabilities;
+    if (!internal_adc_capabilities(&capabilities)) {
+        return false;
+    }
+
     return set_and_maybe_reconfigure(
         &state.sample_rate_hz,
         value,
-        ADC_CAPTURE_MIN_SAMPLE_RATE_HZ,
-        ADC_CAPTURE_MAX_SAMPLE_RATE_HZ,
+        capabilities.min_sample_rate_hz,
+        capabilities.max_sample_rate_hz,
         true
     );
 }
@@ -181,7 +209,13 @@ bool dso_set_trigger_slope(DsoTriggerSlope slope)
 
 uint32_t dso_get_channel(void) { return state.channel; }
 
-uint32_t dso_get_gpio(void) { return adc_capture_channel_to_gpio(state.channel); }
+uint32_t dso_get_gpio(void)
+{
+    return adc_frontend_channel_to_gpio(
+        ADC_FRONTEND_BACKEND_INTERNAL,
+        state.channel
+    );
+}
 
 uint32_t dso_get_sample_rate(void) { return state.sample_rate_hz; }
 
@@ -224,7 +258,7 @@ static bool wait_for_trigger_timeout(uint32_t timeout_us)
             if (trigger_wait_timed_out(use_timeout, deadline_us)) {
                 return false;
             }
-            if (!adc_capture_read_once(&sample)) {
+            if (!adc_frontend_read_once(&sample)) {
                 return false;
             }
             PLATFORM_idle();
@@ -237,7 +271,7 @@ static bool wait_for_trigger_timeout(uint32_t timeout_us)
         if (trigger_wait_timed_out(use_timeout, deadline_us)) {
             return false;
         }
-        if (!adc_capture_read_once(&sample)) {
+        if (!adc_frontend_read_once(&sample)) {
             return false;
         }
 
@@ -260,16 +294,16 @@ bool dso_initiate(void)
 {
     dso_stream_stop();
 
-    if (!adc_initialized && !apply_config()) {
+    if (!apply_config()) {
         return false;
     }
 
     memset(capture_buffer, 0, state.samples * sizeof(capture_buffer[0]));
 
     status_led_capture_started();
-    AdcCaptureInfo info;
+    AdcFrontendCaptureInfo info;
     bool captured = wait_for_trigger() &&
-                    adc_capture_run(capture_buffer, state.samples, &info);
+                    adc_frontend_run(capture_buffer, state.samples, &info);
     status_led_capture_finished();
 
     if (!captured) {
@@ -299,7 +333,7 @@ bool dso_fetch(uint8_t const **data, size_t *len)
 
 uint32_t dso_status(void)
 {
-    if (stream_enabled || adc_capture_is_busy()) {
+    if (stream_enabled || adc_frontend_is_busy()) {
         return 2;
     }
 
@@ -310,7 +344,7 @@ bool dso_stream_start(void)
 {
     dso_stream_stop();
 
-    if (!adc_initialized && !apply_config()) {
+    if (!apply_config()) {
         ++stream_overruns;
         return false;
     }
@@ -343,9 +377,9 @@ bool dso_stream_next_frame(uint8_t const **data, size_t *len, uint32_t *sequence
         return false;
     }
 
-    AdcCaptureInfo info;
+    AdcFrontendCaptureInfo info;
     bool captured = wait_for_trigger_timeout(DSO_STREAM_TRIGGER_TIMEOUT_US) &&
-                    adc_capture_run(capture_buffer, state.samples, &info);
+                    adc_frontend_run(capture_buffer, state.samples, &info);
     if (!captured) {
         ++stream_overruns;
         return false;

--- a/src/system/instrument/mixed_signal.c
+++ b/src/system/instrument/mixed_signal.c
@@ -3,9 +3,9 @@
 #include <stddef.h>
 #include <string.h>
 
-#include "platform/adc_capture.h"
 #include "platform/platform.h"
 #include "platform/status_led.h"
+#include "system/instrument/adc_frontend.h"
 
 enum {
     MIXED_SIGNAL_DEFAULT_DIGITAL_PIN_BASE = 16,
@@ -59,10 +59,15 @@ static bool digital_pins_are_valid(void)
 
 static bool config_is_valid(void)
 {
+    AdcFrontendCapabilities capabilities;
     return digital_pins_are_valid() &&
-           state.analog_channel <= ADC_CAPTURE_MAX_CHANNEL &&
-           state.sample_rate_hz >= ADC_CAPTURE_MIN_SAMPLE_RATE_HZ &&
-           state.sample_rate_hz <= ADC_CAPTURE_MAX_SAMPLE_RATE_HZ &&
+           adc_frontend_get_capabilities(
+               ADC_FRONTEND_BACKEND_INTERNAL,
+               &capabilities
+           ) &&
+           state.analog_channel <= capabilities.max_channel &&
+           state.sample_rate_hz >= capabilities.min_sample_rate_hz &&
+           state.sample_rate_hz <= capabilities.max_sample_rate_hz &&
            state.samples >= 1 && state.samples <= MIXED_SIGNAL_MAX_SAMPLES &&
            state.trigger_pin <= MIXED_SIGNAL_MAX_GPIO_PIN;
 }
@@ -90,7 +95,8 @@ static bool apply_config(void)
         .clk_div = logic_analyser_clock_divider(),
     };
 
-    AdcCaptureConfig adc_config = {
+    AdcFrontendConfig adc_config = {
+        .backend = ADC_FRONTEND_BACKEND_INTERNAL,
         .channel = state.analog_channel,
         .sample_rate_hz = state.sample_rate_hz,
     };
@@ -109,8 +115,8 @@ static bool apply_config(void)
     }
     logic_analyser_initialized = true;
 
-    bool adc_ready = adc_initialized ? adc_capture_configure(&adc_config)
-                                     : adc_capture_init(&adc_config);
+    bool adc_ready = adc_initialized ? adc_frontend_configure(&adc_config)
+                                     : adc_frontend_init(&adc_config);
     if (!adc_ready) {
         return false;
     }
@@ -150,7 +156,7 @@ void mixed_signal_reset_state(void)
         logic_analyser_deinit(&logic_analyser);
     }
     if (adc_initialized) {
-        adc_capture_deinit();
+        adc_frontend_deinit();
     }
 
     logic_analyser_initialized = false;
@@ -190,22 +196,38 @@ bool mixed_signal_set_digital_pin_count(uint32_t value)
 
 bool mixed_signal_set_analog_channel(uint32_t value)
 {
+    AdcFrontendCapabilities capabilities;
+    if (!adc_frontend_get_capabilities(
+            ADC_FRONTEND_BACKEND_INTERNAL,
+            &capabilities
+        )) {
+        return false;
+    }
+
     return set_and_maybe_reconfigure(
         &state.analog_channel,
         value,
         0,
-        ADC_CAPTURE_MAX_CHANNEL,
+        capabilities.max_channel,
         true
     );
 }
 
 bool mixed_signal_set_sample_rate(uint32_t value)
 {
+    AdcFrontendCapabilities capabilities;
+    if (!adc_frontend_get_capabilities(
+            ADC_FRONTEND_BACKEND_INTERNAL,
+            &capabilities
+        )) {
+        return false;
+    }
+
     return set_and_maybe_reconfigure(
         &state.sample_rate_hz,
         value,
-        ADC_CAPTURE_MIN_SAMPLE_RATE_HZ,
-        ADC_CAPTURE_MAX_SAMPLE_RATE_HZ,
+        capabilities.min_sample_rate_hz,
+        capabilities.max_sample_rate_hz,
         true
     );
 }
@@ -278,7 +300,7 @@ MixedSignalCaptureInfo const *mixed_signal_get_last_info(void)
 
 bool mixed_signal_initiate(void)
 {
-    if ((!logic_analyser_initialized || !adc_initialized) && !apply_config()) {
+    if (!apply_config()) {
         return false;
     }
 
@@ -296,9 +318,9 @@ bool mixed_signal_initiate(void)
     memset(digital_buffer, 0, digital_word_count * sizeof(digital_buffer[0]));
     memset(analog_buffer, 0, state.samples * sizeof(analog_buffer[0]));
 
-    AdcCaptureInfo adc_info;
+    AdcFrontendCaptureInfo adc_info;
     LogicAnalyserCaptureInfo logic_info;
-    if (!adc_capture_arm(analog_buffer, state.samples, &adc_info)) {
+    if (!adc_frontend_arm(analog_buffer, state.samples, &adc_info)) {
         return false;
     }
 
@@ -313,7 +335,7 @@ bool mixed_signal_initiate(void)
         false
     );
     if (!logic_armed) {
-        adc_capture_abort();
+        adc_frontend_abort();
         return false;
     }
 
@@ -325,24 +347,24 @@ bool mixed_signal_initiate(void)
         MIXED_SIGNAL_TRIGGER_TIMEOUT_US
     );
     if (!triggered) {
-        adc_capture_abort();
+        adc_frontend_abort();
         logic_analyser_capture_abort(&logic_analyser);
         status_led_capture_finished();
         capture_valid = false;
         return false;
     }
 
-    bool adc_started = adc_capture_start();
+    bool adc_started = adc_frontend_start();
     bool logic_started = logic_analyser_capture_start_armed(&logic_analyser);
     if (!adc_started || !logic_started) {
-        adc_capture_abort();
+        adc_frontend_abort();
         logic_analyser_capture_abort(&logic_analyser);
         status_led_capture_finished();
         return false;
     }
 
     logic_analyser_capture_wait(&logic_analyser);
-    bool adc_completed = adc_capture_wait();
+    bool adc_completed = adc_frontend_wait();
     bool logic_completed = logic_analyser_capture_complete(&logic_analyser);
     status_led_capture_finished();
 
@@ -394,7 +416,7 @@ bool mixed_signal_fetch_analog(uint8_t const **data, size_t *len)
 
 MixedSignalStatus mixed_signal_status(void)
 {
-    if (logic_analyser_is_busy(&logic_analyser) || adc_capture_is_busy()) {
+    if (logic_analyser_is_busy(&logic_analyser) || adc_frontend_is_busy()) {
         return MIXED_SIGNAL_STATUS_BUSY;
     }
 


### PR DESCRIPTION
Working on #201.
This PR adds a hardware agnostic ADC frontend interface for the DSO/MSO capture paths.

- Adds a generic ADC frontend registry and driver interface in system/instrument.
- Adds the current RP2350 internal ADC as the first registered backend.
- Refactors DSO and mixed signal capture to use the frontend interface instead of directly depending on platform/adc_capture.
- Keeps the existing internal ADC behavior working while creating a clean path for the future external parallel ADC backend.
- Adds frontend capabilities for channel/rate/sample count limits and sample width.

## Summary by Sourcery

Introduce a hardware-agnostic ADC frontend layer and migrate existing capture paths to use it.

New Features:
- Add a generic ADC frontend abstraction with backend selection, capability querying, and capture control APIs.
- Register the RP2350 internal ADC as an ADC frontend backend with defined capabilities and capture metadata reporting.
- Add an optional capture-complete callback mechanism for ADC frontend users.

Enhancements:
- Refactor DSO and mixed-signal instruments to use the ADC frontend interface instead of the platform-specific ADC capture API while preserving behavior.
- Expose ADC capabilities such as channel limits, sample rate bounds, maximum sample count, and sample width to instrument code for validation.
- Integrate ADC frontend and internal ADC backend initialization into the platform startup sequence.

Build:
- Include the new ADC frontend core and internal ADC backend source files in the build configuration.