### PR TITLE
ci: add automated build artifacts

### DIFF
--- a/.github/workflows/main-builder.yml
+++ b/.github/workflows/main-builder.yml
@@ -1,37 +1,38 @@
-name: Build
+name: Build 
 
 on:
-  pull_request:
-    branches:
-      - main
   push:
-    branches:
-      - main
-env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    branches: [ main ]
+  workflow_dispatch: 
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
+      - name: Checkout PSLab Mini Firmware
         uses: actions/checkout@v4
 
-      - name: Install Dependencies
+      - name: Install Toolchain
         run: |
           sudo apt update
-          sudo apt install gcc-arm-none-eabi libnewlib-arm-none-eabi
+          sudo apt install cmake gcc-arm-none-eabi libnewlib-arm-none-eabi build-essential python3
 
-      - name: Build Firmware
+      - name: Setup Pico SDK 2.1.0
+        run: |
+          git clone --depth 1 --branch 2.1.0 https://github.com/raspberrypi/pico-sdk.git $HOME/pico-sdk
+          cd $HOME/pico-sdk
+          git submodule update --init
+
+      - name: Build Firmware for Pico 2 W
         run: |
           mkdir build
           cd build
-          cmake ..
-          make
+          cmake .. -DPICO_BOARD=pico2_w -DPICO_SDK_PATH=$HOME/pico-sdk
+          make -j4
 
-      - name: Publish build files
+      - name: Upload .uf2 Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: pslab-mini-firmware
-          path: build/src/pslab-mini-firmware.srec
+          name: pslab_pico2_w_firmware
+          path: build/*.uf2

--- a/.github/workflows/main-builder.yml
+++ b/.github/workflows/main-builder.yml
@@ -2,7 +2,7 @@ name: Build
 
 on:
   push:
-    branches: [ main ]
+    branches: [ dev26, main ]
   workflow_dispatch: 
 
 jobs:
@@ -35,4 +35,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: pslab_pico2_w_firmware
-          path: build/*.uf2
+          path: build/*.uf2 
+          if-no-files-found: error


### PR DESCRIPTION
Fixes #211

### Changes

* Updated `main_builder.yml` to trigger CI for automated build artifacts.
* CI now runs for changes to the `dev26` and `main` branches for the new PSLab Mini.

## Summary by Sourcery

Automate PSLab Mini Pico 2 W firmware builds and publish the resulting UF2 files as artifacts.

New Features:
- Generate and publish Pico 2 W firmware as a CI build artifact.

Enhancements:
- Update the firmware build workflow to support the Pico SDK and build environment required by the new PSLab Mini.

Build:
- Run automated builds on pushes to the dev26 and main branches, with optional manual triggering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Build and Release**
  - Updated automated firmware builds for the Pico 2 W board.
  - Firmware builds now run for updates to the `dev26` and `main` branches, as well as manual requests.
  - Build outputs are provided as downloadable UF2 firmware artifacts.
  - Builds now fail when the expected firmware artifact is not produced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->